### PR TITLE
Binary: add expected trigger.

### DIFF
--- a/lib/DDG/Goodie/Binary.pm
+++ b/lib/DDG/Goodie/Binary.pm
@@ -48,7 +48,7 @@ sub bin2dec {
 handle remainder => sub {
     my @out;
 
-    if (/^[^01]*([01]+)(\s+from)?$/) {
+    if (/^([01]+)(\s+from)?$/) {
         # Looks like they gave us some binary, let's turn it into decimal!
         @out = ($1, bin2dec($1), "binary", "decimal");
     } elsif (s/\s+(in|to|into|as)$//) {

--- a/t/Binary.t
+++ b/t/Binary.t
@@ -33,6 +33,10 @@ ddg_goodie_test(
     '12 from binary'       => undef,
     'decimal 12 binary'    => undef,
     'hex 12 binary'        => undef,
+    'Cyngus X-1 binary'    => undef,
+    'Cygnus X-1 as binary' => test_zci(
+        'Binary conversion: "Cygnus X-1" (string) = 01000011011110010110011101101110011101010111001100100000010110000010110100110001 (binary)'),
+    'to binary' => undef,
 );
 
 done_testing;


### PR DESCRIPTION
- Add expected trigger "decimal 3 to binary" which fixes #291
- Add complementary trigger for 'hex' where it may be ambiguous.
- Normalize hex conversion output.
- Add additional prepositions which imply conversion ('as', 'into')
- Adjust output style to be more like other IAs.
- Improve comments, albeit very slightly.
- Add additional tests, including covering all example queries.
- Add ABSTRACT to reduce scroll spam under `dzil test`
