### PR TITLE
Calculator: add 'squared' and 'score'.

### DIFF
--- a/lib/DDG/Goodie/Calculator.pm
+++ b/lib/DDG/Goodie/Calculator.pm
@@ -30,14 +30,14 @@ triggers query_nowhitespace => qr<
         [\( \) x X * % + / \^ \$ -]*
 
         (?: [0-9 \. ,]* )
-        (?: gross | dozen | pi | e | c |)
+        (?: gross | dozen | pi | e | c | squared | score |)
         [\( \) x X * % + / \^ 0-9 \. , \$ -]*
 
         (?(1) (?: -? [0-9 \. ,]+ |) |)
-        (?: [\( \) x X * % + / \^ \$ -] | times | divided by | plus | minus | cos | sin | tan | cotan | log | ln | log[_]?\d{1,3} | exp | tanh | sec | csc)+
+        (?: [\( \) x X * % + / \^ \$ -] | times | divided by | plus | minus | cos | sin | tan | cotan | log | ln | log[_]?\d{1,3} | exp | tanh | sec | csc | squared )+
 
         (?: [0-9 \. ,]* )
-        (?: gross | dozen | pi | e | c |)
+        (?: gross | dozen | pi | e | c | squared | score |)
 
         [\( \) x X * % + / \^ 0-9 \. , \$ -]* =? 
 
@@ -87,6 +87,7 @@ my %named_operations = (
     'plus'        => '+',
     'divided\sby' => '/',
     'ln'          => 'log',                         # perl log() is natural log.
+    'squared'     => '**2',
 );
 
 my %named_constants = (
@@ -94,6 +95,7 @@ my %named_constants = (
     e     => 2.71828182845904523536028747135266249,    # This should be computed.
     pi    => pi,                                       # pi constant from Math::Trig
     gross => 144,
+    score => 20,
 );
 
 my $ored_constants = join('|', keys %named_constants);    # For later substitutions
@@ -208,7 +210,7 @@ sub spacing {
 
     $text =~ s/(\s*(?<!<)(?:[\+\-\^xX\*\/\%]|times|plus|minus|dividedby)+\s*)/ $1 /ig;
     $text =~ s/\s*dividedby\s*/ divided by /ig;
-    $text =~ s/(\d+?)((?:dozen|pi|gross))/$1 $2/ig;
+    $text =~ s/(\d+?)((?:dozen|pi|gross|squared|score))/$1 $2/ig;
     $text =~ s/(\d+?)e/$1 e/g;    # E == *10^n
     $text =~ s/([\(\)\$])/ $1 /g if ($space_for_parse);
 

--- a/t/Calculator.t
+++ b/t/Calculator.t
@@ -274,11 +274,53 @@ ddg_goodie_test(
         heading => 'Calculator',
         html    => qr/./,
     ),
+    '5 squared' => test_zci(
+        '5 squared = 25',
+        heading => 'Calculator',
+        html    => qr/./,
+    ),
+    '1.0 + 5 squared' => test_zci(
+        '1.0 + 5 squared = 26.0',
+        heading => 'Calculator',
+        html    => qr/./,
+    ),
+    '3 squared + 4 squared' => test_zci(
+        '3 squared + 4 squared = 25',
+        heading => 'Calculator',
+        html    => qr/./,
+    ),
+    '2,2 squared' => test_zci(
+        '2,2 squared = 4,8',
+        heading => 'Calculator',
+        html    => qr/./,
+    ),
+    '0.8^2 + 0.6^2' => test_zci(
+        '0.8 ^ 2 + 0.6 ^ 2 = 1',
+        heading => 'Calculator',
+        html    => qr#0.8<sup>2</sup> \+ 0.6<sup>2</sup> = 1#,
+    ),
+    '2 squared ^ 3' => test_zci(
+        '2 squared ^ 3 = 256',
+        heading => 'Calculator',
+        html    => qr#2 squared<sup>3</sup> = 256#,
+    ),
+    '2^3 squared' => test_zci(
+        '2 ^ 3 squared = 512',
+        heading => 'Calculator',
+        html    => qr#2<sup>3</sup>squared = 512#,
+    ),
+    '4 score + 7' => test_zci(
+        '4 score + 7 = 87',
+        heading => 'Calculator',
+        html    => qr/./,
+    ),
     'sin(1.0) + 1,05'    => undef,
     '4,24,334+22,53,828' => undef,
     '5234534.34.54+1'    => undef,
     '//'                 => undef,
     dividedbydividedby   => undef,
+    time                 => undef,    # We eval perl directly, only do whitelisted stuff!
+    'four squared'       => undef,
 );
 
 done_testing;


### PR DESCRIPTION
This is an attempt to add the requested "squared" operation without all
of the nasty trigger changes I introduced last time I tried.

Also added a constant for 'score' as both an attempt to better
understand that trigger regex and an historical oddity.

It's clear that if I want to continue with this I should make a lexer.
