### PR TITLE
Spelling fix in plugin descriptio

### DIFF
--- a/lib/DDG/Goodie/ParseCron.pm
+++ b/lib/DDG/Goodie/ParseCron.pm
@@ -18,7 +18,7 @@ zci is_cached => 0;
 
 primary_example_queries 'crontab * */3 * * *';
 secondary_example_queries 'crontab 42 12 3 Feb Sat';
-description 'show the next occurance of a cron job in human-readable form';
+description 'show the next occurence of a cron job in human-readable form';
 name 'ParseCron';
 code_url 'https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/ParseCron.pm';
 category 'computing_info';


### PR DESCRIPTION
This is the plugin description which is displayed on the DuckDuckGo website. Surprising nobody else hasn't caught it before.
