### PR TITLE
ReverseIP: add reverse lookup for bare IP4 addresses.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -55,6 +55,7 @@ URI::Escape = 3.31
 Lingua::EN::Words2Nums = 0
 Locale::Currency::Format = 1.30
 Net::IP = 0
+Net::DNS = 0
 Math::BaseConvert = 0
 
 [Prereqs / TestRequires]

--- a/lib/DDG/Goodie/ReverseIP.pm
+++ b/lib/DDG/Goodie/ReverseIP.pm
@@ -1,0 +1,49 @@
+package DDG::Goodie::ReverseIP;
+# ABSTRACT: Do a reverse lookup for a bare IP (v4 only, for now) address.
+
+use DDG::Goodie;
+use Net::IP;
+use Net::DNS;
+
+zci is_cached   => 0;              # Let the tried and true DNS caching handle this.
+zci answer_type => "reverse_ip";
+
+primary_example_queries '127.0.0.1';
+description 'reverse lookup of a bare IP4 address';
+name 'reverse_ip';
+code_url 'https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/ReverseIP.pm';
+category 'computing_tools';
+topics 'sysadmin';
+attribution web => ['https://www.duckduckgo.com', 'DuckDuckGo'];
+
+my $ip4_octet = qr/([01]?\d\d?|2[0-4]\d|25[0-5])/;      # Each octet should look like a number between 0 and 255.
+my $ip4_regex = qr/^(?:$ip4_octet\.){3}$ip4_octet$/;    # There should be 4 of them separated by 3 dots.
+
+triggers query => $ip4_regex;
+
+my $timeout     = 1;                                    # Max seconds to wait for an answer. Even 1 seems like too long.
+my $record_type = 'PTR';                                # We're only interested in pointer records.
+
+handle query => sub {
+    my $ip_candidate = shift;
+
+    my $ip = Net::IP->new($ip_candidate);
+    return unless ($ip);                                # Each guard gets us out as quickly as possible when
+                                                        # it seems unlikely we'll be able to get an answer.
+
+    my $resolver = Net::DNS::Resolver->new(
+        tcp_timeout => $timeout,
+        udp_timeout => $timeout,
+    );
+    return unless ($resolver);
+
+    my $query = $resolver->query($ip_candidate, $record_type);
+    return unless ($query);
+
+    my @ptrs = map { $_->rdatastr } grep { $_->type eq $record_type } ($query->answer);
+    return unless (@ptrs);
+
+    return join(', ', @ptrs) . ' (Reverse DNS for ' . $ip_candidate . ')';
+};
+
+1;

--- a/t/ReverseIP.t
+++ b/t/ReverseIP.t
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Goodie;
+
+zci answer_type => 'reverse_ip';
+zci is_cached   => 0;
+
+ddg_goodie_test(
+    [qw( DDG::Goodie::ReverseIP )],
+    '8.8.8.256'             => undef,                                                                             # Not an IP address
+    '8.8.8.8.8'             => undef,
+    '208.43.32.125.'        => undef,
+    '127.0.0.01'            => undef,                                                                             # Not a well-formed IP address
+    'ip 208.43.32.125'      => undef,                                                                             # Extra stuff with IP
+    '208.43.32.125 reverse' => undef,
+    '208.43.32.125'         => test_zci('duckco.com.32.43.208.in-addr.arpa. (Reverse DNS for 208.43.32.125)'),    # Answers!
+    '127.0.0.1'             => test_zci('localhost. (Reverse DNS for 127.0.0.1)'),
+);
+
+done_testing;


### PR DESCRIPTION
There are some potential problems with this:
- DNS lookup can be slow, although we try to mitigate this by only
  waiting for up to 1 second for a response.
- It's more or less uncacheable in the application, given the wide
  search space and unknown cache invalidation parameters.
- Results will depend on the resolver set up.  This may include leaking
  some information about specialized internal DDG reverse lookup, if any.
- Returns FQDN, which is both correct and possibly not exactly what the
  searcher might expect.

This version only handles well-formed IP4 addresses.  It could be easily
expanded to include IP6, but I wanted to make sure this was what was
being sought before adding more matching.

---

**What does your instant answer do?**

Returns the reverse DNS information when a user queries for a bare IP address.

**What problem does your instant answer solve (Why is it better than organic links)?**

Less clicking through to potentially questionable sites which provide the same service.

**What is the data source for your instant answer? (Provide a link if possible)**

The DNS.  

**Why did you choose this data source?**

It's pretty much authoritative for this kind of info.

**Are there any other alternative (better) data sources?**

Possibly, if the actual request is for WHOIS info on the discovered address.

**What are some example queries that trigger this instant answer?**

127.0.0.1
46.51.216.186

**Which communities will this instant answer be especially useful for? (gamers, book lovers, etc)**

People who read logs (mostly sysadmins) and the overly curious

**Is this instant answer connected to a DuckDuckHack [instant answer idea](https://duck.co/ideas)?**

It may address [738](https://duck.co/ideas/idea/734/reverse-dns-an-ip-address).  Considering that an API is thought to be required, I am not sure that it does.

**Which existing instant answers will this one supercede/overlap with?**

Currently, Wolfram|Alpha returns an odd answer like: `Date: 127.0.0.1 (IPv4 address), assuming 127.0.0.1 is referring to an internet site.`

**Are you having any problems? Do you need our help with anything?**

I'm not sure that this is actually a goodie, since it ostensibly requires network access. Even though it is lighter weight access than something like HTTP, the supplied timeout might lead to uncertainty as to whether or not we'll be able to show the answer.

![revip](https://f.cloud.github.com/assets/6280000/1948977/a29f0488-80d0-11e3-9684-300861a311ed.png)

```
[✔] Added metadata and attribution information
[✔] Wrote test file and added to t/ directory
[✔] Verified that instant answer adheres to design guidelines(https://github.com/duckduckgo/duckduckgo-documentation/blob/master/duckduckhack/styleguides/design_styleguide.md)
[] Tested cross-browser compatability
```
