### PR TITLE
Binary: expand to converting 64-bit decimal integers.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -70,6 +70,7 @@ DateTime::Calendar::Chinese = 1.00
 DateTime::Event::Chinese = 1.00
 Geo::Coordinates::DecimalDegrees = 0.09
 Math::SigFigs = 1.09
+Bit::Vector = 7.3
 
 [Prereqs / TestRequires]
 Test::More = 0.98

--- a/lib/DDG/Goodie/Binary.pm
+++ b/lib/DDG/Goodie/Binary.pm
@@ -3,6 +3,8 @@ package DDG::Goodie::Binary;
 
 use DDG::Goodie;
 
+use Bit::Vector;
+
 triggers end => "binary";
 
 zci is_cached => 1;
@@ -26,12 +28,14 @@ sub bin {
 }
 
 sub dec2bin {
-    my @dec = shift;
-    my $str = unpack("B*", pack("N", $dec[0] ));
-    $str =~ s/^0+(?=\d)//;   # first suppress leading zeros
-# Then add some more ...    
-    return ('0' x (8 - (length($str) % 8))) . $str if (length($str)%8 > 0); 
-    return $str
+    my $dec = shift;
+    #  Method for packing without 'q' taken from:
+    #  http://www.perlmonks.org/?node_id=163123
+    my $vec = Bit::Vector->new_Dec(64, $dec);
+    my $str = unpack("B*", pack('NN', $vec->Chunk_Read(32, 32), $vec->Chunk_Read(32, 0)));
+    $str =~ s/^0+(?=\d)//;    # first suppress leading zeros
+    my $alignment = length($str) % 8;    # Then see if we need to pad for byte-sized output.
+    return ($alignment) ? ('0' x (8 - $alignment)) . $str : $str;
 }
 
 sub hex2bin {

--- a/t/Binary.t
+++ b/t/Binary.t
@@ -28,6 +28,9 @@ ddg_goodie_test(
     'hex 10 into binary'   => test_zci('Binary conversion: 0x10 (hex) = 00010000 (binary)'),
     '0xg into binary'      => test_zci('Binary conversion: "0xg" (string) = 001100000111100001100111 (binary)'),
     'hex 0xg as binary'    => test_zci('Binary conversion: "hex 0xg" (string) = 01101000011001010111100000100000001100000111100001100111 (binary)'),
+    '2336462209024 in binary' => test_zci('Binary conversion: 2336462209024 (decimal) = 000000100010000000000000000000000000000000000000 (binary)'),
+    '300000000000000 as binary' =>
+      test_zci('Binary conversion: 300000000000000 (decimal) = 00000001000100001101100100110001011011101100000000000000 (binary)'),
     'binary 10'            => undef,
     '12 binary'            => undef,
     '12 from binary'       => undef,


### PR DESCRIPTION
This uses Bit::Vector rather than presuming anything about the perl
support for 64-bit ints. This seems safer, even if it's a smidge slower.

This fixes issue #564 with test demonstrating such.
