### PR TITLE
`dns server` does not respond with a list of DNS servers

### DIFF
--- a/lib/DDG/Goodie/PublicDNS.pm
+++ b/lib/DDG/Goodie/PublicDNS.pm
@@ -15,7 +15,7 @@ topics 'sysadmin';
 
 attribution github => ['https://github.com/warthurton', 'warthurton'];
 
-triggers end => "public dns", "dns servers";
+triggers end => "public dns", "dns server", "dns servers";
 
 zci is_cached   => 1;
 zci answer_type => "public_dns";


### PR DESCRIPTION
Unlike the similar `dns servers`, `dns server` does not yield a list of DNS servers.  Since we have this information available already, it seems reasonable to be more accepting in the input that triggers this list.
