### PR TITLE
Linux Permissions

### DIFF
--- a/lib/DDG/Goodie/LinuxPermissions.pm
+++ b/lib/DDG/Goodie/LinuxPermissions.pm
@@ -5,10 +5,9 @@ use DDG::Goodie;
 triggers query_lc => qr/^([0|1|2|4]{1}[0-7]{3})$/;
 
 zci is_cached => 1;
-zci answer_type => "linux_permission";
+zci answer_type => "linux_permissions";
 
 sub calcperms {
-      print "  In calc: Parms = @_ \n";
 	if($_[0] == 7) {
             return "Read, Write, and Execute";
              }

--- a/t/LinuxPermissions.t
+++ b/t/LinuxPermissions.t
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Goodie;
+
+zci answer_type => 'linux_permissions';
+zci is_cached => 1;
+
+ddg_goodie_test(
+   [qw(
+       DDG::Goodie::LinuxPermissions
+   )],
+   '0644' => test_zci('User: Read and Write
+Group: Read
+Others: Read
+
+rw-r--r--'),
+   '0777' => test_zci('User: Read, Write, and Execute
+Group: Read, Write, and Execute
+Others: Read, Write, and Execute
+
+rwxrwxrwx')
+);
+
+done_testing;


### PR DESCRIPTION
Type octal notation "0644" and get back:
User: Read and Write
Group: Read
Others: Read

rw-r--r--

Future:
Right now I don't do anything with the special bit (the first one) so I would like to add support for that in later commits

I would also eventually like to add support for reverse octal notation, for example: 
rwx-rw-rw- to 0766
