### PR TITLE
Calc triggers

### DIFF
--- a/lib/DDG/Goodie/Calculator.pm
+++ b/lib/DDG/Goodie/Calculator.pm
@@ -96,18 +96,18 @@ my %named_constants = (
 
 my $ored_constants = join('|', keys %named_constants);    # For later substitutions
 
-my $ip4_octet = qr/([01]?\d\d?|2[0-4]\d|25[0-5])/;        # Each octet should look like a number between 0 and 255.
-my $ip4_regex = qr/(?:$ip4_octet\.){3}$ip4_octet/;        # There should be 4 of them separated by 3 dots.
-my $up_to_32  = qr/([1-2]?[0-9]{1}|3[1-2])/;              # 0-32
-my $cidr      = qr#^$ip4_regex\s*/\s*$up_to_32\s*$#;      # Looks like CIDR notation.
+my $ip4_octet = qr/([01]?\d\d?|2[0-4]\d|25[0-5])/;                     # Each octet should look like a number between 0 and 255.
+my $ip4_regex = qr/(?:$ip4_octet\.){3}$ip4_octet/;                     # There should be 4 of them separated by 3 dots.
+my $up_to_32  = qr/([1-2]?[0-9]{1}|3[1-2])/;                           # 0-32
+my $network   = qr#^$ip4_regex\s*/\s*(?:$up_to_32|$ip4_regex)\s*$#;    # Looks like network notation, either CIDR or subnet mask
 
 handle query_nowhitespace => sub {
     my $results_html;
     my $results_no_html;
     my $query = $_;
 
-    return if ($query =~ /\b0x/);    # Probable attempt to express a hexadecimal number, query_nowhitespace makes this overreach a bit.
-    return if ($query =~ $cidr);     # Probably want to talk about addresses, not calculations.
+    return if ($query =~ /\b0x/);      # Probable attempt to express a hexadecimal number, query_nowhitespace makes this overreach a bit.
+    return if ($query =~ $network);    # Probably want to talk about addresses, not calculations.
 
     $query =~ s/^(?:whatis|calculate|solve|math)//;
 

--- a/t/Calculator.t
+++ b/t/Calculator.t
@@ -375,16 +375,22 @@ ddg_goodie_test(
         heading => 'Calculator',
         html    => qr/./,
     ),
-    '83.166.167.160/27'  => undef,
-    '9 + 0 x 07'         => undef,
-    '0x07'               => undef,
-    'sin(1.0) + 1,05'    => undef,
-    '4,24,334+22,53,828' => undef,
-    '5234534.34.54+1'    => undef,
-    '//'                 => undef,
-    dividedbydividedby   => undef,
-    time                 => undef,    # We eval perl directly, only do whitelisted stuff!
-    'four squared'       => undef,
+    '123.123.123.123/255.255.255.256' => test_zci(
+        '123.123.123.123 / 255.255.255.256 = 0,482352941174581',
+        heading => 'Calculator',
+        html    => qr/./,
+    ),
+    '123.123.123.123/255.255.255.255' => undef,
+    '83.166.167.160/27'               => undef,
+    '9 + 0 x 07'                      => undef,
+    '0x07'                            => undef,
+    'sin(1.0) + 1,05'                 => undef,
+    '4,24,334+22,53,828'              => undef,
+    '5234534.34.54+1'                 => undef,
+    '//'                              => undef,
+    dividedbydividedby                => undef,
+    time                              => undef,    # We eval perl directly, only do whitelisted stuff!
+    'four squared'                    => undef,
 );
 
 done_testing;


### PR DESCRIPTION
This pares back the triggers for the Calculator goodie such that it doesn't handle things which look sort of like arithmetic expressions, but are more likely attempts to express some other intent. Particularly:
- skip `0xN`-looking things, because they are probably more interested in hex numbers than seeing that part turned into "0"
- skip things which look like IP4 addresses with network identifiers.
