### PR TITLE
fix calculator alarm after result

### DIFF
--- a/lib/DDG/Goodie/Calculator.pm
+++ b/lib/DDG/Goodie/Calculator.pm
@@ -96,6 +96,7 @@ handle query_nowhitespace => sub {
 	    # e.g. sin(100000)/100000 completely makes this go haywire.
 	    alarm(1);
 	    $tmp_result = eval($tmp_expr);
+	    alarm(0);
 	};
 	
 	# 0-9 check for http://yegg.duckduckgo.com/?q=%243.43%20%2434.45&format=json


### PR DESCRIPTION
The alarm function (used to guard against run-away evals) needs to be
canceled after it's been initiated or it will deliver a SIGALRM to the
process after the result has been returned [shutting down duckpan].

I looked into this after realizing that queries for `1+1` were failing in `duckpan query` strangely after delivering a correct result. I'm not quite sure why this isn't failing in production, maybe it's got a different signal handler in its context, maybe it's getting restarted, or maybe this is only a problem on my system :-).

[perldoc alarm](http://perldoc.perl.org/functions/alarm.html)
