### PR TITLE
Switching Rubik's cube patterns to cheatsheet

### DIFF
--- a/lib/DDG/Goodie/RubiksCubePatterns.pm
+++ b/lib/DDG/Goodie/RubiksCubePatterns.pm
@@ -16,7 +16,8 @@ attribution web => ['robert.io', 'Robert Picard'], twitter => '__rlp', github =>
 
 triggers start =>	"rcube", "rubik", "rubiks", "rubix", 
 					"rubicks", "rubik's", "rubic's", "rubick's", 
-					"rubik cube", "rubiks cube", "rubic cube", "rubics cube";
+					"rubik cube", "rubiks cube", "rubic cube", "rubics cube",
+					"rubik's cube patterns", "rubiks cube patterns";
 
 zci answer_type => "rubiks_cube";
 

--- a/t/RubiksCubePatterns.t
+++ b/t/RubiksCubePatterns.t
@@ -31,6 +31,11 @@ ddg_goodie_test(
         	"Cube in a Cube in a Cube: U' L' U' F' R2 B' R F U B2 U B' L U' F U R F' \n",
         	"html" => "<div><i>Cube in a Cube in a Cube</i>: U' L' U' F' R2 B' R F U B2 U B' L U' F U R F'</div>\n"
         ),
+        "rubik's cube patterns" => test_zci(
+        	qr/.+: .+/s,
+        	"html" => qr{<div><i>.+</i>: .+</div>}s,
+        	"heading" => "Rubik's Cube Patterns"
+        ),
 );
 
 done_testing;


### PR DESCRIPTION
Hi,

I think this should address: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/122

Also I've added more patterns and added HTML output.

Thanks,
Rob
