### PR TITLE
Tips: use as more general percentage calculator.

### DIFF
--- a/lib/DDG/Goodie/Tips.pm
+++ b/lib/DDG/Goodie/Tips.pm
@@ -2,8 +2,10 @@ package DDG::Goodie::Tips;
 # ABSTRACT: calculate a tip on a bill
 
 use DDG::Goodie;
+with 'DDG::GoodieRole::NumberStyler';
 
-triggers any => 'tip', 'tips', '%';
+# Yes, 'of' is very generic, the gaurd should kick back false positives very quickly.
+triggers any => 'tip', 'tips', 'of';
 
 primary_example_queries '20% tip on $21.63';
 secondary_example_queries '20 percent tip for a $20 bill';
@@ -17,25 +19,20 @@ attribution github => [ 'http://github.com/mattlehning', 'mattlehning' ];
 zci answer_type => 'tip';
 zci is_cached   => 1;
 
+my $number_re = number_style_regex();
+
 handle query_lc => sub {
-    return unless my ($p, $is_tip, $sign,$num) = $_ =~/^(\d{1,3})(?: ?%| percent) (?:(tip (?:on|for|of))|of)(?: an?)? ([\$\-]?)(\d+(\.?)(?(5)\d+))(?: bill)?$/;
-    $p /= 100;
-    my $t = $p*$num;
-    my $tot;
+    return unless (/^(?<p>$number_re)(?: ?%| percent) (?:(?<do_tip>tip (?:on|for|of))|of)(?: an?)? (?<sign>[\$\-]?)(?<num>$number_re)(?: bill)?$/);
+    my ($p, $num, $sign) = ($+{'p'}, $+{'num'}, $+{'sign'});
+    my $style = number_style_for($p, $num);
+    $p   = $style->for_computation($p) / 100;
+    $num = $style->for_computation($num);
+    my $t = $p * $num;
 
-    if ($is_tip) {
-	$tot = $num + $t;
-    }
+    return 'Tip: $' . $style->for_display(sprintf "%.2f", $t) . '; Total: $' . $style->for_display(sprintf "%.2f", $num + $t) if ($+{'do_tip'});
 
-    $t = sprintf "%.2f", $t;
-    $tot = sprintf "%.2f", $tot if $tot;
-
-    if ($tot) {
-	return "Tip: \$$t; Total: \$$tot";
-    }
-    $t = $sign . $t;
-    $tot = $sign . $tot if $tot;
-    return "$t is ".($p*100)." percent of $sign$num";
+    $t = sprintf "%.2f", $t if ($sign eq '$');    # Maybe this makes cents.
+    return $sign . $style->for_display($t) . ' is ' . $style->for_display($p * 100) . ' percent of ' . $sign . $style->for_display($num);
 };
 
 1;

--- a/t/Tips.t
+++ b/t/Tips.t
@@ -9,15 +9,20 @@ zci answer_type => 'tip';
 zci is_cached   => 1;
 
 ddg_goodie_test(
-        [qw(
-                DDG::Goodie::Tips
-        )],
-        '20% tip on $20' => test_zci('Tip: $4.00; Total: $24.00'),
-        '20% tip on $20 bill' => test_zci('Tip: $4.00; Total: $24.00'),
-        '20% tip for a $20 bill' => test_zci('Tip: $4.00; Total: $24.00'),
-        '20 percent tip on $20' => test_zci('Tip: $4.00; Total: $24.00'),
-        '20% tip on $21.63' => test_zci('Tip: $4.33; Total: $25.96'),
-        '20 percent tip for a $20 bill' => test_zci('Tip: $4.00; Total: $24.00'),
+    [qw( DDG::Goodie::Tips)],
+    '20% tip on $20'                  => test_zci('Tip: $4.00; Total: $24.00'),
+    '20% tip on $20 bill'             => test_zci('Tip: $4.00; Total: $24.00'),
+    '20% tip for a $20 bill'          => test_zci('Tip: $4.00; Total: $24.00'),
+    '20 percent tip on $20'           => test_zci('Tip: $4.00; Total: $24.00'),
+    '20% tip on $21.63'               => test_zci('Tip: $4.33; Total: $25.96'),
+    '20 percent tip for a $20 bill'   => test_zci('Tip: $4.00; Total: $24.00'),
+    '20 percent tip for a $2000 bill' => test_zci('Tip: $400.00; Total: $2,400.00'),
+    '25 percent of 20000'             => test_zci('5,000 is 25 percent of 20,000'),
+    '2% of 25,000'                    => test_zci('500 is 2 percent of 25,000'),
+    '2% of $25,000'                   => test_zci('$500.00 is 2 percent of $25,000'),
+    '2,000% of -2'                    => test_zci('-40 is 2,000 percent of -2'),
+    'best of 5'                       => undef,
+    '4 of 5 dentists'                 => undef,
 );
 
 done_testing;


### PR DESCRIPTION
The guts were already here, just made them all work properly.
- Greatly expand triggering and allow guard to kick back false
  positives
- Use NumberStyler to handle and "make pretty" a variety of number
  formats
- Use named captures to make things easier to follow.

Fixes #690.
