### PR TITLE
HexToASCII: display information about invisible characters

### DIFF
--- a/t/HexToASCII.t
+++ b/t/HexToASCII.t
@@ -10,12 +10,12 @@ zci is_cached   => 1;
 
 ddg_goodie_test(
     [qw( DDG::Goodie::HexToASCII )],
+    'ascii 0x7465ff7374'                   => undef,
     'ascii 0x7465007374'                   => test_zci('test (ASCII)',           html => 'te<code title="null">[NUL]</code>st (ASCII)'),
     'ascii 0x74657374'                     => test_zci('test (ASCII)',           html => 'test (ASCII)'),
     'ascii 0x5468697320697320612074657374' => test_zci('This is a test (ASCII)', html => 'This is a test (ASCII)'),
     'ascii 0x466f7220736f6d6520726561736f6e2c2049206465636964656420746f2061736b20612073656172636820656e67696e6520746f20636f6e766572742068657820746f2041534349492e0d0a436f6f6c2c20746869732073656172636820656e67696e6520646f65732069742c20756e74696c20492072756e206f7574206f662073706163652e'
       => test_zci('For some reason, I decided to ask a search engine to convert hex to ASCII.Cool, this search engine does it, until I run out of ... (ASCII)', html => 'For some reason, I decided to ask a search engine to convert hex to ASCII.<code title="carriage return">[CR]</code><code title="linefeed">[LF]</code>Cool, this search engine does it, until I run out of &hellip; (ASCII)'),
-
 );
 
 done_testing;


### PR DESCRIPTION
- Reduce the number of entered characters to 128, since we can't be sure
  of the display width any more.
- Show "invisible characters" (unprintable + non-space whitespace) in a
  special format

I am unsure if the styling is done appropriately or will look as nice as I think on the results page.

Also, there is the localization issue with the description text. I am not sure how big a deal this is, given that it is ASCII.  If it's a big problem, I could always go to the simpler abbreviation-only. 
