### PR TITLE
ColorCodes: eliminate NBS_ISCC sub dictionaries from lookups.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -40,6 +40,8 @@ Convert::Pluggable = 0.021
 YAML = 0
 ; ParseCron
 Schedule::Cron::Events = 0
+; ColorCodes
+Color::Library = 0
 Convert::Color = 0.08
 Convert::Color::Library = 0.03
 Convert::Braille = 0.05

--- a/lib/DDG/Goodie/ColorCodes.pm
+++ b/lib/DDG/Goodie/ColorCodes.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::ColorCodes;
 
 use DDG::Goodie;
+use Color::Library;
 use Convert::Color;
 use Convert::Color::Library;
 use Convert::Color::RGB8;
@@ -18,6 +19,11 @@ my %types = ( # hash of keyword => Convert::Color prefix
         cmyk    => 'cmyk',
         cmyb    => 'cmyk',
         );
+
+# Eliminate NBS_ISCC sub-dictionaries from our lookups.
+# They contain "idiosyncratic" color names (including 'email' in NBS_ISCC::M) which will
+# otherwise cause this to return answers for which no one was looking.
+my $color_dictionaries = join(',', grep { $_ !~ /^nbs-iscc-/ } map { $_->id } Color::Library->dictionaries);
 
 my $typestr = join '|', sort { length $b <=> length $a } keys %types;
 $typestr =~ s/([#\^\$\*\+\?])/\\$1/g;
@@ -103,7 +109,7 @@ handle matches => sub {
 
     return unless $type && $color;
 
-    eval { $color = join(',',Convert::Color::Library->new($color)->as_rgb8->hex); $type = 'rgb8'; };
+    eval { $color = join(',',Convert::Color::Library->new($color_dictionaries.'/'.$color)->as_rgb8->hex); $type = 'rgb8'; };
 
     my $col;
     eval { $col = Convert::Color->new("$type:$color"); };

--- a/t/ColorCodes.t
+++ b/t/ColorCodes.t
@@ -44,6 +44,13 @@ ddg_goodie_test(
         'Hex: #ff00ff ~ rgb(255, 0, 255) ~ rgb(100%, 0%, 100%) ~ hsl(300, 100%, 50%) ~ cmyb(0%, 100%, 0%, 0%)',
         html => qq(<div style="background:#ff00ff;border:2px solid #999;height:30px;width:30px;margin:5px;margin-right:10px;margin-top:3px;float:left;"></div>Hex: #ff00ff ~ rgb(255, 0, 255) ~ rgb(100%, 0%, 100%) ~ hsl(300, 100%, 50%) ~ cmyb(0%, 100%, 0%, 0%) [<a href='http://labs.tineye.com/multicolr#colors=ff00ff;weights=100;'>Images</a>] [<a href='http://www.color-hex.com/color/ff00ff' title='Tints, information and similar colors on color-hex.com'>Info</a>]),
     ),
+    'html bluishblack' => test_zci(
+        'Hex: #202428 ~ rgb(32, 36, 40) ~ rgb(13%, 14%, 16%) ~ hsl(210, 11%, 14%) ~ cmyb(20%, 10%, 0%, 84%)',
+        html => qq(<div style="background:#202428;border:2px solid #999;height:30px;width:30px;margin:5px;margin-right:10px;margin-top:3px;float:left;"></div>Hex: #202428 ~ rgb(32, 36, 40) ~ rgb(13%, 14%, 16%) ~ hsl(210, 11%, 14%) ~ cmyb(20%, 10%, 0%, 84%) [<a href='http://labs.tineye.com/multicolr#colors=202428;weights=100;'>Images</a>] [<a href='http://www.color-hex.com/color/202428' title='Tints, information and similar colors on color-hex.com'>Info</a>]),
+    ),
+    'bluishblack html' => undef,
+    'HTML email'       => undef,
+    'wield color'      => undef,
 );
 
 done_testing;


### PR DESCRIPTION
By their own documentation, the NBS submodules contain idiosyncratic
color names which are not well-suited to a general purpose color code
search.

In particular, NBS_ISCC::M contains a color called 'email' which caused
a confusing result for 'HTML email'.

The main NBS colors are included because they seem reasonable enough as
color names.

This fixes #490 and possibly partially addresses #454 and #442, I guess.
