### PR TITLE
adjust example queries

### DIFF
--- a/lib/DDG/Goodie/DaysBetween.pm
+++ b/lib/DDG/Goodie/DaysBetween.pm
@@ -10,8 +10,8 @@ triggers start => "days", "daysbetween", "days_between";
 zci is_cached => 1;
 zci answer_type => "days_between";
 
-primary_example_queries 'days between 01/01/2000 01/01/2001';
-secondary_example_queries 'days between 01/01/2000 01/01/2001 inclusive';
+primary_example_queries 'days between 01/31/2000 01/31/2001';
+secondary_example_queries 'days between 01/31/2000 01/31/2001 inclusive';
 description 'calculate the number of days between two dates';
 name 'DaysBetween';
 code_url 'https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/DaysBetween.pm';


### PR DESCRIPTION
make usage of MDY date format (US) more obvious
https://en.wikipedia.org/wiki/Date_format_by_country
