### PR TITLE
CallingCodes: adjust trigger-space.

### DIFF
--- a/lib/DDG/Goodie/CallingCodes.pm
+++ b/lib/DDG/Goodie/CallingCodes.pm
@@ -15,30 +15,27 @@ code_url    "https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/D
 category    "geography";
 topics      "travel", "geography";
 
-primary_example_queries   "country code 55", "country code brazil";
+primary_example_queries   "calling code 55", "dialing code brazil";
 secondary_example_queries "dialing code +55", "country calling code 55";
 
 attribution github  => ["kablamo",            "Eric Johnson"],
             web     => ["http://kablamo.org", "Eric Johnson"];
 
-triggers any => 
-    "calling code",
-    "calling codes",
-    "country calling code", 
-    "country calling codes", 
-    "country code", 
-    "country dialing code", 
-    "country dialing codes", 
-    "dial in code",
-    "dial in codes",
-    "dialing code", 
-    "dialing codes", 
-    "international calling code", 
-    "international calling codes", 
-    "international dial in code",
-    "international dial in codes",
-    "international dialing code",
-    "international dialing codes"; 
+my @codewords   = qw(code codes);
+my @descriptors = ('calling', 'dialing', 'dial-in', 'dial in');
+my @extras      = qw(international country);
+
+my @triggers;
+foreach my $cw (@codewords) {
+    foreach my $desc (@descriptors) {
+        push @triggers, $desc . ' ' . $cw;
+        foreach my $extra (@extras) {
+            push @triggers, join(' ', $extra, $desc, $cw);
+        }
+    }
+}
+
+triggers any => @triggers;
 
 Locale::Country::rename_country('ae' => 'the United Arab Emirates');
 Locale::Country::rename_country('do' => 'the Dominican Republic');

--- a/t/CallingCodes.t
+++ b/t/CallingCodes.t
@@ -13,16 +13,19 @@ my $txt = "is the international calling code for";
 
 ddg_goodie_test(
         [qw( DDG::Goodie::CallingCodes )],
+        # Example queries
+        "calling code 55"         => test_zci("+55 $txt Brazil."),
+        "dialing code brazil"     => test_zci("+55 $txt Brazil."),
+        "dialing code +55"        => test_zci("+55 $txt Brazil."),
+        "country calling code 55" => test_zci("+55 $txt Brazil."),
+        # Other working queries.
         "calling code for the moon"   => undef,
         "calling code +3boop"         => undef,
         "calling code for the sudan"  => test_zci("+249 $txt Sudan."),
         "calling code for vatican"    => test_zci("+379 $txt the Holy See (Vatican City State)."),
         "379 calling code vatican"    => test_zci("+379 $txt the Holy See (Vatican City State)."),
         "vatican calling code 379"    => test_zci("+379 $txt the Holy See (Vatican City State)."),
-        "calling code 55"             => test_zci("+55 $txt Brazil."),
-        "country code brazil"         => test_zci("+55 $txt Brazil."),
-        "dialing code +55"            => test_zci("+55 $txt Brazil."),
-        "country calling code 55"     => test_zci("+55 $txt Brazil."),
+        "international calling code brazil"         => test_zci("+55 $txt Brazil."),
         "calling code 55 Brazil"      => test_zci("+55 $txt Brazil."),
         "calling code for Brazil +55" => test_zci("+55 $txt Brazil."),
         "calling code +55 for Brazil" => test_zci("+55 $txt Brazil."),
@@ -31,9 +34,9 @@ ddg_goodie_test(
         "calling code 65"             => test_zci("+65 $txt Singapore."),
         "calling code +65"            => test_zci("+65 $txt Singapore."),
         "dialing code +65"            => test_zci("+65 $txt Singapore."),
-        "country code +65"            => test_zci("+65 $txt Singapore."),
-        "country code for Singapore"  => test_zci("+65 $txt Singapore."),
-        "country code for Singapore"  => test_zci("+65 $txt Singapore."),
+        "dial-in code +65"            => test_zci("+65 $txt Singapore."),
+        "calling code for Singapore"  => test_zci("+65 $txt Singapore."),
+        "international dial-in codes for Singapore"  => test_zci("+65 $txt Singapore."),
         "dialing code Singapore"      => test_zci("+65 $txt Singapore."),
         "dialing code for Singapore"  => test_zci("+65 $txt Singapore."),
         "dialing code for UK"         => test_zci("+44 $txt the United Kingdom."),
@@ -46,7 +49,7 @@ ddg_goodie_test(
         "calling code for tobago"     => test_zci("+1 $txt Trinidad and Tobago."),
         "dialing code for US"         => test_zci("+1 $txt the United States."),
         "calling code for america"    => test_zci("+1 $txt the United States."),
-        "country code +1"             => test_zci("+1 $txt Antigua and Barbuda, Anguilla, American Samoa, Barbados, Bermuda, the Bahamas, Canada, Dominica, the Dominican Republic, Grenada, Guam, Jamaica, Saint Lucia, Saint Kitts and Nevis, the Cayman Islands, the Northern Mariana Islands, Montserrat, Puerto Rico, Turks and Caicos Islands, Trinidad and Tobago, the United States, Saint Vincent and the Grenadines, the British Virgin Islands, and the US Virgin Islands."),
+        "calling code +1"             => test_zci("+1 $txt Antigua and Barbuda, Anguilla, American Samoa, Barbados, Bermuda, the Bahamas, Canada, Dominica, the Dominican Republic, Grenada, Guam, Jamaica, Saint Lucia, Saint Kitts and Nevis, the Cayman Islands, the Northern Mariana Islands, Montserrat, Puerto Rico, Turks and Caicos Islands, Trinidad and Tobago, the United States, Saint Vincent and the Grenadines, the British Virgin Islands, and the US Virgin Islands."),
         "calling code +7"             => test_zci("+7 $txt the Russian Federation and Kazakhstan."),
         "calling code for russia"     => test_zci("+7 $txt the Russian Federation."),
         "dial in code to the Russian Federation" => test_zci("+7 $txt the Russian Federation."),
@@ -54,6 +57,10 @@ ddg_goodie_test(
         "calling code for the republic of korea" => test_zci("+82 $txt the Republic of Korea."),
         "calling code for north korea"           => test_zci("+850 $txt the Democratic People's Republic of Korea."),
         "calling code for the democratic people's republic of korea" => test_zci("+850 $txt the Democratic People's Republic of Korea."),
+        # Properly negative
+        'country code for the netherlands' => undef,
+        'country code for north korea'     => undef,
+        'country code +850'                => undef,
 );
 
 done_testing;


### PR DESCRIPTION
- Remove 'country code'/'country codes'
- Add 'dial-in' as alternative for 'dial in'
- Add more combinations of the various words

Fixes #682...in part.
