### PR TITLE
Goodie to show days between two dates

### DIFF
--- a/lib/DDG/Goodie/DaysBetween.pm
+++ b/lib/DDG/Goodie/DaysBetween.pm
@@ -5,13 +5,14 @@ use DDG::Goodie;
 use Date::Calc qw( Date_to_Days); 
 use Time::localtime;
 
-triggers startend => "days between", "daysbetween", "days_between";
+triggers startend => "days", "daysbetween", "days_between";
 zci is_cached => 1;
 zci answer_type => "days_between";
 
 
 handle remainder => sub {
 
+	return unless s/^between//;
 	@dates = $_ =~ m#([01]?[0-9])/([0-3]?[0-9])/([0-9]{4}(?=\s|$))#g;
 
 	if(scalar(@dates) == 3) {


### PR DESCRIPTION
If only one date is listed, then will tell days between current date. 'inclusive' keyword to include last day in count.
https://duckduckhack.uservoice.com/forums/5168-plugins/suggestions/2701570-days-in-between-calculate-date-differences
