### PR TITLE
TimezoneConverter: add "my time" support.

### DIFF
--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -57,13 +57,15 @@ my %timezones = qw(
     YEKT      5
 );
 
-my $default_tz = 'UTC';
+my $default_tz   = 'UTC';
+my $localtime_re = qr/(?:(?:my|local|my local)\s*time(?:zone)?)/i;
+my $timezone_re  = qr/(?:\w+(?:\s*[+-]0*[0-9]{1,5}(?::[0-5][0-9])?)?|$localtime_re)?/;
 
 sub parse_timezone {
     my $timezone = shift;
 
     # They said "my timezone" or similar.
-    if ($timezone =~ /^my time/i) {
+    if ($timezone =~ /$localtime_re/i) {
         my $dt = DateTime->now(time_zone => $loc->time_zone || $default_tz );
         return ($dt->time_zone_short_name, $dt->offset / 3600);
     }
@@ -112,8 +114,6 @@ sub to_time {
     }
     sprintf "%i:%02.0f$seconds_format$pm", $hours, $minutes, $seconds;
 }
-
-my $timezone_re = qr/(?:\w+(?:\s*[+-]0*[0-9]{1,5}(?::[0-5][0-9])?)?|(?:my\s+time(?:zone)?))?/;
 
 handle query => sub {
     my $query = $_;

--- a/t/TimezoneConverter.t
+++ b/t/TimezoneConverter.t
@@ -98,11 +98,27 @@ ddg_goodie_test(
         test_zci(qr/11:22 AM \(CEST, UTC\+2\) is [54]:22 AM $test_location_tz/,
         html => '-ANY-'
     ),
+    '11:22am cest in localtime' =>
+        test_zci(qr/11:22 AM \(CEST, UTC\+2\) is [54]:22 AM $test_location_tz/,
+        html => '-ANY-'
+    ),
+    '11:22am cest in my local timezone' =>
+        test_zci(qr/11:22 AM \(CEST, UTC\+2\) is [54]:22 AM $test_location_tz/,
+        html => '-ANY-'
+    ),
     '12pm my time in CEST' =>
         test_zci(qr/Noon $test_location_tz is [67]:00 PM \(CEST, UTC\+2\)./,
         html => '-ANY-'
     ),
+    '12pm local timezone in CEST' =>
+        test_zci(qr/Noon $test_location_tz is [67]:00 PM \(CEST, UTC\+2\)./,
+        html => '-ANY-'
+    ),
     '12am my timezone in UTC' =>
+        test_zci(qr/Midnight $test_location_tz is [45]:00 AM \(UTC\)./,
+        html => '-ANY-'
+    ),
+    '12am local time in UTC' =>
         test_zci(qr/Midnight $test_location_tz is [45]:00 AM \(UTC\)./,
         html => '-ANY-'
     ),


### PR DESCRIPTION
This makes it such that the entered timezone can be "my time" or "my timezone" and we'll figure it out based on the GeoIP data.  A sort of stop-gap measure until we get better answers elsewhere.

Also changes A.M. and P.M. to be AM and PM, more in concert with the other answers.
