### PR TITLE
DuckDuckGo: hidden service updates.

### DIFF
--- a/lib/DDG/Goodie/DuckDuckGo.pm
+++ b/lib/DDG/Goodie/DuckDuckGo.pm
@@ -55,7 +55,7 @@ foreach my $keyword (keys %$responses) {
     }
 }
 
-my $skip_words_re = qr/\b(?:what|where|is|of|for|the)\b/;
+my $skip_words_re = qr/\b(?:what|where|is|of|for|the|in|on)\b/;
 
 handle remainder => sub {
     my $key = lc;

--- a/share/goodie/duck_duck_go/responses.yml
+++ b/share/goodie/duck_duck_go/responses.yml
@@ -148,8 +148,10 @@ syntax:
 tor:
   aliases:
     - hiddenservice
+    - onion
+    - onionservice
     - torhiddenservice
-  base_format: "DuckDuckGo's [Tor hidden service]"
+  base_format: "DuckDuckGo's [service on Tor]"
   info_url: http://3g2upl4pq6kufc4m.onion
 traffic:
   base_format: "DuckDuckGo's [traffic page]"

--- a/t/DuckDuckGo.t
+++ b/t/DuckDuckGo.t
@@ -11,8 +11,8 @@ zci is_cached   => 1;
 # The results should be static, so these facilitate easier testing of triggers.
 my @about_result =
   ("DuckDuckGo's about page: https://duckduckgo.com/about", html => "DuckDuckGo's <a href='https://duckduckgo.com/about'>about page</a>.");
-my @blog_result = ("DuckDuckGo's official blog: https://duck.co/blog", html => "DuckDuckGo's <a href='https://duck.co/blog'>official blog</a>."),
-  my @help_result =
+my @blog_result = ("DuckDuckGo's official blog: https://duck.co/blog", html => "DuckDuckGo's <a href='https://duck.co/blog'>official blog</a>.");
+my @help_result =
   ("Need help? Visit our help page: http://dukgo.com/help/", html => "Need help? Visit our <a href='http://dukgo.com/help/'>help page</a>.");
 my @irc_result = (
     "DuckDuckGo's official IRC channel is #duckduckgo on irc.freenode.net.",
@@ -24,6 +24,8 @@ my @merch_result = (
     html =>
       "Thanks for the support! Check out the <a href='https://duck.co/help/community/swag'>DuckDuckGo store</a> for t-shirts, stickers, and other items."
 );
+my @tor_result =
+  ("DuckDuckGo's service on Tor: http://3g2upl4pq6kufc4m.onion", html => "DuckDuckGo's <a href='http://3g2upl4pq6kufc4m.onion'>service on Tor</a>.");
 my @shorturl_result = ("DuckDuckGo's short URL: http://ddg.gg/", html => "DuckDuckGo's short URL: <a href='http://ddg.gg/'>http://ddg.gg/</a>.");
 my @zci_result = (
     "Zero Click Info is the term DuckDuckGo uses for these boxes, which often provide useful instant answers above traditional results.",
@@ -50,6 +52,10 @@ ddg_goodie_test([qw(
     "duck duckgos help"                     => test_zci(@help_result),
     "where is the ddg irc"                  => test_zci(@irc_result),
     'what is the short url for duckduckgo?' => test_zci(@shorturl_result),
+    "ddg on onion"                          => test_zci(@tor_result),
+    "tor on duck duck go"                   => test_zci(@tor_result),
+    "duckduckgo onion service"              => test_zci(@tor_result),
+    "ddg in tor"                            => test_zci(@tor_result),
     irc                                     => undef,
 );
 


### PR DESCRIPTION
- Play down its status as a "hidden service", since we widely
  adverterise the availability of such.
- Add more 'onion'-y keys.
