### PR TITLE
CalendarToday: tighten up query triggers a bit.

### DIFF
--- a/lib/DDG/Goodie/CalendarToday.pm
+++ b/lib/DDG/Goodie/CalendarToday.pm
@@ -28,16 +28,20 @@ triggers startend => 'calendar', 'cal';
 # define variables
 my @weekDays = ("S", "M", "T", "W", "T", "F", "S");
 
-my $datestring_regex  = datestring_regex();
+my $filler_words_regex         = qr/(?:\b(?:on|of|for|the|a)\b)/;
+my $datestring_regex           = datestring_regex();
 my $formatted_datestring_regex = formatted_datestring_regex();
 
 handle remainder => sub {
     my $query       = $_;
     my $date_object = DateTime->now;
     my ($currentDay, $currentMonth, $currentYear) = ($date_object->day(), $date_object->month(), $date_object->year());
-    my $highlightDay = 0;    # Initialized, but won't match, by default.
+    my $highlightDay = 0;                  # Initialized, but won't match, by default.
+    $query =~ s/$filler_words_regex//g;    # Remove filler words.
+    $query =~ s/\s{2,}/ /g;                # Tighten up any extra spaces we may have left.
+    $query =~ s/^\s+|\s+$//g;              # Trim outside spaces.
     if ($query) {
-        my ($date_string) = $query =~ qr#($datestring_regex)#i;    # Extract any datestring from the query.
+        my ($date_string) = $query =~ qr#^($datestring_regex)$#i;    # Extract any datestring from the query.
 
         $date_object = parse_datestring_to_date($date_string);
 
@@ -53,7 +57,7 @@ handle remainder => sub {
     my $start = parse_datestring_to_date($the_year . "-" . $the_month . "-1");
     return format_result({
             first_day     => $start,
-            first_day_num => $start->day_of_week() % 7, # 0=Sunday
+            first_day_num => $start->day_of_week() % 7,                                    # 0=Sunday
             last_day      => DateTime->last_day_of_month(
                 year  => $the_year,
                 month => $the_month,

--- a/lib/DDG/GoodieRole/Dates.pm
+++ b/lib/DDG/GoodieRole/Dates.pm
@@ -338,7 +338,7 @@ sub parse_datestring_to_date {
 sub parse_formatted_datestring_to_date {
     my ($d) = @_;
 
-    return unless ($d =~ qr/^$formatted_datestring$/);    # Only handle white-listed strings, even if they might otherwise work.
+    return unless ($d && $d =~ qr/^$formatted_datestring$/);    # Only handle white-listed strings, even if they might otherwise work.
     if ($d =~ $ambiguous_dates_matches) {
         # guesswork for ambigous DMY/MDY and switch to ISO
         my ($month, $day, $year) = ($+{'m'}, $+{'d'}, $+{'y'});    # Assume MDY, even though it's crazy, for backward compatibility
@@ -394,7 +394,7 @@ sub parse_all_datestrings_to_date {
 sub parse_descriptive_datestring_to_date {
     my ($string) = @_;
 
-    return unless ($string =~ qr/^$descriptive_datestring_matches$/);
+    return unless ($string && $string =~ qr/^$descriptive_datestring_matches$/);
 
     my $now = DateTime->now();
     my $month = $+{'m'}; # Set in each alternative match.

--- a/t/CalendarToday.t
+++ b/t/CalendarToday.t
@@ -58,7 +58,26 @@ S M T W T F S      November 1980
  23  24  25  26  27  28 |29|
  30 
 ", html => qr#<table class="calendar"><tr><th class="calendar__header" colspan="7"><b>November 1980</b></th></tr><tr><th>S</th><th>M</th><th>T</th><th>W</th><th>T</th><th>F</th><th>S</th></tr><tr><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>1</td></tr><tr><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td><td>8</td></tr><tr><td>9</td><td>10</td><td>11</td><td>12</td><td>13</td><td>14</td><td>15</td></tr><tr><td>16</td><td>17</td><td>18</td><td>19</td><td>20</td><td>21</td><td>22</td></tr><tr><td>23</td><td>24</td><td>25</td><td>26</td><td>27</td><td>28</td><td><span class="calendar__today circle">29</span></td></tr><tr><td>30</td></tr></table>#),
-);
+    'calendar for november 2009' => test_zci("
+S M T W T F S      November 2009
+  1   2   3   4   5   6   7 
+  8   9  10  11  12  13  14 
+ 15  16  17  18  19  20  21 
+ 22  23  24  25  26  27  28 
+ 29  30 
+", html => qr#<table class="calendar"><tr><th class="calendar__header" colspan="7"><b>November 2009</b></th></tr><tr><th>S</th><th>M</th><th>T</th><th>W</th><th>T</th><th>F</th><th>S</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td></tr><tr><td>8</td><td>9</td><td>10</td><td>11</td><td>12</td><td>13</td><td>14</td></tr><tr><td>15</td><td>16</td><td>17</td><td>18</td><td>19</td><td>20</td><td>21</td></tr><tr><td>22</td><td>23</td><td>24</td><td>25</td><td>26</td><td>27</td><td>28</td></tr><tr><td>29</td><td>30</td></tr></table>#),
+'next november on a calendar' => test_zci(qr/\nS M T W T F S      November [0-9]{4}\n.+/, html => qr#<table class="calendar".+</table>#),
+  'calendar for november'     => test_zci(qr/\nS M T W T F S      November [0-9]{4}\n.+/, html => qr#<table class="calendar".+</table>#),
+  'calendar of november 2009' => test_zci("
+S M T W T F S      November 2009
+  1   2   3   4   5   6   7 
+  8   9  10  11  12  13  14 
+ 15  16  17  18  19  20  21 
+ 22  23  24  25  26  27  28 
+ 29  30 
+", html => qr#<table class="calendar"><tr><th class="calendar__header" colspan="7"><b>November 2009</b></th></tr><tr><th>S</th><th>M</th><th>T</th><th>W</th><th>T</th><th>F</th><th>S</th></tr><tr><td>1</td><td>2</td><td>3</td><td>4</td><td>5</td><td>6</td><td>7</td></tr><tr><td>8</td><td>9</td><td>10</td><td>11</td><td>12</td><td>13</td><td>14</td></tr><tr><td>15</td><td>16</td><td>17</td><td>18</td><td>19</td><td>20</td><td>21</td></tr><tr><td>22</td><td>23</td><td>24</td><td>25</td><td>26</td><td>27</td><td>28</td></tr><tr><td>29</td><td>30</td></tr></table>#),
+'22/8/2003 to the hijri calendar' => undef,
+  );
 
 done_testing;
 


### PR DESCRIPTION
- Add filler_words list which can be stripped from the query before
  trying to parse date strings.
- Anchor datestring_regex so as to allow for only date left in query
  after clean-up.
- Improve guard against empty strings and `undef` in Dates role parsers.

Fixes #661.
