### PR TITLE
dist.ini: require Data::RandomPerson 0.51 or later

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -66,7 +66,7 @@ Digest::MD5 = 2.53
 ; Factors
 Math::Prime::Util = 0.43
 Games::Sudoku::Component = 0.02
-Data::RandomPerson = 0.4
+Data::RandomPerson = 0.51
 Lingua::EN::Words2Nums = 0
 Locale::Currency::Format = 1.30
 Net::IP = 0


### PR DESCRIPTION
I adopted Data::RandomPerson and made the first CPAN release in 9+
years. Unfortunately, it broke this goodie and caused issue #857.

I was not aware of this goodie nor this being used on DuckDuckGo!
I'm sorry for the breakage, have just uploaded version 0.51 of
the module to CPAN which does not use the **DATA** handles anymore
and should have no problems.

See commit mbeijen/Data-RandomPerson@6ea585555c6c810f41f1e0f9a79a15bdb7ce384c

This change to dist.ini makes sure version 0.50 (the bad version)
is no longer used.
