### PR TITLE
Update Travis to use faster container-based (Docker) infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 ---
+sudo: false
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
   - rm .travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   - rm .travis.yml
   - git config --global user.name "Dist Zilla Plugin TravisCI"
   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
+  - chmod 755 install_mpfr.sh
   - ./install_mpfr.sh
 install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ before_install:
   - rm .travis.yml
   - git config --global user.name "Dist Zilla Plugin TravisCI"
   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libmpfr-dev
+  - ./install_mpfr.sh
 install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed
   - dzil listdeps | grep -ve '^\W' | cpanm  --quiet   --notest  --skip-installed
   - cpanm  --quiet   --notest  App::DuckPAN autodie
+after_install:
   - duckpan DDG
 language: perl
 perl:

--- a/dist.ini
+++ b/dist.ini
@@ -134,6 +134,3 @@ perl_version = 5.16
 perl_version = 5.18
 extra_dep = App::DuckPAN
 extra_dep = autodie
-after_install = duckpan DDG
-before_install = sudo apt-get update -qq
-before_install = sudo apt-get install -y libmpfr-dev

--- a/install_mpfr.sh
+++ b/install_mpfr.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -ex
+
+# download and install mpfr for Chinese Zodiac Goodie
+wget http://www.mpfr.org/mpfr-current/mpfr-3.1.2.tar.gz
+tar -xzvf mpfr-3.1.2.tar.gz
+cd mpfr-3.1.2 && ./configure --prefix=/usr && make && sudo make install

--- a/install_mpfr.sh
+++ b/install_mpfr.sh
@@ -4,4 +4,4 @@ set -ex
 # download and install mpfr for Chinese Zodiac Goodie
 wget http://www.mpfr.org/mpfr-current/mpfr-3.1.2.tar.gz
 tar -xzvf mpfr-3.1.2.tar.gz
-cd mpfr-3.1.2 && ./configure --prefix=/usr && make && sudo make install
+cd mpfr-3.1.2 && ./configure --prefix=/usr && make && make check && make install


### PR DESCRIPTION
Travis offers a [new, faster infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) that uses Docker. The only downside is that it doesn't allow for `sudo` access. 

This PR cleans up the dist.ini (we have duplicate commands in the dist and travis.yml file) and updates travis.yml to install our only system dependency, GNU MPFR, via a shell script, to avoid the use of `sudo`

Travis also allows for caching of folders and packages, we could potentially cache the CPAN packages but I'm not sure about that