### PR TITLE
Calculator: improve precision/accuracy trade-off.

### DIFF
--- a/lib/DDG/Goodie/Calculator.pm
+++ b/lib/DDG/Goodie/Calculator.pm
@@ -246,8 +246,9 @@ sub _well_formed_for_style_func {
         return (
             $number =~ /^[\d$thousands$decimal]+$/
               # Only contains things we understand.
-              && ($number !~ /$thousands/ || ($number !~ /$thousands\d{1,2}\b/ && $number !~ /$thousands\d{4,}/))
-              # You can leave out thousands breaks, but the ones you put in must be in the right place.
+              && ($number !~ /$thousands/ || ($number !~ /$thousands\d{1,2}\b/ && $number !~ /$thousands\d{4,}/ && $number !~ /^0\Q$thousands\E/))
+              # You can leave out thousands breaks, but the ones you put in must be in the right place
+              # which does not include following an initial 0.
               # Note that this does not confirm that they put all the 'required' ones in.
               && ($number !~ /$decimal/ || $number !~ /$decimal(?:.*)?(?:$decimal|$thousands)/)
               # You can omit the decimal but you cannot have another decimal or thousands after:

--- a/t/Calculator.t
+++ b/t/Calculator.t
@@ -13,6 +13,7 @@ subtest 'display format selection' => sub {
     my $ds_name = 'DDG::Goodie::Calculator::display_style';
     my $ds      = \&$ds_name;
 
+    is($ds->('0,013')->{id}, 'euro', '0,013 is euro');
     is($ds->('4,431',      '4.321')->{id}, 'perl', '4,431 and 4.321 is perl');
     is($ds->('4,431',      '4.32')->{id},  'perl', '4,431 and 4.32 is perl');
     is($ds->('4,431',      '4,32')->{id},  'euro', '4,431 and 4,32 is euro');


### PR DESCRIPTION
This includes multiplication and division in things which should not be
rounded to our determined precision. While this doesn't break any
current tests, it might lead to some surprising floating-point issues.

On the other hand, the other way led to some surprising results where

418.10 / 2 != 418.1 / 2

Hopefully there exists a better long-term solution which we'll find soon
enough.

Addresses issue #509.
