### PR TITLE
Passphrase: bring up to current standards.

### DIFF
--- a/lib/DDG/Goodie/Passphrase.pm
+++ b/lib/DDG/Goodie/Passphrase.pm
@@ -2,9 +2,9 @@ package DDG::Goodie::Passphrase;
 
 use DDG::Goodie;
 
-triggers start => "passphrase";
+triggers start => "passphrase", "pass phrase";
 
-primary_example_queries 'passphrase 3';
+primary_example_queries 'passphrase 3 words', 'pass phrase 4 words';
 description 'generate a random passphrase';
 name 'Passphrase';
 code_url 'https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Passphrase.pm';
@@ -13,23 +13,28 @@ topics 'cryptography';
 
 attribution github => ['https://github.com/hunterlang', 'hunterlang'];
 
-my @words = share('words.txt')->slurp;
+# Remove the line endings up front.
+my @words = map { chomp $_; $_ } share('words.txt')->slurp;
+# When we "floor" our random numbers with `int` we will end up with
+# numbers in the range [0,$list_size - 1].. which just so happens
+# to be perfect for an index into the array!
+my $list_size = scalar @words;
 
-handle query_parts => sub {
-    my $count = @_;
-    return unless $count == 3;
-    my ( $word_count, $descriptor ) = @_[ 1, 2 ]; 
-    return if $word_count < 1;
+handle remainder => sub {
+    # Guard against queries we are unprepared to handle.
+    return unless ($_ =~ /^(\d+) words?$/);
+    my $word_count = $1;
+    # Guard against silly request sizes.
+    return unless ($word_count >= 1 && $word_count <= 10);
 
-    my $output = "random passphrase: ";
-    for (1..$word_count) {
-        my $word = splice @words, (int(rand @words)), 1;
-        $output .= "$word ";
+    my @chosen_words;
+    while (scalar @chosen_words < $word_count) {
+        # Pick random words from the slurped array until we have enough
+        push @chosen_words, $words[int(rand $list_size)];
     }
-    # Remove the trailing space
-    chop $output;
-    $output =~ s/\n//g;
-    return $output;
+
+    # Now stick them together with an indicator as to what it is
+    return join ' ', ('random passphrase:', @chosen_words);
 };
 
 1;

--- a/t/Passphrase.t
+++ b/t/Passphrase.t
@@ -6,15 +6,18 @@ use Test::More;
 use DDG::Test::Goodie;
 
 zci answer_type => 'passphrase';
-zci is_cached => 0;
+zci is_cached   => 0;
 
 ddg_goodie_test(
-        [qw(
-                DDG::Goodie::Passphrase
-        )],
-        'passphrase 1 word' => test_zci(qr/random passphrase: ([a-z]+)/),
-        'passphrase 2 word' => test_zci(qr/random passphrase: ([a-z]+){2}/),
-        'passphrase 3 words' => test_zci(qr/random passphrase: ([a-z]+){3}/),
+    [qw( DDG::Goodie::Passphrase )],
+    'passphrase 1 word'   => test_zci(qr/random passphrase: ([a-z]+)/),
+    'passphrase 2 word'   => test_zci(qr/random passphrase: ([a-z]+){2}/),
+    'passphrase 3 words'  => test_zci(qr/random passphrase: ([a-z]+){3}/),
+    'pass phrase 3 words' => test_zci(qr/random passphrase: ([a-z]+){3}/),
+    'pass phrase 0 words' => undef,
+    'passphrase 11 words' => undef,
+    'passphrase 3'        => undef,
+    'pass phrase 3 chars' => undef,
 );
 
 done_testing;


### PR DESCRIPTION
Intended to fix issue #313 and also fix #314.
- Add ability to use queries like "pass phrase 3 words"
- Add comments describing how it works.
- Add (arbitrarily chosen) limit of 10 words maximum.
- Constrain the query format more tightly
- Add more tests

This turned into more of a rewrite than I intended.

In the previous version, it was more forgiving about what trailed the
number of words requested... but it was assuredly requiring something.
I've decided to be explicit on wanting 'word(s)' at the end.

Previously it required a minimum of 1 word requested, but didn't have a
maximum.  I chose to make the max 10, as it keeps the output fairly
tidy and seems like a reasonable maximum someone might actually use
in practice.
