### PR TITLE
VIN: remove "Useless use of greediness modifier"

### DIFF
--- a/lib/DDG/Goodie/VIN.pm
+++ b/lib/DDG/Goodie/VIN.pm
@@ -98,7 +98,7 @@ handle query_nowhitespace_nodash => sub {
     # No exclusive trigger, do checksum.
     # Since the vin numbers are just numbers,
     # we are more strict in regex (e.g. than UPS).
-    } elsif($query =~ /^(?:$tracking_qr|$vin_qr|)*([A-Z\d]{17}?)(?:$tracking_qr|$vin_qr|)*$/io || $query =~ /^(?:$tracking_qr|$vin_qr|)*([A-Z\d]{17})(?:$tracking_qr|$vin_qr|)*$/io) {
+    } elsif($query =~ /^(?:$tracking_qr|$vin_qr|)*([A-Z\d]{17})(?:$tracking_qr|$vin_qr|)*$/io || $query =~ /^(?:$tracking_qr|$vin_qr|)*([A-Z\d]{17})(?:$tracking_qr|$vin_qr|)*$/io) {
         $vin_number = uc $1;
 
         my $checksum   = 0;


### PR DESCRIPTION
Perl 5.20 generates a warning on this which cascades into a failure in
our environment.
