### PR TITLE
HelpLine.t: do not construct a test plan.

### DIFF
--- a/t/HelpLine.t
+++ b/t/HelpLine.t
@@ -63,7 +63,4 @@ ddg_goodie_test(
     } 0 .. scalar @ok_queries - 1),
 );
 
-done_testing(
-    (scalar @queries * scalar @locations * 2) +
-    (scalar @ok_queries * scalar @locations)
-);
+done_testing;


### PR DESCRIPTION
We're not actually getting a test count from test_zci. Someday soon this
will reconcile exactly with the number of `test_zci` calls you make, but
it clearly does not today (see the extra 2 factor).

Rather than try to predict which version is running these tests, remove
the plan for now.
