### PR TITLE
First Goodie returns pi

### DIFF
--- a/lib/DDG/Goodie/Pi.pm
+++ b/lib/DDG/Goodie/Pi.pm
@@ -1,0 +1,29 @@
+# ABSTRACT: This Goodie returns 'pi' to a user-specified number of decimal places
+
+use DDG::Goodie;
+use Math::Trig;
+
+zci answer_type => "pi";
+zci is_cached   => 1;
+
+name "Pi";
+primary_example_queries "pi 7";
+description "Ex. returns 3.1415926";
+
+code_url "https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Pi.pm";
+attribution github => ["https://github.com/jmvbxx", "jmvbxx"];
+
+# Triggers
+triggers any => "pi";
+
+# Handle statement
+handle remainder => sub {
+
+    my $decimal = $_;
+    my $answer = substr pi, 0, ( $decimal + 2 );
+    
+    return "$answer";
+    
+};
+
+1;

--- a/t/Pi.t
+++ b/t/Pi.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Goodie;
+
+zci answer_type => "pi";
+zci is_cached   => 1;
+
+ddg_goodie_test(
+    [qw( DDG::Goodie::Pi )],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'example query' => test_zci('query'),
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'bad example query' => undef,
+);
+
+done_testing;


### PR DESCRIPTION
**What does your Instant Answer do?**

This is my first Goodie and I wanted it to return 'pi' to user-specified number of decimal places.

**What problem does your Instant Answer solve (Why is it better than organic links)?**

I wrote an Instant Answer for this earlier today.

**What is the data source for your Instant Answer? (Provide a link if possible)**

For now pi comes from Math::Trig which only provides limited number of decimal places.

**Why did you choose this data source?**

For simplicity.

**Are there any other alternative (better) data sources?**

We could calculate pi right in the code.

**What are some example queries that trigger this Instant Answer?**

pi 2 => 3.14
pi 5 => 3.14159

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**

Students

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**

Yes, I wrote an Instant Answer earlier today.

**Which existing Instant Answers will this one supercede/overlap with?**

N/A

**Are you having any problems? Do you need our help with anything?**

The code is extremely basic.  I have not yet done the pi.t and I have to put checks into pi.pm.

**Where did you hear about DuckDuckHack? (For first time contributors)**

N/A

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**

![img-20141216-wa0003](https://cloud.githubusercontent.com/assets/10154595/5461388/e8490408-8538-11e4-95c4-d0443d8d8f35.jpg)


## Checklist
Please place an 'X' where appropriate.

```
[] Added metadata and attribution information (https://duck.co/duckduckhack/metadata)
[] Wrote test file and added to t/ directory (https://duck.co/duckduckhack/goodie_tests)
[] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
[] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
[] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Windows 8
        [] Google Chrome
        [] Firefox
        [] Opera
        [] IE 10

    - Windows 7
        [] Google Chrome
        [] Firefox
        [] Opera
        [] IE 8
        [] IE 9
        [] IE 10

    - Windows XP
        [] IE 7
        [] IE 8

    - Mac OSX
        [] Google Chrome
        [] Firefox
        [] Opera
        [] Safari

    - iOS (iPhone)
        [] Safari Mobile
        [] Google Chrome
        [] Opera

    - iOS (iPad)
        [] Safari Mobile
        [] Google Chrome
        [] Opera

    - Android
        [] Firefox
        [] Native Browser
        [] Google Chrome
        [] Opera