### PR TITLE
Reverse: add guard against empty remainder.

### DIFF
--- a/lib/DDG/Goodie/Reverse.pm
+++ b/lib/DDG/Goodie/Reverse.pm
@@ -19,6 +19,7 @@ zci answer_type => "reverse";
 
 handle remainder => sub {
 
+  return unless $_; # Guard against empty query.
   #Filter out requests for DNA/RNA reverse complements, handled
   # by the ReverseComplement goodie
   return if $_ =~ /^complement\s(of )?[ATCGURYKMSWBVDHN\s-]+$/i;

--- a/t/Reverse.t
+++ b/t/Reverse.t
@@ -15,6 +15,7 @@ ddg_goodie_test(
 	'reverse bla' => test_zci('Reversed "bla": alb'),
 	'reverse blabla' => test_zci('Reversed "blabla": albalb'),
   'reverse esrever' => test_zci('Reversed "esrever": reverse'),
+    'reverse' => undef,
 
   #Should not trigger on a request for DNA/RNA reverse complement
   'reverse complement of ATG-CTA-GGG-GCT' => undef,


### PR DESCRIPTION
This fixes #521, plus regression test.
