### PR TITLE
use utf8

### DIFF
--- a/lib/DDG/Goodie/FIGlet.pm
+++ b/lib/DDG/Goodie/FIGlet.pm
@@ -1,5 +1,6 @@
 package DDG::Goodie::FIGlet;
 # ABSTRACT: Uses FIGlet to make large letters out of ordinary text.
+
 use utf8;
 use DDG::Goodie;
 use Text::FIGlet;

--- a/lib/DDG/Goodie/MD5.pm
+++ b/lib/DDG/Goodie/MD5.pm
@@ -1,5 +1,6 @@
 package DDG::Goodie::MD5;
 # ABSTRACT: Calculate the MD5 digest of a string.
+
 use utf8;
 use DDG::Goodie;
 use Digest::MD5 qw(md5_base64 md5_hex);

--- a/lib/DDG/Goodie/ValarMorghulis.pm
+++ b/lib/DDG/Goodie/ValarMorghulis.pm
@@ -1,5 +1,6 @@
 package DDG::Goodie::ValarMorghulis;
 # ABSTRACT: A Game of Thrones / A Song of Ice and Fire easter egg.
+
 use utf8;
 use DDG::Goodie;
 


### PR DESCRIPTION
a few perl files missing `use utf8` 
