### PR TITLE
Fix minor code layout issues.

### DIFF
--- a/lib/DDG/Goodie/Average.pm
+++ b/lib/DDG/Goodie/Average.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Average;
+# ABSTRACT: take statistics for a list of numbers
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Base.pm
+++ b/lib/DDG/Goodie/Base.pm
@@ -1,6 +1,8 @@
 package DDG::Goodie::Base;
+# ABSTRACT: convert numbers between arbitrary bases
 
 use DDG::Goodie;
+
 use Math::Int2Base qw/int2base/;
 use 5.010;
 use bigint;

--- a/lib/DDG/Goodie/Base64.pm
+++ b/lib/DDG/Goodie/Base64.pm
@@ -1,7 +1,9 @@
 package DDG::Goodie::Base64;
+# ABSTRACT: Base64 <-> Unicode
 
 use DDG::Goodie;
-use MIME::Base64; 
+
+use MIME::Base64;
 use Encode;
 
 triggers startend => "base64";

--- a/lib/DDG/Goodie/BashPrimaryExpressions.pm
+++ b/lib/DDG/Goodie/BashPrimaryExpressions.pm
@@ -1,9 +1,12 @@
 package DDG::Goodie::BashPrimaryExpressions;
+# ABSTRACT: human-readable descriptions of bash shell expressions
 
-use HTML::Entities;
-use DDG::Goodie;
 use strict;
 use warnings;
+
+use DDG::Goodie;
+
+use HTML::Entities;
 
 triggers startend => 'bash if', 'bash';
 primary_example_queries 'bash [ -z hello ]';

--- a/lib/DDG/Goodie/Binary.pm
+++ b/lib/DDG/Goodie/Binary.pm
@@ -1,5 +1,5 @@
 package DDG::Goodie::Binary;
-# ABSTRACT Convert decimal, hex and string to binary.
+# ABSTRACT: Convert decimal, hex and string to binary.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/BirthStone.pm
+++ b/lib/DDG/Goodie/BirthStone.pm
@@ -1,5 +1,5 @@
 package DDG::Goodie::BirthStone;
-#Returns the birthstone of the queried month
+# ABSTRACT: Returns the birthstone of the queried month
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Braille.pm
+++ b/lib/DDG/Goodie/Braille.pm
@@ -1,8 +1,9 @@
 package DDG::Goodie::Braille;
+# ABSTRACT: Braille <-> ASCII/Unicode
 
 use DDG::Goodie;
+
 use Convert::Braille;
-use utf8;
 
 triggers query_raw => qr/\p{Braille}|braille/i;
 
@@ -12,7 +13,7 @@ handle query_raw => sub {
     s/translate to braille |( in)? braille$|^braille //;
     return join(" ", map {lc(brailleDotsToAscii($_))} split(/\x{2800}/, $_)) . ' (Braille)' if /\p{Braille}/;
     # the space used in this join is not a normal space, it's a braille unicode space (U+2800)
-    return join("\x{2800}", map {brailleAsciiToUnicode(uc $_)} split(/\s/, $_)) . ' (Braille)' if $_;    
+    return join("\x{2800}", map {brailleAsciiToUnicode(uc $_)} split(/\s/, $_)) . ' (Braille)' if $_;
     return;
 };
 

--- a/lib/DDG/Goodie/CalcRoots.pm
+++ b/lib/DDG/Goodie/CalcRoots.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::CalcRoots;
+# ABSTRACT: compute the n-th root of a number
 
 use DDG::Goodie;
 use Lingua::EN::Numericalize;

--- a/lib/DDG/Goodie/CanadaPost.pm
+++ b/lib/DDG/Goodie/CanadaPost.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::CanadaPost;
+# ABSTRACT: Track a package through Canada Post
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Chess960.pm
+++ b/lib/DDG/Goodie/Chess960.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Chess960;
+# ABSTRACT: return a random Chess 960 starting position.
 
 use strict;
 

--- a/lib/DDG/Goodie/Coin.pm
+++ b/lib/DDG/Goodie/Coin.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Coin;
+# ABSTRACT: flip a (fair) coin.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/ColorCodes.pm
+++ b/lib/DDG/Goodie/ColorCodes.pm
@@ -1,6 +1,8 @@
 package DDG::Goodie::ColorCodes;
+# ABSTRACT: Copious information about various ways ofencoding colors.
 
 use DDG::Goodie;
+
 use Color::Library;
 use Convert::Color;
 use Convert::Color::Library;

--- a/lib/DDG/Goodie/DHL.pm
+++ b/lib/DDG/Goodie/DHL.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::DHL;
+# ABSTRACT: track a package through DHL.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/DateMath.pm
+++ b/lib/DDG/Goodie/DateMath.pm
@@ -1,5 +1,5 @@
 package DDG::Goodie::DateMath;
-# ABSTRACT add/subtract days/weeks/months/years to/from a date
+# ABSTRACT: add/subtract days/weeks/months/years to/from a date
 
 use DDG::Goodie;
 use Date::Calc qw( Add_Delta_Days Add_Delta_YM Decode_Date_US This_Year );

--- a/lib/DDG/Goodie/Dessert.pm
+++ b/lib/DDG/Goodie/Dessert.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Dessert;
+# ABSTRACT: find desserts starting with a given letter.
 
 use DDG::Goodie;
 use utf8;

--- a/lib/DDG/Goodie/Dice.pm
+++ b/lib/DDG/Goodie/Dice.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Dice;
+# ABSTRACT: roll a number of (abstract) dice.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/EmToPx.pm
+++ b/lib/DDG/Goodie/EmToPx.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::EmToPx;
+# ABSTRACT: em <-> px for font sizes.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Epoch.pm
+++ b/lib/DDG/Goodie/Epoch.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Epoch;
+# ABSTRACT: UNIX epoch <-> human time
 
 use DDG::Goodie;
 use Date::Calc qw(Today_and_Now Mktime);

--- a/lib/DDG/Goodie/Factors.pm
+++ b/lib/DDG/Goodie/Factors.pm
@@ -1,7 +1,8 @@
 package DDG::Goodie::Factors;
-#Returns the factors of the entered number
+# ABSTRACT: Returns the factors of the entered number
 
 use DDG::Goodie;
+
 use Math::Prime::Util 'divisors';
 
 zci answer_type => "factors";

--- a/lib/DDG/Goodie/FedEx.pm
+++ b/lib/DDG/Goodie/FedEx.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::FedEx;
+# ABSTRACT: Track a package through FedEx
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Fibonacci.pm
+++ b/lib/DDG/Goodie/Fibonacci.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Fibonacci;
+# ABSTRACT: n-th Fibonacci number
 
 use strict;
 

--- a/lib/DDG/Goodie/FlipText.pm
+++ b/lib/DDG/Goodie/FlipText.pm
@@ -1,6 +1,8 @@
 package DDG::Goodie::FlipText;
+# ABSTRACT: appear to flip text upside down via UNICODE.
 
 use DDG::Goodie;
+
 use Text::UpsideDown;
 
 triggers startend => "flip text", "mirror text", "spin text", "rotate text";

--- a/lib/DDG/Goodie/Fortune.pm
+++ b/lib/DDG/Goodie/Fortune.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Fortune;
+# ABSTRACT: UNIX fortune quips.
 
 use DDG::Goodie;
 use Fortune;

--- a/lib/DDG/Goodie/FrequencySpectrum.pm
+++ b/lib/DDG/Goodie/FrequencySpectrum.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::FrequencySpectrum;
+# ABSTRACT: describe the nature of various wave frequencies.
 
 use strict;
 

--- a/lib/DDG/Goodie/GUID.pm
+++ b/lib/DDG/Goodie/GUID.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::GUID;
+# ABSTRACT: Generated a GUID on-demand.
 
 use DDG::Goodie;
 use Data::GUID;

--- a/lib/DDG/Goodie/GenerateMAC.pm
+++ b/lib/DDG/Goodie/GenerateMAC.pm
@@ -1,5 +1,5 @@
 package DDG::Goodie::GenerateMAC;
-#generates a random network MAC address
+# ABSTRACT: generates a random network MAC address
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/GoldenRatio.pm
+++ b/lib/DDG/Goodie/GoldenRatio.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::GoldenRatio;
+# ABSTRACT: find number related to the given number by the Golden Ratio.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/GreatestCommonFactor.pm
+++ b/lib/DDG/Goodie/GreatestCommonFactor.pm
@@ -1,5 +1,5 @@
 package DDG::Goodie::GreatestCommonFactor;
-#Returns the greatest common factor of the two numbers entered
+# ABSTRACT: Returns the greatest common factor of the two numbers entered
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/HKDK.pm
+++ b/lib/DDG/Goodie/HKDK.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::HKDK;
+# ABSTRACT: Track a package through HKDK.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/HelpLine.pm
+++ b/lib/DDG/Goodie/HelpLine.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::HelpLine;
+# ABSTRACT: Provide localized suicide intervention phone numbers.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Hijri.pm
+++ b/lib/DDG/Goodie/Hijri.pm
@@ -1,6 +1,8 @@
 package DDG::Goodie::Hijri;
+# ABSTRACT: convert between Gregorian and Hiriji calendars.
 
 use DDG::Goodie;
+
 use Date::Hijri;
 
 zci answer_type => "conversion";

--- a/lib/DDG/Goodie/IPS.pm
+++ b/lib/DDG/Goodie/IPS.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::IPS;
+# ABSTRACT: track a package through IPS.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Jira.pm
+++ b/lib/DDG/Goodie/Jira.pm
@@ -1,5 +1,5 @@
 package DDG::Goodie::Jira;
-# ABSTRACT returns the URL of an Apache or Codehaus JIRA bug ticket according to its identifier
+# ABSTRACT: returns the URL of an Apache or Codehaus JIRA bug ticket according to its identifier
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/LaserShip.pm
+++ b/lib/DDG/Goodie/LaserShip.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::LaserShip;
+# ABSTRACT: Track a package through Lasership
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/LeapYear.pm
+++ b/lib/DDG/Goodie/LeapYear.pm
@@ -1,6 +1,8 @@
 package DDG::Goodie::LeapYear;
 # ABSTRACT: Check if a year is leap year
+
 use DDG::Goodie;
+
 use Date::Leapyear;
 
 zci answer_type => "leap_year";

--- a/lib/DDG/Goodie/Lowercase.pm
+++ b/lib/DDG/Goodie/Lowercase.pm
@@ -1,9 +1,10 @@
 package DDG::Goodie::Lowercase;
+# ABSTRACT: Convert a string into lowercase.
+
 use DDG::Goodie;
 
 use HTML::Entities;
 
-# ABSTRACT: Convert a string into lowercase.
 name "Lowercase";
 description "Convert a string into lowercase.";
 primary_example_queries "lowercase GitHub";

--- a/lib/DDG/Goodie/MakeMeASandwich.pm
+++ b/lib/DDG/Goodie/MakeMeASandwich.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::MakeMeASandwich;
+# ABSTRACT: XKCD #149 Easter Egg
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/NLetterWords.pm
+++ b/lib/DDG/Goodie/NLetterWords.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::NLetterWords;
+# ABSTRACT: find words of a certain length
 
 use DDG::Goodie;
 use Lingua::EN::Numericalize;

--- a/lib/DDG/Goodie/Parcelforce.pm
+++ b/lib/DDG/Goodie/Parcelforce.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Parcelforce;
+# ABSTRACT: track a package through Parcelforce.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Password.pm
+++ b/lib/DDG/Goodie/Password.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Password;
+# ABSTRACT: Generate a random password.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/PercentError.pm
+++ b/lib/DDG/Goodie/PercentError.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::PercentError;
+# ABSTRACT: find the percent error given accepted and experimental values
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Perimeter.pm
+++ b/lib/DDG/Goodie/Perimeter.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Perimeter;
+# ABSTRACT: Compute the perimeter of basic shapes.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::PigLatin;
+# ABSTRACT: convert a given string to pig latin
 
 use DDG::Goodie;
 use Lingua::PigLatin 'piglatin';

--- a/lib/DDG/Goodie/Poker.pm
+++ b/lib/DDG/Goodie/Poker.pm
@@ -1,5 +1,5 @@
 package DDG::Goodie::Poker;
-#Returns requested statistic for the requested poker hand
+# ABSTRACT: Returns requested statistic for the requested poker hand
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -1,7 +1,8 @@
 package DDG::Goodie::PrimeFactors;
-#Returns all the prime factors of the entered number
+# ABSTRACT: Returns all the prime factors of the entered number
 
 use DDG::Goodie;
+
 use Math::Prime::Util 'factor_exp', 'is_prime';
 
 use bignum;

--- a/lib/DDG/Goodie/PrivateNetwork.pm
+++ b/lib/DDG/Goodie/PrivateNetwork.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::PrivateNetwork;
+# ABSTRACT: show non-Internet routable IP addresses.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Rafl.pm
+++ b/lib/DDG/Goodie/Rafl.pm
@@ -1,5 +1,6 @@
 package DDG::Goodie::Rafl;
 # ABSTRACT: rafl is so everywhere, there's a DuckDuckGo.com "!rafl" bang syntax
+
 use DDG::Goodie;
 
 use Acme::rafl::Everywhere;

--- a/lib/DDG/Goodie/RandomName.pm
+++ b/lib/DDG/Goodie/RandomName.pm
@@ -1,11 +1,12 @@
 package DDG::Goodie::RandomName;
 # ABSTRACT: Return random first and last name
+
 use DDG::Goodie;
+
 use Data::RandomPerson;
 
 triggers start  => 'random';
 zci answer_type => 'rand';
-
 
 name 'RandomName';
 description 'returns a random and fictive title, first- and lastname and day of birth';

--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::RandomNumber;
+# ABSTRACT: select a random number
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/RegexCheatSheet.pm
+++ b/lib/DDG/Goodie/RegexCheatSheet.pm
@@ -1,5 +1,6 @@
 package DDG::Goodie::RegexCheatSheet;
 # ABSTRACT: Provide a cheatsheet for common Regular Expression syntax
+
 use strict;
 use warnings;
 

--- a/lib/DDG/Goodie/Regexp.pm
+++ b/lib/DDG/Goodie/Regexp.pm
@@ -1,6 +1,8 @@
 package DDG::Goodie::Regexp;
+# ABSTRACT: Parse a regexp.
 
 use DDG::Goodie;
+
 use Safe;
 
 zci answer_type => "regexp";

--- a/lib/DDG/Goodie/Roman.pm
+++ b/lib/DDG/Goodie/Roman.pm
@@ -1,6 +1,8 @@
 package DDG::Goodie::Roman;
+# ABSTRACT: Convert between Roman and Arabic numeral systems.
 
 use DDG::Goodie;
+
 use Roman;
 
 primary_example_queries 'roman numeral MCCCXXXVII';

--- a/lib/DDG/Goodie/RouterPasswords.pm
+++ b/lib/DDG/Goodie/RouterPasswords.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::RouterPasswords;
+# ABSTRACT: Return default passwords forvarious routers.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/RubiksCubePatterns.pm
+++ b/lib/DDG/Goodie/RubiksCubePatterns.pm
@@ -1,8 +1,8 @@
 package DDG::Goodie::RubiksCubePatterns;
+# ABSTRACT: Create interesting patterns from a solved Rubik's Cube.
 
 use DDG::Goodie;
 
-# Create interesting patterns from a solved Rubik's Cube.
 
 primary_example_queries 'rcube stripes';
 secondary_example_queries 'rcube cube in a cube', 'rcube swap centers';

--- a/lib/DDG/Goodie/Sha.pm
+++ b/lib/DDG/Goodie/Sha.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Sha;
+# ABSTRACT: Compute a SHA sum for a provided string.
 
 use DDG::Goodie;
 use Digest::SHA;

--- a/lib/DDG/Goodie/SigFigs.pm
+++ b/lib/DDG/Goodie/SigFigs.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::SigFigs;
+# ABSTRACT: Count the significant figures in a number.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/SubnetCalc.pm
+++ b/lib/DDG/Goodie/SubnetCalc.pm
@@ -1,6 +1,7 @@
 #!/bin/env perl
 package DDG::Goodie::SubnetCalc;
 # ABSTRACT: Calculate IP ranges & Subnet Information from a host & CIDR or netmask 
+
 use strict;
 use warnings;
 

--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::TimezoneConverter;
+# ABSTRACT: Convert times between timezones.
 
 use 5.010;
 use strict;

--- a/lib/DDG/Goodie/Tips.pm
+++ b/lib/DDG/Goodie/Tips.pm
@@ -1,4 +1,6 @@
 package DDG::Goodie::Tips;
+# ABSTRACT: calculate a tip on a bill
+
 use DDG::Goodie;
 
 triggers any => 'tip', 'tips', '%';

--- a/lib/DDG/Goodie/TitleCase.pm
+++ b/lib/DDG/Goodie/TitleCase.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::TitleCase;
+# ABSTRACT: Convert a string to title case.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/UPS.pm
+++ b/lib/DDG/Goodie/UPS.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::UPS;
+# ABSTRACT: Track a package through United Parcel Service.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/USPS.pm
+++ b/lib/DDG/Goodie/USPS.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::USPS;
+# ABSTRACT: Track a package through the US postal service.
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Unicode.pm
+++ b/lib/DDG/Goodie/Unicode.pm
@@ -1,6 +1,8 @@
 package DDG::Goodie::Unicode;
+# ABSTRACT: unicode character information lookup
 
 use DDG::Goodie;
+
 use Unicode::UCD qw/charinfo/;
 use Unicode::Char ();              # For name -> codepoint lookup
 use Encode qw/encode_utf8/;

--- a/lib/DDG/Goodie/UnixPermissions.pm
+++ b/lib/DDG/Goodie/UnixPermissions.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::UnixPermissions;
+# ABSTRACT: describe UNIX file mode permissions
 
 use strict;
 

--- a/lib/DDG/Goodie/UnixTime.pm
+++ b/lib/DDG/Goodie/UnixTime.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::UnixTime;
+# ABSTRACT: epoch -> human readable time
 
 use DDG::Goodie;
 use DateTime;

--- a/lib/DDG/Goodie/Uppercase.pm
+++ b/lib/DDG/Goodie/Uppercase.pm
@@ -1,4 +1,6 @@
 package DDG::Goodie::Uppercase;
+# ABSTRACT: uppercase a provided string.
+
 use DDG::Goodie;
 
 use HTML::Entities;

--- a/lib/DDG/Goodie/VIN.pm
+++ b/lib/DDG/Goodie/VIN.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::VIN;
+# ABSTRACT: extract information about vehicle identification numbers
 
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Xor.pm
+++ b/lib/DDG/Goodie/Xor.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::Xor;
+# ABSTRACT: bitwise XOR two numbers.
 
 use DDG::Goodie;
 use utf8;

--- a/lib/DDG/Goodie/ZappBrannigan.pm
+++ b/lib/DDG/Goodie/ZappBrannigan.pm
@@ -1,4 +1,5 @@
 package DDG::Goodie::ZappBrannigan;
+# ABSTRACT: Zapp Brannigan quotes.
 
 use DDG::Goodie;
 

--- a/lib/DDG/GoodieRole/NumberStyle.pm
+++ b/lib/DDG/GoodieRole/NumberStyle.pm
@@ -1,4 +1,5 @@
 package DDG::GoodieRole::NumberStyle;
+# ABSTRACT: An object representing a particular numerical notation.
 
 use strict;
 use warnings;

--- a/lib/DDG/GoodieRole/NumberStyler.pm
+++ b/lib/DDG/GoodieRole/NumberStyler.pm
@@ -1,4 +1,5 @@
 package DDG::GoodieRole::NumberStyler;
+# ABSTRACT: A role to allow Goodies to recognize and work with numbers in different notations.
 
 use strict;
 use warnings;


### PR DESCRIPTION
Reducing scroll spam from dzil by:
- Providing ABSTRACTs for all packages.
- Leaving VERSION vertical space where necessary.

Addresses #600 plus other annoyances in the process.
