### PR TITLE
Data "validation" plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -34,6 +34,7 @@ Net::IDN::Encode = 2.003
 ; IsValid::JSON and IsValid::XML
 Try::Tiny = 0
 JSON = 0
+XML::SAX::Expat = 0
 XML::Simple = 0
 
 [Prereqs / TestRequires]

--- a/lib/DDG/Goodie/IsValid/JSON.pm
+++ b/lib/DDG/Goodie/IsValid/JSON.pm
@@ -17,21 +17,22 @@ triggers any => 'json';
 handle remainder => sub {
 	return unless $_ =~ /valid\s*(.*)$/;
 
-	my $result = try {
+	my ($result, $error) = try {
 		from_json($1);
 		return 'valid!';
 	} catch {
 		$_ =~ /^(.* at character offset \d+ .*) at/;
 
-		if ($1) {
-			my $css = "font-size:12px;display:inline;";
-			return "invalid: <pre style=\"$css\">$1</pre>"
-		} else {
-			return "invalid"
-		}
+		return ('invalid: ', $1);
 	};
 
-	return "Your JSON is $result"
+	my $answer      = "Your JSON is $result";
+	my $answer_html = $answer;
+
+	$answer      .= $error if $error;
+	$answer_html .= "<pre style=\"font-size:12px\">$error</pre>" if $error;
+
+	return $answer, html => $answer_html
 };
 
 1;

--- a/lib/DDG/Goodie/IsValid/XML.pm
+++ b/lib/DDG/Goodie/IsValid/XML.pm
@@ -17,21 +17,22 @@ triggers any => 'xml';
 handle remainder => sub {
 	return unless $_ =~ /valid\s*(.*)$/;
 
-	my $result = try {
+	my ($result, $error) = try {
 		XMLin($1);
 		return 'valid!';
 	} catch {
 		$_ =~ /^\n(.* at line \d+, column \d+, byte \d+) at/;
 
-		if ($1) {
-			my $css = "font-size:12px;display:inline;";
-			return "invalid: <pre style=\"$css\">$1</pre>"
-		} else {
-			return "invalid"
-		}
+		return ('invalid: ', $1);
 	};
 
-	return "Your XML is $result"
+	my $answer      = "Your XML is $result";
+	my $answer_html = $answer;
+
+	$answer      .= $error if $error;
+	$answer_html .= "<pre style=\"font-size:12px\">$error</pre>" if $error;
+
+	return $answer, html => $answer_html
 };
 
 1;

--- a/t/IsValid.t
+++ b/t/IsValid.t
@@ -11,22 +11,34 @@ zci is_cached   => 1;
 
 ddg_goodie_test(
 	[qw(DDG::Goodie::IsValid::JSON)],
-	'is valid json {"test":"lol"}' => test_zci('Your JSON is valid!'),
+	'is valid json {"test":"lol"}' => test_zci(
+		'Your JSON is valid!',
+		html => 'Your JSON is valid!'
+	)
 );
 
 ddg_goodie_test(
 	[qw(DDG::Goodie::IsValid::JSON)],
-	'is valid json {"test" "lol"}' => test_zci('Your JSON is invalid: <pre style="font-size:12px;display:inline;">\':\' expected, at character offset 8 (before ""lol"}")</pre>')
+	'is valid json {"test" "lol"}' => test_zci(
+		'Your JSON is invalid: \':\' expected, at character offset 8 (before ""lol"}")',
+		html => 'Your JSON is invalid: <pre style="font-size:12px">\':\' expected, at character offset 8 (before ""lol"}")</pre>'
+	)
 );
 
 ddg_goodie_test(
 	[qw(DDG::Goodie::IsValid::XML)],
-	'is valid xml <test></test>' => test_zci('Your XML is valid!'),
+	'is valid xml <test></test>' => test_zci(
+		'Your XML is valid!',
+		html => 'Your XML is valid!'
+	)
 );
 
 ddg_goodie_test(
 	[qw(DDG::Goodie::IsValid::XML)],
-	'is valid xml <test>lol' => test_zci('Your XML is invalid: <pre style="font-size:12px;display:inline;">no element found at line 1, column 9, byte 9</pre>')
+	'is valid xml <test>lol' => test_zci(
+		'Your XML is invalid: no element found at line 1, column 9, byte 9',
+		html => 'Your XML is invalid: <pre style="font-size:12px">no element found at line 1, column 9, byte 9</pre>'
+	)
 );
 
 done_testing;


### PR DESCRIPTION
A couple of plugins that check whether the submitted JSON or XML is valid. E.g.:

```
is valid json {"test": "hello"}
is valid xml <test>hello</test>
```

It works fine with multiline text too, so that data can be easily copy-pasted.
