### PR TITLE
MoonPhase: make tests less dependant on phase of the moon.

### DIFF
--- a/lib/DDG/Goodie/MoonPhases.pm
+++ b/lib/DDG/Goodie/MoonPhases.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::MoonPhases;
+# ABSTRACT: answer queries for the current phase of the moon.
 
 use DDG::Goodie;
 use Astro::MoonPhase;

--- a/t/MoonPhases.t
+++ b/t/MoonPhases.t
@@ -5,20 +5,24 @@ use warnings;
 use Test::More;
 use DDG::Test::Goodie;
 
-zci is_cached => 0;
+zci is_cached   => 0;
 zci answer_type => 'moonphases';
 
+my $space_plus = qr/(?:\s|\+)/;
+my $wax_wane   = qr/(?:Waxing|Waning)$space_plus(?:Gibbous|Crescent)/;
+my $quarter    = qr/(?:First|Third)$space_plus(?:Quarter)/;
+my $named      = qr/(?:New|Full)$space_plus(?:Moon)/;
+my $phases     = qr/$wax_wane|$quarter|$named/;
+
+my $ascii_answer = qr/^The current lunar phase is: $phases$/;
+my $html_answer  = qr%^The current lunar phase is: <a href="\?q=$phases">$phases</a>$%;
+
 ddg_goodie_test(
-    [qw(
-        DDG::Goodie::MoonPhases
-    )],
-    'moon phase' => test_zci(
-    	qr/The current lunar phase is/,
-    	html => qr/The current lunar phase is/
-    ),
-    'lunar phase' => test_zci('The current lunar phase is: Waxing Gibbous', html => 'The current lunar phase is: <a href="?q=Waxing+Gibbous">Waxing Gibbous</a>'),
-    'phase of the moon' => test_zci('The current lunar phase is: Waxing Gibbous', html => 'The current lunar phase is: <a href="?q=Waxing+Gibbous">Waxing Gibbous</a>'),
-    'what is the current lunar phase' => test_zci('The current lunar phase is: Waxing Gibbous', html => 'The current lunar phase is: <a href="?q=Waxing+Gibbous">Waxing Gibbous</a>'),
+    [qw( DDG::Goodie::MoonPhases)],
+    'moon phase'                      => test_zci($ascii_answer, html => $html_answer,),
+    'lunar phase'                     => test_zci($ascii_answer, html => $html_answer,),
+    'phase of the moon'               => test_zci($ascii_answer, html => $html_answer,),
+    'what is the current lunar phase' => test_zci($ascii_answer, html => $html_answer,),
 );
 
 done_testing;


### PR DESCRIPTION
This improves on the former naive version for "moon phase" while (I
think) keeping the test time independant.

Hopefully the addition of the built up regexes works as intended to keep
it readable and maintainable.

On the other hand, it doesn't do anything about proving that the given
answer is correct or even internally consistent.  I am not sure how to
do that within the testing environment constraints.

Also adds an abstract to reduce `dzil test` scroll spam.
