### PR TITLE
Uppercase: switch triggers to "start"-only.

### DIFF
--- a/lib/DDG/Goodie/Uppercase.pm
+++ b/lib/DDG/Goodie/Uppercase.pm
@@ -3,8 +3,10 @@ use DDG::Goodie;
 
 use HTML::Entities;
 
-triggers startend => 'uppercase', 'upper case', 'allcaps', 'all caps', 'strtoupper', 'toupper';
+triggers start => 'uppercase', 'upper case', 'allcaps', 'all caps', 'strtoupper', 'toupper';
 # leaving out 'uc' because of queries like "UC Berkley", etc
+# 2014-08-10: triggers to "start"-only  to make it act more like a "command"
+#   resolves issue with queries like "why do people type in all caps"
 
 zci is_cached => 1;
 zci answer_type => "uppercase";

--- a/t/Uppercase.t
+++ b/t/Uppercase.t
@@ -18,8 +18,7 @@ ddg_goodie_test(
         html => qr/THAT/),
     'allcaps this string' => test_zci('THIS STRING',
         html => qr/THIS STRING/),
-    'that string all caps' => test_zci('THAT STRING',
-        html => qr/THAT STRING/),
+    'that string all caps' => undef,
     'is this uppercase, sir?' => undef,
 );
 


### PR DESCRIPTION
Since these act like a command, it makes sense to have it at the start
only.  This is also in line with the triggers for the very similar
lowercase IA.

Attempt to address issue #578.
