### PR TITLE
Added lookup by name to existing Unicode goodie

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,7 @@ Text::Unidecode = 0.04
 Date::Calc = 6.3
 Lingua::EN::Numericalize = 1.52
 Locale::SubCountry = 1.50
+Unicode::Char = 0.02
 
 [Prereqs / TestRequires]
 Test::More = 0.98

--- a/lib/DDG/Goodie/Unicode.pm
+++ b/lib/DDG/Goodie/Unicode.pm
@@ -2,16 +2,42 @@ package DDG::Goodie::Unicode;
 
 use DDG::Goodie;
 use Unicode::UCD qw/charinfo/;
+use Unicode::Char ();              # For name -> codepoint lookup
 use Encode qw/encode_utf8/;
 
-triggers query_raw => qr/^\s*u\+[a-f0-9]{4,6}\s*$/i;
+use constant {
+    CODEPOINT_RE => qr/^ \s* U \+ (?<codepoint> [a-f0-9]{4,6}) \s* $/xi,
+    NAME_RE      => qr/^ (?<name> [A-Z][A-Z\s]+) $/xi,
+    CODEPOINT    => 1,
+    NAME         => 2,
+};
+
+triggers query_raw => CODEPOINT_RE;
+
+# Also allows open-ended queries like: "LATIN SMALL LETTER X"
+triggers query_raw => qr{^unicode \s+ (.+) $}xi;
 
 zci is_cached => 1;
 
 zci answer_type => "unicode_conversion";
 
 handle sub {
-    /([a-f0-9]+)/i or return;
+    my $term = $_[0];
+
+    if ($term =~ m{^unicode \s+ (.+) $}x) {
+        return unicode_lookup($1);
+    }
+
+    return codepoint_description($term);
+};
+
+sub codepoint_description {
+    my $term = $_[0];
+
+    if ($term !~ m{([a-f0-9]+)}i) {
+        return;
+    }
+
     my $c = hex $1;
     my %i = %{ charinfo($c) };
     return unless $i{name};
@@ -47,6 +73,67 @@ handle sub {
         $info_str .= ", $_: $extra{$_}" if exists $extra{$_};
     }
     return $info_str;
-};
+}
+
+sub char_to_codepoint {
+    my $c = $_[0];
+
+    my $u = Unicode::Char->new();
+    return if ! defined $c or $c eq "";
+
+    my $cp = unpack('H*', pack('N', ord($c)));
+    $cp =~ s{^ 0+ }{}x;
+    $cp = uc ('u+' . $cp);
+    return $cp;
+}
+
+sub input_type ($) {
+    my $input = $_[0] || q{};
+    my $type;
+
+    if ($input =~ CODEPOINT_RE) {
+        $input = $+{codepoint};
+        $type = CODEPOINT;
+    }
+    elsif ($input =~ NAME_RE) {
+        $input = $+{name};
+        $type = NAME;
+    }
+
+    return ($input, $type);
+}
+
+sub name_to_char {
+    my $name = $_[0];
+    my $u = Unicode::Char->new();
+    return $u->n($name);
+}
+
+sub unicode_lookup {
+    my $term = $_[0];
+
+    if (! defined $term or $term eq "") {
+        return;
+    }
+
+    my $result;
+    my $type;
+
+    ($term, $type) = input_type($term);
+    if (! defined $type) {
+        return;
+    }
+
+    if ($type == CODEPOINT) {
+        $result = codepoint_description($term);
+    }
+    elsif ($type == NAME) {
+        my $char = name_to_char($term);
+        my $cp = char_to_codepoint($char);
+        $result = codepoint_description($cp);
+    }
+
+    return $result;
+}
 
 1;

--- a/share/unicode.txt
+++ b/share/unicode.txt
@@ -1,0 +1,4 @@
+unicode U+0100
+unicode U+590c
+unicode black smiling face
+unicode latin small letter z with circumflex


### PR DESCRIPTION
Now handles both raw "U+xxxx" queries (query_raw trigger),
and "unicode <...>" (start trigger). Any of these are valid:
- `U+590c`
- `unicode U+590C`
- `unicode white smiling face`

I posted the idea with a few comments here:

https://duckduckhack.uservoice.com/forums/5168-plugins/suggestions/2815905-unicode-show-codepoints-by-hex-number-or-description
