### PR TITLE
GUID.pm: return GUID as a string

### DIFF
--- a/lib/DDG/Goodie/GUID.pm
+++ b/lib/DDG/Goodie/GUID.pm
@@ -30,11 +30,9 @@ my %guid = (
 handle query_lc => sub {
     return unless exists $guid{$_};
     if (my $guid = Data::GUID->new) {
-        if ($guid{$_}) {
-            $guid = lc $guid;
-        }
+        my $guid_string = $guid->as_string;
 
-        return  answer => qq($guid),
+        return  answer => $guid_string,
                 html => qq(<input type="text" onclick='this.select();' size="45" value="$guid"/>),
                 heading => 'Random GUID';
     }


### PR DESCRIPTION
In response to #293

@jagtalon pointed out that we should not be interpolating the variable. 

Now uses as_string, which returns a GUID string representation
