### PR TITLE
PublicDNS: use different name space in CSS.

### DIFF
--- a/share/goodie/public_dns/style.css
+++ b/share/goodie/public_dns/style.css
@@ -1,16 +1,16 @@
-#zero_click_abstract table.publicdns {
+#zci-answer table.publicdns {
     font-family: Consolas,"Anonymous Pro",Anonymous,"Courier New",monospace;
     font-size: 12px;
     line-height: 14px;
 }
 
-#zero_click_abstract table.publicdns td {
+#zci-answer table.publicdns td {
     white-space: nowrap;
     padding: 2px 4px;
     border: 2px solid #fff;
 }
 
-#zero_click_abstract table.publicdns th {
+#zci-answer table.publicdns th {
     font-weight: bold;
     text-align: center;
     background-color: #888;


### PR DESCRIPTION
Intended to address issue #429

I honestly don't know if this is the correct minimal namespace or if
other restyling may be required.

In testing with `duckpan` the "Answer" text is missing from the header, but this seems like a common property of goodie answers.

![screenshot from 2014-05-10 08 48 16](https://cloud.githubusercontent.com/assets/6280000/2934821/1a141f7c-d7dd-11e3-9d49-2249a05bcff5.png)
