### PR TITLE
xor bug fix and clickable answer

### DIFF
--- a/xor/goodie.pl
+++ b/xor/goodie.pl
@@ -8,7 +8,7 @@ if (!$type && $q_check =~ m/^[0-9]+\s*(\s+(xor|⊕)\s*[0-9]+)+\s*$/i) {
     foreach (@numbers) {
         $num ^= ord(chr($_)); 
     }
-    $answer_results = qq($num);
+    $answer_results = qq(Answer: <a href="javascript:;" onclick="document.x.q.value='$num';document.x.q.focus();">$num</a>);
     if ($answer_results) {
         $answer_type = 'xor';
         $type = 'E';

--- a/xor/queries.txt
+++ b/xor/queries.txt
@@ -2,3 +2,4 @@
 5 ⊕ 79
 4 xor 3 xor 1
 9489 xor 394 xor 9349 xor 39 xor 29 xor 4967 xor 3985
+2 xor 2


### PR DESCRIPTION
So apparently you can't just pass back a zero (e.g. [2 xor 2](https://duckduckgo.com/?q=2+xor+2)) without the result coming back blank. To fix this, I added an "Answer: ..." part so it will go through. I thought about adding the original query in as well (like "2 xor 5 xor 56 = 63") but it looks too messy if you have lots of numbers to xor.

I also added a clickable answer, like [2 + 2](https://duckduckgo.com/?q=2+%2B+2). I'm really not sure if this works, so please feel free to remove/fix if this is bad/broken. Thanks.
