### PR TITLE
Example.pm template: freshener updates

### DIFF
--- a/template/lib/DDG/Goodie/Example.pm
+++ b/template/lib/DDG/Goodie/Example.pm
@@ -8,18 +8,16 @@ use DDG::Goodie;
 zci answer_type => "<: $lia_name :>";
 zci is_cached   => 1;
 
-#Attribution
+# Metadata.  See https://duck.co/duckduckhack/metadata for help in filling out this section.
+name "<: $ia_name :>";
+description "Succinct explanation of what this instant answer does";
 primary_example_queries "first example query", "second example query";
 secondary_example_queries "optional -- demonstrate any additional triggers";
-description "Succinct explanation of what this instant answer does";
-name "<: $ia_name :>";
-icon_url "";
-source "";
-code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/<: $ia_name :>.pm";
 category "";
 topics "";
-attribution github => ["https://github.com/", ""],
-            twitter => ["https://twitter.com/", ""];
+code_url "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Spice/<: $ia_name :>.pm";
+attribution github => ["GitHubAccount", "Friendly Name"],
+            twitter => "twitterhandle",
 
 # Triggers
 triggers any => "triggerWord", "trigger phrase";
@@ -30,8 +28,9 @@ handle remainder => sub {
 	# optional - regex guard
 	# return unless qr/^\w+/;
 
-	return $_ if $_;
-	return;
+	return unless $_; # Guard against "no answer"
+
+	return $_;
 };
 
 1;


### PR DESCRIPTION
- Point to metadata docs to help fill out section.
- Reorganize metadata into same order as docs.
- Remove "icon_url" and "source" which do not generally apply to
  Goodies.
- Better example strings for the `attribution` section.
- Use "guard" before "work" in example code.

If and when this is vetted and merged, I will make similar updates to the Spice repository (including the previous explicit caching changes.)
