### PR TITLE
dice: larger font size

### DIFF
--- a/lib/DDG/Goodie/Dice.pm
+++ b/lib/DDG/Goodie/Dice.pm
@@ -91,7 +91,8 @@ handle remainder_lc => sub {
             }
             $total += $sum; # track total of all rolls
             $out .= join(', ', @output) . '<br/>';
-            $html .= '<span style="font-size:2em;">' . join(' ', @output) . ' = ' . $sum .'</span> <br/>';
+            $html .= '<span style="font-size:2em;">' . join(' ', @output).'</span>'
+                    .'<span style="white-space: nowrap; font-size:2em;">'." = ". $sum.'</span></br>';
         }
         elsif ($_ =~ /^(\d*)[d|w](\d+)\s?([+-])?\s?(\d+|[lh])?$/) { 
             # ex. '2d8', '2w6 - l', '3d4 + 4', '3d4-l'

--- a/t/Dice.t
+++ b/t/Dice.t
@@ -117,7 +117,7 @@ ddg_goodie_test(
 
         # Check the HTML. Just once for a longhand query.
         "throw die" => test_zci(qr/^.$/,
-                html =>  qr/<span style="font-size:2em;">. = \d+<\/span> <br\/>/,
+                html =>  qr/<span style="font-size:2em;">.<\/span><span style="white-space: nowrap; font-size:2em;"> = \d+<\/span><\/br>/,
                 heading => $heading
         ),
         


### PR DESCRIPTION
Current: 
![selection_049](https://cloud.githubusercontent.com/assets/1882892/3152366/4d13ba32-ea8d-11e3-9df8-984c9a060de8.png)

Larger font and no comma:
![selection_048](https://cloud.githubusercontent.com/assets/1882892/3152370/5303d350-ea8d-11e3-8783-f0ce31c3b211.png)

@chrismorast  @russellholt 
