### PR TITLE
Add Math Goodie to render TeX with MathJax

### DIFF
--- a/lib/DDG/Goodie/Math.pm
+++ b/lib/DDG/Goodie/Math.pm
@@ -1,0 +1,40 @@
+package DDG::Goodie::Math;
+# ABSTRACT: Render mathematical equations with MathJax.
+
+use DDG::Goodie;
+use HTML::Entities;
+
+triggers query_nowhitespace => qr/^\$.*\$$/, qr/^\$\$.*\$\$$/,
+                               qr/^\\\(.*\\\)$/, qr/^\\\[.*\\\]$/;
+
+
+zci is_cached => 1;
+zci answer_type => "math";
+
+attribution github => ['https://github.com/SamWhited', 'SamWhited'];
+primary_example_queries '$\sum_{i=0}^{N} x_i$';
+description 'Render maths using LaTeX via MathJax';
+name 'math';
+code_url 'https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Math.pm';
+category 'computing_tools';
+topics 'math';
+
+
+handle query_raw => sub {
+    my $html = '<script type="text/javascript"
+                src="https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+                </script><script type="text/javascript">
+                MathJax.Hub.Config({
+                  tex2jax: {
+                    inlineMath: [["$","$"],["\\(","\\)"]],
+                    processEscapes: true,
+                    processEnvironments: true,
+                    skipTags: ["script","noscript","style","textarea","pre","code","span","head"],
+                    processClass: "math"
+                  }
+                });
+                </script><span class="math">'.$_.'</span>';
+    return '', html => $html;
+};
+
+1;

--- a/t/Math.t
+++ b/t/Math.t
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+
+use DDG::Test::Goodie;
+
+zci answer_type => 'math';
+zci is_cached => 1;
+
+use_ok('DDG::Goodie::Math');
+
+ddg_goodie_test(
+	[qw(
+		DDG::Goodie::Math
+	)],
+	'$\sum_{i=0}^{N} x_i$' => test_zci('', html => qr|<span class="math">\$\\sum_{i=0}\^{N} x_i\$</span>|),
+	'$$\sum_{i=0}^{N} x_i$$' => test_zci('', html => qr|<span class="math">\$\$\\sum_{i=0}\^{N} x_i\$\$</span>|),
+	'\(\sum_{i=0}^{N} x_i\)' => test_zci('', html => qr|<span class="math">\\\(\\sum_{i=0}\^{N} x_i\\\)</span>|),
+	'\[\sum_{i=0}^{N} x_i\]' => test_zci('', html => qr|<span class="math">\\\[\\sum_{i=0}\^{N} x_i\\\]</span>|),
+);
+
+done_testing;


### PR DESCRIPTION
Renders math using MathJax.

Eg. A search for `$\sum_{i=0}^{N} x_i$` or `\(\sum_{i=0}^{N} x_i\)` will load MathJax from the official CDN (using SSL) and render the equation.

See here for original feature request: https://duckduckhack.uservoice.com/forums/5168-ideas-for-duckduckgo-instant-answer-plugins/suggestions/2679072-latex-rendering-give-a-rendered-image
