### PR TITLE
CalendarToday: use correct timezone

### DIFF
--- a/lib/DDG/Goodie/CalendarToday.pm
+++ b/lib/DDG/Goodie/CalendarToday.pm
@@ -3,6 +3,8 @@ package DDG::Goodie::CalendarToday;
 
 use DDG::Goodie;
 use Time::Piece;
+use DateTime;
+use DateTime::TimeZone; 
 
 primary_example_queries "calendar";
 secondary_example_queries "calendar november", 
@@ -36,8 +38,9 @@ my $css = share("style.css")->slurp;
 
 handle remainder => sub {
   
-  # check current date
-  my $t = localtime;
+  # check current date in users timezone
+  my $t = DateTime->now; 
+  $t->set_time_zone($loc->time_zone);
   $currentDay = $t->mday;
   $currentMonth = $t->mon;
   $currentYear = $t->year;


### PR DESCRIPTION
minor addition to pullrequest #333
use correct timezone of user instead of servertime
suggested by @jagtalon
