### PR TITLE
dist.ini: bump Math::Prime::Util version

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -56,7 +56,7 @@ Lingua::EN::Numbers::Ordinate = 1.02
 Digest::SHA = 5.82
 Digest::MD5 = 2.53
 ; Factors
-Math::Prime::Util = 0.34
+Math::Prime::Util = 0.43
 Games::Sudoku::Component = 0.02
 Data::RandomPerson = 0.4
 URI::Escape = 3.31


### PR DESCRIPTION
The change to `divisors` in #599 is not present in older versions of
MPU. Previous installaions might not be upgraded if this is not bumped.

`0.43` is known working.
