### PR TITLE
Added a simple UnixTime Plugin

### DIFF
--- a/lib/DDG/Goodie/UnixTime.pm
+++ b/lib/DDG/Goodie/UnixTime.pm
@@ -14,7 +14,7 @@ handle remainder => sub {
 	
 		my $my_time = localtime($time_input);
 
-		return $my_time if $my_time;
+		return "Unix Time Conversion: " . $my_time if $my_time;
 	
 	}
 

--- a/t/UnixTime.t
+++ b/t/UnixTime.t
@@ -12,11 +12,11 @@ ddg_goodie_test(
 	[qw(
 		DDG::Goodie::UnixTime
 	)],
-	'time 0' => test_zci('Wed Dec 31 19:00:00 1969'),
-	'time 1335233773453' => test_zci('Mon Apr 23 22:16:13 2012'),
-	'time 1335233773' => test_zci('Mon Apr 23 22:16:13 2012'),
-	'time 5325423' => test_zci('Tue Mar  3 10:17:03 1970'),
-	'time 53492399294' => test_zci('Sat Feb  7 18:48:14 3665')
+	'time 0' => test_zci('Unix Time Conversion: Wed Dec 31 19:00:00 1969'),
+	'time 1335233773453' => test_zci('Unix Time Conversion: Mon Apr 23 22:16:13 2012'),
+	'time 1335233773' => test_zci('Unix Time Conversion: Mon Apr 23 22:16:13 2012'),
+	'time 5325423' => test_zci('Unix Time Conversion: Tue Mar  3 10:17:03 1970'),
+	'time 53492399294' => test_zci('Unix Time Conversion: Sat Feb  7 18:48:14 3665')
 );
 
 done_testing;


### PR DESCRIPTION
Converts numerical unixtime, timestamps, and time values into human-readable formats using the perl localtime function.
