### PR TITLE
NumberStyle: do not automatically convert numbers with_html.

### DIFF
--- a/lib/DDG/Goodie/Calculator.pm
+++ b/lib/DDG/Goodie/Calculator.pm
@@ -161,11 +161,11 @@ sub prepare_for_display {
 sub format_html {
     my ($query, $result, $style) = @_;
 
-    $query  = $style->with_html($query);
-    $result = $style->with_html($result);
+    $query  = spacing($style->with_html($query));
+    $result = $style->with_html($style->for_display($result));
 
     return "<div class='zci--calculator text--primary'>"
-      . spacing($query)
+      . $query
       . "<span class='text--secondary'> = </span><a href='javascript:;' onclick='document.x.q.value=\"$result\";document.x.q.focus();' class='text--primary'>"
       . $result
       . "</a></div>";

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -61,7 +61,7 @@ my %plural_exceptions = (
 sub wrap_html {
     my ($factor, $result, $styler) = @_;
     my $from = $styler->with_html($factor) . " <span class='text--secondary'>" . html_enc($result->{'from_unit'}) . "</span>";
-    my $to = $styler->with_html($result->{'result'}) . " <span class='text--secondary'>" . html_enc($result->{'to_unit'}) . "</span>";
+    my $to = $styler->with_html($styler->for_display($result->{'result'})) . " <span class='text--secondary'>" . html_enc($result->{'to_unit'}) . "</span>";
     return "<div class='zci--conversions text--primary'>$from = $to</div>";
 }
 

--- a/lib/DDG/GoodieRole/NumberStyle.pm
+++ b/lib/DDG/GoodieRole/NumberStyle.pm
@@ -95,7 +95,7 @@ sub for_display {
 sub with_html {
     my ($self, $number_text) = @_;
 
-    return $self->_add_html_exponents($self->for_display($number_text));
+    return $self->_add_html_exponents($number_text);
 }
 
 sub _add_html_exponents {


### PR DESCRIPTION
In some cases, we have numbers which are _already_ in the appropriate
style. Most notably, when considering the user input values from which we
made the style determinations in the first place.

This fixes the bug, but is still unsatisfying because we would need
to convert both in and out in order to do better input styling.
