### PR TITLE
IDN goodie

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -29,6 +29,7 @@ Convert::Color = 0.08
 Convert::Color::Library = 0.03
 Math::Round = 0.06
 Convert::Morse = 0.05
+Net::IDN::Encode = 2.003
 
 [Prereqs / TestRequires]
 Test::More = 0.98

--- a/lib/DDG/Goodie/IDN.pm
+++ b/lib/DDG/Goodie/IDN.pm
@@ -1,0 +1,22 @@
+package DDG::Goodie::IDN;
+# ABSTRACT: Convert domain names from/to Punycode.
+
+use DDG::Goodie;
+use Net::IDN::Encode ':all';
+use HTML::Entities;
+
+triggers start => 'idn';
+
+handle remainder => sub {
+	if(/^xn--/) {
+		return 'decoded IDN: '.encode_entities(domain_to_unicode($_));
+	}
+	else {
+		return 'encoded IDN: '.encode_entities(domain_to_ascii($_));
+	}
+	# return;
+};
+
+zci is_cached => 1;
+
+1;


### PR DESCRIPTION
This adds an IDN goodie for IDN/Punycode-encoded domain names. Example inputs: idn exämple.com, idn idn xn--exmple-cua.com
