### PR TITLE
Add hex/base64 formatting option to md5 goodie

### DIFF
--- a/lib/DDG/Goodie/MD5.pm
+++ b/lib/DDG/Goodie/MD5.pm
@@ -39,19 +39,18 @@ handle remainder => sub {
     s/^hash\s+(.*\S+)/$1/; # Remove 'hash' in queries like 'md5 hash this'
     s/^of\s+(.*\S+)/$1/; # Remove 'of' in queries like 'md5 hash of this'
     s/^"(.*)"$/$1/; # Remove quotes
-    if (/^\s*(.*\S+)/) {
-        # The string is encoded to get the utf8 representation instead of
-        # perls internal representation of strings, before it's passed to
-        # the md5 subroutine.
-        my $str = encode("utf8",$1);
-        my $md5;
-        #use approprite output format, default to hex
-        $md5 = $format eq 'base64' ? md5_base64($str) : md5_hex($str);
-        return $md5, html => html_output($str, $md5);
-    } else {
-        # Exit unless a string is found
-        return;
-    }
+
+    # return if there is nothing left to hash
+    return unless (/^\s*(.*\S+)/);
+
+    # The string is encoded to get the utf8 representation instead of
+    # perls internal representation of strings, before it's passed to
+    # the md5 subroutine.
+    my $str = encode("utf8",$1);
+    #use approprite output format, default to hex
+    my $md5 = $format eq 'base64' ? md5_base64($str) : md5_hex($str);
+    return $md5, html => html_output($str, $md5);
+
 };
 
 1;

--- a/t/MD5.t
+++ b/t/MD5.t
@@ -13,6 +13,7 @@ ddg_goodie_test(
         DDG::Goodie::MD5
     )],
     'md5 digest this!' => test_zci('3838c8fb10a114e6d21203359ef147ad', html=>qr/.*/),
+    'md5 base64 this string' => test_zci('xzix7ki/mKlygQ8V94J05Q', html=>qr/.*/),
     'duckduckgo md5' => test_zci('96898bb8544fa56b03c08cdc09886c6c', html=>qr/.*/),
     'md5sum the sum of a string' => test_zci('a704c8833f9850cd342ead27207ca1a1', html=>qr/.*/),
     'md5 of password' => test_zci('5f4dcc3b5aa765d61d8327deb882cf99', html=>qr/.*/),


### PR DESCRIPTION
The sha and md5 goodies do very similar things, but have different look and behaviour. 

This PR implements the option to format md5 hashes in either hex or base64, similarly to the sha goodie's current behaviour, and adds relevant tests.

I'm still familiarizing myself with the instant answer architechture and I need to brush up on my perl skills, so I'm starting out with just a small change.
