### PR TITLE
Goodie to return the URL of a Jira bugticket

### DIFF
--- a/lib/DDG/Goodie/Jira.pm
+++ b/lib/DDG/Goodie/Jira.pm
@@ -44,14 +44,16 @@ handle query => sub {
  
 	  # Dealing with the case where two projects on different bugtrackers have the same project key
     if ($apacheKey){
-        my $apacheTicket = $apacheKey . "-" . $apacheTicketID;
-        my $apacheProject = $Apache_JIRA_projects{$apacheKey}; 
+        my $uKey = uc $apacheKey;
+        my $apacheTicket = $uKey . "-" . $apacheTicketID;
+        my $apacheProject = $Apache_JIRA_projects{$uKey}; 
         $html_return .= qq($apacheProject (Apache JIRA Bugtracker): see ticket <a href="https://issues.apache.org/jira/browse/$apacheTicket">$apacheTicket</a>.<br>);
     }
 
     if ($codehausKey){
-        my $codehausTicket = $codehausKey . "-" . $codehausTicketID;
-        my $codehausProject = $Codehaus_JIRA_projects{$codehausKey}; 
+        my $uKey = uc $codehausKey;
+        my $codehausTicket = uc $uKey . "-" . $codehausTicketID;
+        my $codehausProject = $Codehaus_JIRA_projects{$uKey}; 
 
         $html_return .= qq($codehausProject (Codehaus JIRA Bugtracker): see ticket <a href="https://jira.codehaus.org/browse/$codehausTicket">$codehausTicket</a>.) if $codehausTicket;
     }

--- a/t/Jira.t
+++ b/t/Jira.t
@@ -15,7 +15,15 @@ ddg_goodie_test(
       '',
       html => qq(ACE (Apache JIRA Bugtracker): see ticket <a href="https://issues.apache.org/jira/browse/ACE-230">ACE-230</a>.<br>)
     ),
+    'ace-230' => test_zci(
+      '',
+      html => qq(ACE (Apache JIRA Bugtracker): see ticket <a href="https://issues.apache.org/jira/browse/ACE-230">ACE-230</a>.<br>)
+    ),
     'jira random AJLIB-230 bug random' => test_zci(
+      '',
+      html => qq(ajlib incubator (Codehaus JIRA Bugtracker): see ticket <a href="https://jira.codehaus.org/browse/AJLIB-230">AJLIB-230</a>.)
+    ),
+    'jira random ajlib-230 bug random' => test_zci(
       '',
       html => qq(ajlib incubator (Codehaus JIRA Bugtracker): see ticket <a href="https://jira.codehaus.org/browse/AJLIB-230">AJLIB-230</a>.)
     )


### PR DESCRIPTION
This is an answer to the following request: https://duckduckhack.uservoice.com/forums/5168-ideas-for-duckduckgo-instant-answer-plugins/suggestions/2679035-apache-jira-tickets

The plugin returns the URL of a given bugticket, when the ticket is from the Apache (or  Codehaus) Jira bugtracker.
