### PR TITLE
ISO 639 Language Codes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -22,6 +22,7 @@ Locale::SubCountry = 1.50
 ; causing problems because not pp: HTML::Barcode::QRCode = 0.09
 Unicode::Char = 0.02
 Number::UN = 0.002
+Locale::Language = 3.21
 
 [Prereqs / TestRequires]
 Test::More = 0.98

--- a/lib/DDG/Goodie/ISO639.pm
+++ b/lib/DDG/Goodie/ISO639.pm
@@ -1,0 +1,33 @@
+package DDG::Goodie::ISO639;
+# ABSTRACT: ISO 639 language names and codes
+
+use DDG::Goodie;
+use Locale::Language;
+
+use constant WPHREF => "https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes";
+
+zci answer_type => "language";
+
+# TODO: support "iso 639" and "iso-639"
+triggers start => "iso639";
+
+handle remainder => sub {
+  my ($lang, $code) = langpair(shift) or return;
+  my $text = sprintf qq(%s (ISO 639-1 %s)), $lang, $code;
+  my $html = sprintf qq(%s (<a href="%s">ISO 639-1 %s</a>)), $lang, WPHREF, $code;
+  return $text, html => $html;
+};
+
+sub langpair {
+  if (my $lang = code2language($_)) {
+    return ($lang, language2code($lang));
+  }
+  if (my $code = language2code($_)) {
+    return (code2language($code), $code);
+  }
+  return;
+}
+
+zci is_cached => 1;
+
+1;

--- a/t/ISO639.t
+++ b/t/ISO639.t
@@ -1,0 +1,30 @@
+#!/usr/bin/env perl
+use utf8;
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Goodie;
+
+zci is_cached => 1;
+
+ddg_goodie_test(
+  ["DDG::Goodie::ISO639"],
+  "iso639 ab" => test_zci(
+    qq(Abkhazian (ISO 639-1 ab)),
+    html        => qq(Abkhazian (<a href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">ISO 639-1 ab</a>)),
+    answer_type => "language"
+  ),
+  "iso639 english" => test_zci(
+    qq(English (ISO 639-1 en)),
+    html        => qq(English (<a href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">ISO 639-1 en</a>)),
+    answer_type => "language"
+  ),
+  "iso-639 en" => test_zci(
+    qq(English (ISO 639-1 en)),
+    html        => qq(English (<a href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">ISO 639-1 en</a>)),
+    answer_type => "language"
+  ),
+  "iso639 xyz" => undef,
+);
+
+done_testing;


### PR DESCRIPTION
Idea: [Provide ISO 639 Language Code for a given language](https://duckduckhack.uservoice.com/forums/5168-plugins/suggestions/2774651-provide-iso-639-language-code-for-a-given-language)

```
Query: iso-639 en

DDG::ZeroClickInfo  {
    Parents       WWW::DuckDuckGo::ZeroClickInfo
    Linear @ISA   DDG::ZeroClickInfo, WWW::DuckDuckGo::ZeroClickInfo, Moo::Object
    public methods (10) : after, around, before, extends, has, has_ttl, is_cached, new, ttl, with
    private methods (0)
    internals: {
        answer   "English (ISO 639-1 en)",
        answer_type   "language",
        html   "English (<a href="https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes">ISO 639-1 en</a>)",
        is_cached   1
    }
}
```
