### PR TITLE
DHL Germany added into the DHL.pm-Module

### DIFF
--- a/lib/DDG/Goodie/DHL.pm
+++ b/lib/DDG/Goodie/DHL.pm
@@ -31,6 +31,7 @@ triggers query_nowhitespace_nodash => qr/
 handle query_nowhitespace_nodash => sub {
     # If a Canada Post package number (2 for exclusively).
     my $is_dhl = 0;
+    # dhl = 3 ==> german DHL number
 
     # Tracking number.
     my $package_number = '';
@@ -70,9 +71,22 @@ handle query_nowhitespace_nodash => sub {
         if ($checksum eq $chars[-1]) {
             $is_dhl = 1;
         }
+        
+    }
+    
+    if (length($package_number) eq 12) {
+        $is_dhl = 3; 
+          
     }
 
-    if ($is_dhl) {
+    if ($is_dhl eq 3) {
+        return $package_number, heading => "DHL Shipment Tracking (Germany)", html => "Track this shipment at <a href='http://nolp.dhl.de/nextt-online-public/set_identcodes.do?lang=de&idc=$package_number'>DHL Germany</a>.";
+        
+        # I just added DHL Germany by checking for 12-char-IDs. The checksum algo for those is not known, if you know a better way to detect DHL Germany tracking IDs, please improve. 
+    
+    }
+    
+    elsif ($is_dhl) {
         return $package_number, heading => "DHL Shipment Tracking", html => "Track this shipment at <a href='http://www.dhl-usa.com/content/us/en/express/tracking.shtml?brand=DHL&AWB=$package_number'>DHL</a>.";
     }
 

--- a/t/DHL.t
+++ b/t/DHL.t
@@ -30,6 +30,21 @@ ddg_goodie_test(
             heading => 'DHL Shipment Tracking (Germany)',
             html => "Track this shipment at <a href='http://nolp.dhl.de/nextt-online-public/set_identcodes.do?lang=de&idc=123456789012'>DHL Germany</a>.",
         ),
+        
+        
+        
+        
+        'DHL JJD12345678901' => test_zci(   #no tracking DHL Germany
+            'JJD12345678901',
+            heading => 'DHL Shipment Tracking (Germany)',
+            html => "Track this shipment at <a href='http://nolp.dhl.de/nextt-online-public/set_identcodes.do?lang=de&idc=JJD12345678901'>DHL Germany</a>.",
+        ),        
+        
+        'DHL JJD12345678901234567890' => test_zci(  #tracking DHL Germany
+            'JJD12345678901234567890',
+            heading => 'DHL Shipment Tracking (Germany)',
+            html => "Track this shipment at <a href='http://nolp.dhl.de/nextt-online-public/set_identcodes.do?lang=de&idc=JJD12345678901234567890'>DHL Germany</a>.",
+        ),        
 );
 
 done_testing;

--- a/t/DHL.t
+++ b/t/DHL.t
@@ -25,6 +25,11 @@ ddg_goodie_test(
             heading => 'DHL Shipment Tracking',
             html => "Track this shipment at <a href='http://www.dhl-usa.com/content/us/en/express/tracking.shtml?brand=DHL&AWB=123456789'>DHL</a>.",
         ),
+        'DHL 123456789012' => test_zci(
+            '123456789012',
+            heading => 'DHL Shipment Tracking (Germany)',
+            html => "Track this shipment at <a href='http://nolp.dhl.de/nextt-online-public/set_identcodes.do?lang=de&idc=123456789012'>DHL Germany</a>.",
+        ),
 );
 
 done_testing;


### PR DESCRIPTION
I did not add the checklist because it's just an update for an existing goodie: The DHL tracking goodie will now recognize DHL Germany tracking IDs by their length (USA IDs have <12 chars, most German IDs have 12 chars). 

Screenshot: http://i61.tinypic.com/zilwjl.png 

Addresses: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/642