### PR TITLE
Conversions: Upgrading to 0.24 to support areas and volumes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -40,7 +40,7 @@ Gravatar::URL = 1.06
 CGI = 3.60
 Email::Valid = 1.192
 Net::Domain::TLD = 1.70
-Convert::Pluggable = 0.022
+Convert::Pluggable = 0.024
 YAML = 0
 Encode = 2.62
 ; ParseCron

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -93,6 +93,8 @@ ddg_goodie_test(
     '5 inches in meters' => test_zci('5 inches = 0.127 meters', html => qr /.*/),
     '5 inches in 5 meters' => undef,
     'convert 1 cm to 2 mm' => undef,
+    '100 square metres in hectares' => test_zci('100 square meters = 0.010 hectares', html => qr/.*/),
+    '1 imperial gallon in litres' => test_zci('1 imperial gallon = 4.546 litres', html => qr/.*/)
 );
 
 done_testing;


### PR DESCRIPTION
Tests just prove that CVP supports the new units; conversion factors etc are tested in CVP itself.

Fixes: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/611
