### PR TITLE
templates: update to include basic ZCI attributes.

### DIFF
--- a/template/lib/DDG/Goodie/Example.pm
+++ b/template/lib/DDG/Goodie/Example.pm
@@ -5,6 +5,9 @@ package DDG::Goodie::<: $ia_name :>;
 
 use DDG::Goodie;
 
+zci answer_type => "<: $lia_name :>";
+zci is_cached   => 1;
+
 #Attribution
 primary_example_queries "first example query", "second example query";
 secondary_example_queries "optional -- demonstrate any additional triggers";

--- a/template/t/Example.t
+++ b/template/t/Example.t
@@ -5,6 +5,9 @@ use warnings;
 use Test::More;
 use DDG::Test::Goodie;
 
+zci answer_type => "<: $lia_name :>";
+zci is_cached   => 1;
+
 ddg_goodie_test(
 	[qw(
 		DDG::Goodie::<: $ia_name :>


### PR DESCRIPTION
There will likely be some debate about whether or not to include the
`is_cached` value, but I like making it explicit even when there is
a default.

On the `answer_type`, the tests as produced by `duckpan new` could
not pass. It might not be entirely clear to the new developer how to
add the `answer_type` and fix them.
