### PR TITLE
Calculator: give result for sin(pi)

### DIFF
--- a/lib/DDG/Goodie/Calculator.pm
+++ b/lib/DDG/Goodie/Calculator.pm
@@ -141,6 +141,10 @@ handle query_nowhitespace => sub {
 
         # Guard against non-result results
         return unless (defined $tmp_result && $tmp_result ne 'inf');
+        # Try to determine if the result is supposed to be 0, but isn't because of FP issues.
+        # If there's a defined precision, let sprintf worry about it.
+        # Otherwise, we'll say that smaller than 1e-7 was supposed to be zero.
+        $tmp_result = 0 if (not defined $precision and ($tmp_result =~ /e\-(?<exp>\d+)$/ and $+{exp} > 7));
         # Guard against very small floats which will not be rounded.
         # 0-9 check for http://yegg.duckduckgo.com/?q=%243.43%20%2434.45&format=json
         return unless (defined $precision || ($tmp_result =~ /^(?:\-|)[0-9\.]+$/));

--- a/t/Calculator.t
+++ b/t/Calculator.t
@@ -265,6 +265,31 @@ ddg_goodie_test(
         heading => 'Calculator',
         html    => qq(<div>1. + 1. = <a href="javascript:;" onClick="document.x.q.value='2';document.x.q.focus();">2</a></div>),
     ),
+    '1 + sin(pi)' => test_zci(
+        '1 + sin(pi) = 1',
+        heading => 'Calculator',
+        html    => qq(<div>1 + sin(pi) = <a href="javascript:;" onClick="document.x.q.value='1';document.x.q.focus();">1</a></div>),
+    ),
+    '1 - 1' => test_zci(
+        '1 - 1 = 0',
+        heading => 'Calculator',
+        html    => qq(<div>1 - 1 = <a href="javascript:;" onClick="document.x.q.value='0';document.x.q.focus();">0</a></div>),
+    ),
+    'sin(pi/2)' => test_zci(
+        'sin(pi / 2) = 1',
+        heading => 'Calculator',
+        html    => qq(<div>sin(pi / 2) = <a href="javascript:;" onClick="document.x.q.value='1';document.x.q.focus();">1</a></div>),
+    ),
+    'sin(pi)' => test_zci(
+        'sin(pi) = 0',
+        heading => 'Calculator',
+        html    => qq(<div>sin(pi) = <a href="javascript:;" onClick="document.x.q.value='0';document.x.q.focus();">0</a></div>),
+    ),
+    'cos(2pi)' => test_zci(
+        'cos(2 pi) = 1',
+        heading => 'Calculator',
+        html    => qq(<div>cos(2 pi) = <a href="javascript:;" onClick="document.x.q.value='1';document.x.q.focus();">1</a></div>),
+    ),
     'sin(1.0) + 1,05'    => undef,
     '4,24,334+22,53,828' => undef,
     '5234534.34.54+1'    => undef,


### PR DESCRIPTION
Man, literal months of tweaking and improving on the previous pull request and within 10 queries of noticing the new Calculator was live.. I found a problem.

Turns out that sin(pi) isn't exactly 0 when you account for floating point issues.  This gets caught in the attempts to avoid showing floating point in exponent form.

The fix applied here is to treat anything smaller than 1e-7 as 0, unless it would otherwise be rounded (probably also to 0 but I dare not speculate.)
