### PR TITLE
update GitHub attribution for IsValid plugins

### DIFF
--- a/lib/DDG/Goodie/IsValid/JSON.pm
+++ b/lib/DDG/Goodie/IsValid/JSON.pm
@@ -6,7 +6,7 @@ use DDG::Goodie;
 use Try::Tiny;
 use JSON qw(from_json);
 
-attribution github  => ['https://github.com/AlexBio', 'AlexBio'  ],
+attribution github  => ['https://github.com/ghedo', 'ghedo'      ],
             web     => ['http://ghedini.me', 'Alessandro Ghedini'];
 
 zci answer_type => 'isvalid';

--- a/lib/DDG/Goodie/IsValid/XML.pm
+++ b/lib/DDG/Goodie/IsValid/XML.pm
@@ -6,7 +6,7 @@ use DDG::Goodie;
 use Try::Tiny;
 use XML::Simple;
 
-attribution github  => ['https://github.com/AlexBio', 'AlexBio'  ],
+attribution github  => ['https://github.com/ghedo', 'ghedo'      ],
             web     => ['http://ghedini.me', 'Alessandro Ghedini'];
 
 zci answer_type => 'isvalid';


### PR DESCRIPTION
Hi,

I changed the name of my GitHub account from "AlexBio" to "ghedo", so the github attribution links in the plugins I wrote result invalid. Sorry for the hassle :/
