### PR TITLE
Remove experimental use of lexical $_ causing failures in more recent Perls

### DIFF
--- a/lib/DDG/Goodie/Dice.pm
+++ b/lib/DDG/Goodie/Dice.pm
@@ -77,7 +77,7 @@ handle remainder_lc => sub {
     my $html = ''; 
     my $heading = "Random Dice Roll";
     my $total; # total of all dice rolls
-    foreach my $_ (@values) {
+    foreach (@values) {
         if ($_ =~ /^(?:a? ?die|(\d{0,2})\s*dic?e)$/) { 
             # ex. 'a die', '2 dice', '5dice'
             my @output;


### PR DESCRIPTION
Goodie::Dice was using a lexical `$_`.  This was an experimental feature added in
Perl v5.10.0 that is now considered to have been a bad idea.  See
http://perldoc.perl.org/perlvar.html#%24_ for more info.

This was causing test failures for me and `duckpan server` would not start.  I'm using Perl v5.19 btw.  I realize this is probably not an issue for DDG as you probably aren't using such a modern version of Perl.  But it could be a problem for other contributors.
