### PR TITLE
UnixTime: Adding new triggers

### DIFF
--- a/lib/DDG/Goodie/UnixTime.pm
+++ b/lib/DDG/Goodie/UnixTime.pm
@@ -3,7 +3,7 @@ package DDG::Goodie::UnixTime;
 use DDG::Goodie;
 use DateTime;
 
-triggers startend => "unixtime", "time", "timestamp", "datetime", "epoch", "unix time", "unix epoch";
+triggers startend => "unixtime", "time", "timestamp", "datetime", "epoch", "unix time", "unix timestamp", "unix time stamp", "unix epoch";
 
 zci answer_type => "time_conversion";
 zci is_cached => 0;

--- a/t/UnixTime.t
+++ b/t/UnixTime.t
@@ -17,7 +17,7 @@ ddg_goodie_test(
     'epoch 2147483647' => test_zci('Unix Time Conversion: Tue Jan 19 03:14:07 2038 +0000'),
     map {
         "$_ 0" => test_zci('Unix Time Conversion: Thu Jan 01 00:00:00 1970 +0000'),
-    }, [ 'unixtime', 'time', 'timestamp', 'datetime', 'epoch', 'unix time', 'unix epoch' ]
+    }, [ 'unixtime', 'time', 'timestamp', 'datetime', 'epoch', 'unix time', 'unix timestamp', 'unix epoch' ]
 );
 
 done_testing;


### PR DESCRIPTION
Hey,

Take 2: should add new triggers "unix timestamp" and "unix time stamp".

Apologies for the commits into master (should now be reverted); I just got into a total mess between the FedEx, master and this branch.
