### PR TITLE
Fix for parsecron issue #95

### DIFF
--- a/lib/DDG/Goodie/ParseCron.pm
+++ b/lib/DDG/Goodie/ParseCron.pm
@@ -28,11 +28,13 @@ handle remainder => sub {
 	$crontab =~ s/$day[$_]/$newday/;
     }
     my $cron = Schedule::Cron::Events->new($crontab) or return;
-    my ($sec, $min, $hour, $day, $month, $year) = $cron->nextEvent;
-    $year = $year+1900;
-    my $text = sprintf qq(Cron will start this event next at %02d:%02d:%02d on %d %s, %d), $hour, $min, $sec, $day, $mon[$month], $year;
-    $text .= '.';
-    return $text if $_;
+    my $text;
+    # Fix for issue #95: Show the next 3 events instead of just one.
+    for (my $count=1;$count<=3;$count++) {
+      my ($sec, $min, $hour, $day, $month, $year) = $cron->nextEvent;
+      $text .= sprintf("%2d:%02d:%02d on %d %s, %d\n", $hour, $min, $sec, $day, $mon[$month], ($year+1900));
+    }
+    return "Cron will schedule the job at this frequency: \n$text" if $_;
     return;
 };
 1;

--- a/t/ParseCron.t
+++ b/t/ParseCron.t
@@ -12,8 +12,8 @@ ddg_goodie_test(
 	[qw(
 		DDG::Goodie::ParseCron
 	)],
-	'crontab * */3 * * *' => test_zci(qr/^Cron will start this event next at \d{2}:\d{2}:\d{2} on \d{1,2} [a-zA-Z]{3}, \d{4}\.$/),
-	'crontab 42 12 3 Feb Sat' => test_zci(qr/^Cron will start this event next at \d{2}:\d{2}:\d{2} on \d{1,2} [a-zA-Z]{3}, \d{4}\.$/),
+	'crontab * */3 * * *' => test_zci(qr/^Cron will schedule the job at this frequency: \n\d{2}:\d{2}:\d{2} on \d{1,2} [a-zA-Z]{3}, \d{4}\n\d{2}:\d{2}:\d{2} on \d{1,2} [a-zA-Z]{3}, \d{4}\n\d{2}:\d{2}:\d{2} on \d{1,2} [a-zA-Z]{3}, \d{4}$/),
+	'crontab 42 12 3 Feb Sat' => test_zci(qr/^Cron will schedule the job at this frequency: \n\d{2}:\d{2}:\d{2} on \d{1,2} [a-zA-Z]{3}, \d{4}\n\d{2}:\d{2}:\d{2} on \d{1,2} [a-zA-Z]{3}, \d{4}\n\d{2}:\d{2}:\d{2} on \d{1,2} [a-zA-Z]{3}, \d{4}$/),
 );
 
 done_testing;


### PR DESCRIPTION
Please review the fix (and sorry for the delay). I've used approach (b) discussed in the thread. Sample test:

Query: crontab 42 12 3 Feb Sat

Output:Cron will schedule the job at this frequency:
12:42:00 on 2 Feb, 2013
12:42:00 on 3 Feb, 2013
12:42:00 on 9 Feb, 2013
