### PR TITLE
Travis.yml: Fixing misleading regex and using xargs for all cpan operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ before_install:
   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
 install:
   - cpanm  --quiet  --notest --skip-satisfied Dist::Zilla
-  - "dzil authordeps | grep -vP '[^\\w:]' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-satisfied"
-  - "dzil listdeps | grep -vP '[^\\w:]' | cpanm  --quiet   --notest  --skip-satisfied"
+  - "dzil authordeps | grep -vP '^\\[\\w+\\]' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-satisfied"
+  - "dzil listdeps | grep -vP '^\\[\\w+\\]' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-satisfied"
   - cpanm  --quiet   --notest  App::DuckPAN
   - duckpan DDG
 language: perl


### PR DESCRIPTION
Hello @jagtalon @moollaza @crazedpsyc 

This is related to: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/242 I think the original regex doesn't do what the author intended? It looks like the Travis CI build dependencies are actually only resolved by:

```
cpanm  --quiet   --notest  App::DuckPAN command 
```
