### PR TITLE
HexToDec: tighten up trigger to hex number only.

### DIFF
--- a/lib/DDG/Goodie/HexToDec.pm
+++ b/lib/DDG/Goodie/HexToDec.pm
@@ -6,7 +6,7 @@ use Math::BigInt;
 
 triggers query_raw => qr/^\s*0x[0-9a-fA-F]+\s*$/;
 
-zci answer_type => 'conversion';
+zci answer_type => 'hex_to_dec';
 zci is_cached   => 1;
 
 primary_example_queries '0x44696f21';

--- a/t/HexToDec.t
+++ b/t/HexToDec.t
@@ -5,7 +5,7 @@ use warnings;
 use Test::More;
 use DDG::Test::Goodie;
 
-zci answer_type => 'conversion';
+zci answer_type => 'hex_to_dec';
 zci is_cached   => 1;
 
 ddg_goodie_test(


### PR DESCRIPTION
This was interfering with the HexToASCII goodie.  We will assume that
with other context they may want something besides the conversion.
