### PR TITLE
Make "DuckDuckGo" in "DuckDuckGo or something" query case insensitive.

### DIFF
--- a/lib/DDG/Goodie/ABC.pm
+++ b/lib/DDG/Goodie/ABC.pm
@@ -25,7 +25,7 @@ handle query_parts => sub {
     return if scalar(@choices) <= 1;
     my $choice = int(rand(@choices));
 
-    if (my @duck = grep { $_ eq 'duckduckgo' || $_ eq 'duck' || $_ eq 'ddg' } @choices) {
+    if (my @duck = grep { / \A (?: duck (?: duckgo )? | ddg ) \z /ix } @choices) {
         return $duck[0]." (not random)", answer_type => 'egg';
     }
 

--- a/t/ABC.t
+++ b/t/ABC.t
@@ -15,6 +15,7 @@ ddg_goodie_test(
 	'yes or no' => test_zci(qr/(yes|no) \(random\)/),
     "this or that or none" => test_zci(qr/(this|that|none) \(random\)/),
     "duckduckgo or google or bing or something" => test_zci("duckduckgo (not random)", answer_type => 'egg'),
+    "DuckDuckGo OR Google OR Bing or SOMETHING" => test_zci("DuckDuckGo (not random)", answer_type => 'egg'),
 );
 
 done_testing;


### PR DESCRIPTION
Currently query like `DuckDuckGo or the world` causes either `DuckDuckGo` or `the world` to be choosed randomly. As DuckDuckGo is actual name of search engine, it could happen that somebody will type `DuckDuckGo` instead of `duckduckgo` avoiding special case. This commit adds case insensitivity, so it would work now.
