### PR TITLE
HTTPS -> HTTP for hidden service url

### DIFF
--- a/share/goodie/duck_duck_go/responses.yml
+++ b/share/goodie/duck_duck_go/responses.yml
@@ -150,7 +150,7 @@ tor:
     - hiddenservice
     - torhiddenservice
   base_format: "DuckDuckGo's [Tor hidden service]"
-  info_url: https://3g2upl4pq6kufc4m.onion
+  info_url: http://3g2upl4pq6kufc4m.onion
 traffic:
   base_format: "DuckDuckGo's [traffic page]"
   info_url: https://duckduckgo.com/traffic.html


### PR DESCRIPTION
It's not a necessary change--but it's currently redundant given that all tor traffic is encrypted. Maybe even keep if people are more comfortable seeing the HTTPS

//  @nilnilnil 
