### PR TITLE
Calculator: better display for very small floats.

### DIFF
--- a/lib/DDG/Goodie/Calculator.pm
+++ b/lib/DDG/Goodie/Calculator.pm
@@ -125,12 +125,9 @@ handle query_nowhitespace => sub {
         return unless (defined $tmp_result && $tmp_result ne 'inf');
         # Try to determine if the result is supposed to be 0, but isn't because of FP issues.
         # If there's a defined precision, let sprintf worry about it.
-        # Otherwise, we'll say that smaller than 1e-7 was supposed to be zero.
-        $tmp_result = 0 if (not defined $precision and ($tmp_result =~ /e\-(?<exp>\d+)$/ and $+{exp} > 7));
-        # Guard against very small floats which will not be rounded.
-        # 0-9 check for http://yegg.duckduckgo.com/?q=%243.43%20%2434.45&format=json
-        return unless (defined $precision || ($tmp_result =~ /^(?:\-|)[0-9\.]+$/));
-
+        # Otherwise, we'll say that smaller than 1e-14 was supposed to be zero.
+        # -14 selected to account for the result of sin(pi)
+        $tmp_result = 0 if (not defined $precision and ($tmp_result =~ /e\-(?<exp>\d+)$/ and $+{exp} > 14));
         $tmp_result = sprintf('%0.' . $precision . 'f', $tmp_result) if ($precision);
         # Dollars.
         $tmp_result = '$' . $tmp_result if ($query =~ /^\$/);

--- a/t/Calculator.t
+++ b/t/Calculator.t
@@ -324,7 +324,8 @@ ddg_goodie_test(
     '(pi^4.1^(5-4)+pi^(5-(4^2 -8)))^(1/6)+1' => test_zci(
         '(pi ^ 4.1 ^ (5 - 4) + pi ^ (5 - (4 ^ 2 - 8))) ^ (1 / 6) + 1 = 3.18645452799383',
         heading => 'Calculator',
-        html    => qr#\(pi<sup>4.1<sup>\(5 - 4\)</sup></sup> \+ pi<sup>\(5 - \(4<sup>2</sup> - 8\)\)</sup>\)<sup>\(1 / 6\)</sup> \+ 1<span class='text--secondary'> =#,
+        html =>
+          qr#\(pi<sup>4.1<sup>\(5 - 4\)</sup></sup> \+ pi<sup>\(5 - \(4<sup>2</sup> - 8\)\)</sup>\)<sup>\(1 / 6\)</sup> \+ 1<span class='text--secondary'> =#,
     ),
     '5^4^(3-2)^1' => test_zci(
         '5 ^ 4 ^ (3 - 2) ^ 1 = 625',
@@ -371,6 +372,17 @@ ddg_goodie_test(
         heading => 'Calculator',
         html    => qr/./,
     ),
+    'pi/1e9' => test_zci(
+        'pi / (1  *  10 ^ 9) = 3.14159265358979 * 10^-9',
+        heading => 'Calculator',
+        html    => qr/./,
+    ),
+    'pi*1e9' => test_zci(
+        'pi * (1  *  10 ^ 9) = 3,141,592,653.58979',
+        heading => 'Calculator',
+        html    => qr/./,
+    ),
+
     '123.123.123.123/255.255.255.255' => undef,
     '83.166.167.160/27'               => undef,
     '9 + 0 x 07'                      => undef,


### PR DESCRIPTION
With the addition of the number styling role, we've improved the output
for very small floats.  We don't need to round them any longer, since
they produce comprehensible display values and don't break anything.
