### PR TITLE
implement Unicode info

### DIFF
--- a/lib/DDG/Goodie/Unicode.pm
+++ b/lib/DDG/Goodie/Unicode.pm
@@ -33,7 +33,7 @@ handle sub {
                       split //, encode_utf8(chr($c));
 
     if ($i{decomposition}) {
-        ($extra{decomposition} = $i{decomposition}) =~ s/\b([0-9a-fA-F]{4,6})\b/U+$1/;
+        ($extra{decomposition} = $i{decomposition}) =~ s/\b(?<!<)([0-9a-fA-F]{4,6})\b(?!>)/U+$1/g;
     }
     $extra{block} = $i{block};
 


### PR DESCRIPTION
currently this is fetched from Wolfram Alpha, but generating it locally is nicer.
This also returns slightly different information, including case folding,
Unicode block, script and decomposition information

If you want all the boring information (how to write the codepoint in decimal, as a HTML entity etc.) I can implement that too, but I don't find it particularly exciting.
