### PR TITLE
Calculator: better guard for no-ops.

### DIFF
--- a/t/Calculator.t
+++ b/t/Calculator.t
@@ -395,6 +395,9 @@ ddg_goodie_test(
     time                              => undef,    # We eval perl directly, only do whitelisted stuff!
     'four squared'                    => undef,
     '! + 1'                           => undef,    # Regression test for bad query trigger.
+    '$5'                              => undef,
+    'calculate 5'                     => undef,
+    'solve $50'                       => undef,
 );
 
 done_testing;


### PR DESCRIPTION
The old guard was kinda whacky (and wrong) and inverted all the logic.
So we'll dump out early when we recognize that no operations will be
done.

Intended to fix #728.
