### PR TITLE
DatesRole: support standard output of date(1).

### DIFF
--- a/lib/DDG/GoodieRole/Dates.pm
+++ b/lib/DDG/GoodieRole/Dates.pm
@@ -303,6 +303,9 @@ sub build_datestring_regex {
     # RFC850 08-Feb-94 14:15:29 GMT
     push @regexes, qr#[0-9]{2}-$short_month-(?:[0-9]{2}|[0-9]{4}) $time_24h?(?: ?$tz_suffixes)#i;
 
+    # RFC2822 Sat, 13 Mar 2010 11:29:05 -0800
+    push @regexes, qr#$short_day_of_week, $date_number $short_month [0-9]{4} $time_24h $tz_suffixes#i;
+
     # date(1) default format Sun Sep  7 15:57:56 EDT 2014
     push @regexes, $date_standard;
 

--- a/t/00-roles.t
+++ b/t/00-roles.t
@@ -90,6 +90,8 @@ subtest 'Dates' => sub {
             'Sun Sep  7 15:57:56 EDT 2014' => 1410119876,
             'Sun Sep 14 15:57:56 UTC 2014' => 1410710276,
             'Sun Sep 7 20:11:44 BST 2014'  => 1410117104,
+            # RFC 2822
+            'Sat, 13 Mar 2010 11:29:05 -0800' => 1268508545,
             #Undefined/Natural formats:
             '13/12/2011'        => 1323734400,     #DMY
             '01/01/2001'        => 978307200,      #Ambiguous, but valid


### PR DESCRIPTION
- Convert to ISO-8601 for the parse.
- Support short month to number in service of above.
- Support TZ to UTC offset in service of above.

In cases where the TZ abbreviation was ambiguous I selected what I
deemed to be the most populous or most likely to be a DDG user's intent.
I may, of course, be wrong.

Fixes #621.
