### PR TITLE
add missing semicolon to attribution, comment out empty category and topic

### DIFF
--- a/template/lib/DDG/Goodie/Example.pm
+++ b/template/lib/DDG/Goodie/Example.pm
@@ -13,8 +13,9 @@ name "<: $ia_name_separated :>";
 description "Succinct explanation of what this instant answer does";
 primary_example_queries "first example query", "second example query";
 secondary_example_queries "optional -- demonstrate any additional triggers";
-# Uncomment and fill out before submitting
+# Uncomment and complete: https://duck.co/duckduckhack/metadata#category
 # category "";
+# Uncomment and complete: https://duck.co/duckduckhack/metadata#topics
 # topics "";
 code_url "https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/<: $ia_path :>/<: $ia_name :>.pm";
 attribution github => ["GitHubAccount", "Friendly Name"],

--- a/template/t/Example.t
+++ b/template/t/Example.t
@@ -9,10 +9,14 @@ zci answer_type => "<: $lia_name :>";
 zci is_cached   => 1;
 
 ddg_goodie_test(
-	[qw(
-		DDG::Goodie::<: $ia_package_name :>
-	)],
-	'example query' => test_zci('query')
+    [qw( DDG::Goodie::<: $ia_package_name :> )],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'example query' => test_zci('query'),
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'bad example query' => undef,
 );
 
 done_testing;


### PR DESCRIPTION
- commenting out empty category and topic so no errors are thrown when testing

cc// @mwmiller 
