### PR TITLE
CalendarConversion.pm now uses YAML instead of YAML::XS.

### DIFF
--- a/lib/DDG/Goodie/CalendarConversion.pm
+++ b/lib/DDG/Goodie/CalendarConversion.pm
@@ -7,7 +7,7 @@ with 'DDG::GoodieRole::Dates';
 use Date::Hijri;
 use Date::Jalali2;
 
-use YAML::XS qw(Load);
+use YAML qw(Load);
 
 zci answer_type => "calendar_conversion";
 zci is_cached   => 0;

--- a/share/goodie/calendar_conversion/calendars.yml
+++ b/share/goodie/calendar_conversion/calendars.yml
@@ -1,40 +1,40 @@
 ---
 gregorian:
-- January
-- Feburary
-- March
-- April
-- May
-- June
-- July
-- August
-- September
-- October
-- November
-- December
+  - January
+  - Feburary
+  - March
+  - April
+  - May
+  - June
+  - July
+  - August
+  - September
+  - October
+  - November
+  - December
 hijri:
-- Muharram
-- Safar
-- Rabia Awal
-- Rabia Thani
-- Jumaada Awal
-- Jumaada Thani
-- Rajab
-- Sha'ban
-- Ramadan
-- Shawwal
-- Dhul-Qi'dah
-- Dhul-Hijjah
+  - Muharram
+  - Safar
+  - Rabia Awal
+  - Rabia Thani
+  - Jumaada Awal
+  - Jumaada Thani
+  - Rajab
+  - Sha'ban
+  - Ramadan
+  - Shawwal
+  - Dhul-Qi'dah
+  - Dhul-Hijjah
 jalali:
-- Farvardin
-- Ordibehesht
-- Khordad
-- Tir
-- Mordad
-- Shahrivar
-- Mehr
-- Aban
-- Azar
-- Dey
-- Bahman
-- Esfand
+  - Farvardin
+  - Ordibehesht
+  - Khordad
+  - Tir
+  - Mordad
+  - Shahrivar
+  - Mehr
+  - Aban
+  - Azar
+  - Dey
+  - Bahman
+  - Esfand


### PR DESCRIPTION
Fixes #790. YAML is used instead of YAML::XS. Had to make changes to `calendar.yml` too.

This is my first PR for zeroclickinfo-goodies. I followed https://duck.co/duckduckhack/goodie_quickstart and used Codio to fix it. I can run the testcase for _CalendarConversion_ successfully, but there are 3 other tests failing:

```
Test Summary Report                                                                                                                                                                                                              
-------------------                                                                                                                                                                                                              
t/ChineseZodiac.t         (Wstat: 512 Tests: 0 Failed: 0)                                                                                                                                                                        
  Non-zero exit status: 2                                                                                                                                                                                                        
  Parse errors: No plan found in TAP output                                                                                                                                                                                      
t/Conversions.t           (Wstat: 256 Tests: 115 Failed: 1)                                                                                                                                                                      
  Failed test:  80                                                                                                                                                                                                               
  Non-zero exit status: 1                                                                                                                                                                                                        
t/SunInfo.t               (Wstat: 512 Tests: 0 Failed: 0)                                                                                                                                                                        
  Non-zero exit status: 2                                                                                                                                                                                                        
  Parse errors: No plan found in TAP output                                                                                                                                                                                      
t/Uptime.t                (Wstat: 512 Tests: 0 Failed: 0)                                                                                                                                                                        
  Non-zero exit status: 2                                                                                                                                                                                                        
  Parse errors: No plan found in TAP output       
```

I don't think I broke them, because they are failing even after reverting my changes. If I did break something, please tell me so I can fix it again. :)
