### PR TITLE
Example template: minor copy fixes.

### DIFF
--- a/template/lib/DDG/Goodie/Example.pm
+++ b/template/lib/DDG/Goodie/Example.pm
@@ -1,6 +1,6 @@
 package DDG::Goodie::<: $ia_name :>;
-# ABSTRACT: Write and abstract here
-# Start at https://dukgo.com/duckduckhack/goodie_overview if you are new
+# ABSTRACT: Write an abstract here
+# Start at https://duck.co/duckduckhack/goodie_overview if you are new
 # to instant answer development
 
 use DDG::Goodie;


### PR DESCRIPTION
- 'Write and abstract' -> 'Write an abstract'
- 'dukgo.com' -> 'duck.co'
