### PR TITLE
PrimeFactors: add 'factorize'and 'prime factorize' triggers.

### DIFF
--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -11,16 +11,18 @@ zci answer_type => "prime_factors";
 zci is_cached => 1;
 
 triggers startend => (
-    'prime factors', 
-    'prime factors of', 
-    'the prime factors of', 
-    'factorization of', 
+    'prime factors',
+    'prime factors of',
+    'the prime factors of',
+    'factorization of',
     'prime factorization',
-    'prime factorization of'
+    'prime factorization of',
+    'factorize',
+    'prime factorize',
 );
 
 primary_example_queries 'prime factors of 30';
-secondary_example_queries '72 prime factors';
+secondary_example_queries '72 prime factors', 'factorize 128';
 description 'Returns the prime factors of the entered number';
 name 'PrimeFactors';
 topics 'math';

--- a/t/PrimeFactors.t
+++ b/t/PrimeFactors.t
@@ -22,6 +22,10 @@ ddg_goodie_test(
 				      html => 'The prime factorization of 30 is 2 × 3 × 5'),
     'prime factorization of 45' => test_zci('The prime factorization of 45 is 3^2 × 5',
 					    html => 'The prime factorization of 45 is 3<sup>2</sup> × 5'),
+    'factorize 128' => test_zci('The prime factorization of 128 is 2^7',
+					    html => 'The prime factorization of 128 is 2<sup>7</sup>'),
+    '42 prime factorize' => test_zci('The prime factorization of 42 is 2 × 3 × 7',
+					    html => 'The prime factorization of 42 is 2 × 3 × 7'),
     'optimus prime 45' => undef,
 );
 


### PR DESCRIPTION
Intended to resolve issue #383.
- Add 'factorize' and 'prime factorize' triggers.
- Use 'factorize 128' as a secondary example query.
- Add minimal tests for new triggers.
