### PR TITLE
Game of Thrones easter egg IA.

### DIFF
--- a/lib/DDG/Goodie/ValarMorghulis.pm
+++ b/lib/DDG/Goodie/ValarMorghulis.pm
@@ -18,7 +18,8 @@ attribution
 zci answer_type => 'valarmorghulis';
 
 handle remainder => sub {
-    return 'Valar dohaeris' if $_ eq '';
+    return 'Valar dohaeris',
+			html => '<span style="font-size: 1.5em; font-weight: 400;">Valar dohaeris</span>' if $_ eq '';
     return;
 };
 

--- a/t/ValarMorghulis.t
+++ b/t/ValarMorghulis.t
@@ -15,6 +15,7 @@ ddg_goodie_test(
     'valar morghulis' =>
         test_zci(
             'Valar dohaeris',
+			html => '<span style="font-size: 1.5em; font-weight: 400;">Valar dohaeris</span>'
         ),
     'what is valar morghulis' => undef,
     'valar morghulis meaning' => undef,  


### PR DESCRIPTION
Had some spare time at work today and I implemented [this community idea](https://duck.co/ideas/idea/4427/search-valar-morghulis-instant-answer-valar-doh). It's a small Game of Thrones easter egg.

When a user searches for "Valar Morghulis", we simply reply in plain text the response "Valar Dohaeris". See the community idea page for further explanation.

![ddg-got](https://cloud.githubusercontent.com/assets/851595/3966338/0f2eac98-27a2-11e4-82a4-e33d5813b3cd.png)

Should work on all platforms as it's a plain text response.
