### PR TITLE
Show dice rolls

### DIFF
--- a/dice/goodie.pl
+++ b/dice/goodie.pl
@@ -41,7 +41,8 @@ if (!$type && $q_check_lc =~ m/^(?:roll|throw)/) {
       $sum += $_;
     }
     if (@rolls > 1) {
-      $answer_results = join(' ', @rolls);
+      $answer_results = join(' + ', @rolls);
+      $answer_results =~ s/\+\s\-/\- /g;
       $answer_results .= " = $sum";
     } else {
       $answer_results = $sum;


### PR DESCRIPTION
I've modified the code to show dice rolls, e.g.

`roll 4d6 - L` could show `2 + 3 + 5 - 1 = 9`

I'm not entirely happy with the find/replace to make subtracting the final number look better, but I can't think of a more efficient alternative.

One thing we could do is not show the operators, e.g. `2 3 5 -1 = 9`
