### PR TITLE
Date missing from unix time output

### DIFF
--- a/lib/DDG/Goodie/UnixTime.pm
+++ b/lib/DDG/Goodie/UnixTime.pm
@@ -23,7 +23,7 @@ handle remainder => sub {
             time_zone => "UTC"
           );
 
-        my $time_utc = $my_time->strftime("%a %b %m %T %Y %z");
+        my $time_utc = $my_time->strftime("%a %b %d %T %Y %z");
 
 		return "Unix Time Conversion: " . $time_utc if $time_utc;
 	


### PR DESCRIPTION
The strftime format had "%b %m", which is redundant (month name and month number), but date was missing. I changed %m to %d.
