### PR TITLE
LeapYear: Adding MockTime to output

### DIFF
--- a/lib/DDG/Goodie/LeapYear.pm
+++ b/lib/DDG/Goodie/LeapYear.pm
@@ -75,8 +75,7 @@ sub format_year {
 }
 handle remainder => sub {
     
-    my ($second, $minute, $hour, $dayOfMonth, $month, $partyear, $dayOfWeek, $dayOfYear, $daylightSavings) = localtime();
-    my $year = $partyear + 1900;
+    my $year = (localtime)[5] + 1900;
     
     if ($_ =~ /(last|previous) ([0-9][0-9]?)$/i) {
         my @years = search_leaps($2, -1, 0, $year);

--- a/lib/DDG/Goodie/LeapYear.pm
+++ b/lib/DDG/Goodie/LeapYear.pm
@@ -15,7 +15,7 @@ code_url 'https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DD
 category 'dates';
 topics 'everyday';
 attribution github => [ 'https://github.com/tophattedcoder', 'Tom Bebbington'],
-twitter => '@tophattedcoder';
+           twitter => '@tophattedcoder';
 
 zci is_cached => 1;
 triggers startend => 'leap years', 'leap year';
@@ -31,9 +31,7 @@ my %is_not_tense = (
     present => 'is not',
     future => 'will not be',
 );
-my ($second, $minute, $hour, $dayOfMonth, $month, $partyear, $dayOfWeek, $dayOfYear, $daylightSavings) = localtime();
-# the current year
-my $year = $partyear + 1900;
+
 # searches for leap years
 sub search_leaps {
     my ($num, $direction, $include_curr, $curryear) = @_;
@@ -53,7 +51,7 @@ sub search_leaps {
 }
 # finds the matching tense for the given year
 sub find_tense {
-    my ($cyear) = @_;
+    my ($cyear, $year) = @_;
     if($cyear < $year) {
         return "past";
     } elsif($cyear > $year) {
@@ -76,6 +74,10 @@ sub format_year {
     }
 }
 handle remainder => sub {
+    
+    my ($second, $minute, $hour, $dayOfMonth, $month, $partyear, $dayOfWeek, $dayOfYear, $daylightSavings) = localtime();
+    my $year = $partyear + 1900;
+    
     if ($_ =~ /(last|previous) ([0-9][0-9]?)$/i) {
         my @years = search_leaps($2, -1, 0, $year);
         @years = map(format_year, @years);
@@ -119,7 +121,7 @@ handle remainder => sub {
             $cyear = -$cyear;
         }
         my $fyear = format_year($cyear);
-        my $tense = find_tense($cyear);
+        my $tense = find_tense($cyear, $year);
         if(isleap($cyear)) {
             return "$fyear $is_tense{$tense} a leap year";
         } else {

--- a/t/LeapYear.t
+++ b/t/LeapYear.t
@@ -11,14 +11,14 @@ zci answer_type => 'leap_year';
 zci is_cached => 1;
 
 ddg_goodie_test(
-	[qw(
-		DDG::Goodie::LeapYear
-	)],
-	'was 2012 a leap year' => test_zci('2012 CE was a leap year'),
-	'will 3012 be a leap year' => test_zci('3012 CE will be a leap year'),
-	'was 1 bce a leap year' => test_zci('1 BCE was not a leap year'),
-	'leap years after 2005' => test_zci('The 5 leap years after 2005 CE are 2008 CE, 2012 CE, 2016 CE, 2020 CE, 2024 CE, 2028 CE'),
-	'leap years before 2 bc' => test_zci('The 5 leap years before 2 BCE are 4 BCE, 8 BCE, 12 BCE, 16 BCE, 20 BCE, 24 BCE'),
+    [qw(
+        DDG::Goodie::LeapYear
+    )],
+    'was 2012 a leap year' => test_zci('2012 CE was a leap year'),
+    'will 3012 be a leap year' => test_zci('3012 CE will be a leap year'),
+    'was 1 bce a leap year' => test_zci('1 BCE was not a leap year'),
+    'leap years after 2005' => test_zci('The 5 leap years after 2005 CE are 2008 CE, 2012 CE, 2016 CE, 2020 CE, 2024 CE, 2028 CE'),
+    'leap years before 2 bc' => test_zci('The 5 leap years before 2 BCE are 4 BCE, 8 BCE, 12 BCE, 16 BCE, 20 BCE, 24 BCE'),
     'when were the last 50 leap years' => test_zci('The last 50 leap years were 2012 CE, 2008 CE, 2004 CE, 2000 CE, 1996 CE, 1992 CE, 1988 CE, 1984 CE, 1980 CE, 1976 CE, 1972 CE, 1968 CE, 1964 CE, 1960 CE, 1956 CE, 1952 CE, 1948 CE, 1944 CE, 1940 CE, 1936 CE, 1932 CE, 1928 CE, 1924 CE, 1920 CE, 1916 CE, 1912 CE, 1908 CE, 1904 CE, 1896 CE, 1892 CE, 1888 CE, 1884 CE, 1880 CE, 1876 CE, 1872 CE, 1868 CE, 1864 CE, 1860 CE, 1856 CE, 1852 CE, 1848 CE, 1844 CE, 1840 CE, 1836 CE, 1832 CE, 1828 CE, 1824 CE, 1820 CE, 1816 CE, 1812 CE, 1808 CE'),
     'is it a leap year?' => test_zci(qr'[0-9]{4} CE is (not )?a leap year'),
 );
@@ -26,25 +26,25 @@ ddg_goodie_test(
 set_fixed_time("2014-12-01T00:00:00");
 ddg_goodie_test(
     [qw(
-		DDG::Goodie::LeapYear
-	)],
-	'is it a leap year?' => test_zci('2014 CE is not a leap year')
+        DDG::Goodie::LeapYear
+    )],
+    'is it a leap year?' => test_zci('2014 CE is not a leap year')
 );
 restore_time();
 set_fixed_time("2015-01-01T00:00:00");
 ddg_goodie_test(
     [qw(
-		DDG::Goodie::LeapYear
-	)],
-	'is it a leap year?' => test_zci('2015 CE is not a leap year')
+        DDG::Goodie::LeapYear
+    )],
+    'is it a leap year?' => test_zci('2015 CE is not a leap year')
 );
 restore_time();
 set_fixed_time("2012-12-01T00:00:00");
 ddg_goodie_test(
     [qw(
-		DDG::Goodie::LeapYear
-	)],
-	'is it a leap year?' => test_zci('2012 CE is a leap year')
+        DDG::Goodie::LeapYear
+    )],
+    'is it a leap year?' => test_zci('2012 CE is a leap year')
 );
 restore_time();
 

--- a/t/LeapYear.t
+++ b/t/LeapYear.t
@@ -2,11 +2,14 @@
 
 use strict;
 use warnings;
+
+use Test::MockTime qw( :all );
 use Test::More;
 use DDG::Test::Goodie;
 
 zci answer_type => 'leap_year';
 zci is_cached => 1;
+
 ddg_goodie_test(
 	[qw(
 		DDG::Goodie::LeapYear
@@ -18,5 +21,22 @@ ddg_goodie_test(
 	'leap years before 2 bc' => test_zci('The 5 leap years before 2 BCE are 4 BCE, 8 BCE, 12 BCE, 16 BCE, 20 BCE, 24 BCE'),
     'when were the last 50 leap years' => test_zci('The last 50 leap years were 2012 CE, 2008 CE, 2004 CE, 2000 CE, 1996 CE, 1992 CE, 1988 CE, 1984 CE, 1980 CE, 1976 CE, 1972 CE, 1968 CE, 1964 CE, 1960 CE, 1956 CE, 1952 CE, 1948 CE, 1944 CE, 1940 CE, 1936 CE, 1932 CE, 1928 CE, 1924 CE, 1920 CE, 1916 CE, 1912 CE, 1908 CE, 1904 CE, 1896 CE, 1892 CE, 1888 CE, 1884 CE, 1880 CE, 1876 CE, 1872 CE, 1868 CE, 1864 CE, 1860 CE, 1856 CE, 1852 CE, 1848 CE, 1844 CE, 1840 CE, 1836 CE, 1832 CE, 1828 CE, 1824 CE, 1820 CE, 1816 CE, 1812 CE, 1808 CE'),
 );
+
+set_fixed_time("2014-12-01T00:00:00");
+ddg_goodie_test(
+    [qw(
+		DDG::Goodie::LeapYear
+	)],
+	'is it a leap year?' => test_zci('2014 is a leap year')
+);
+restore_time();
+set_fixed_time("2015-01-01T00:00:00");
+ddg_goodie_test(
+    [qw(
+		DDG::Goodie::LeapYear
+	)],
+	'is it a leap year?' => test_zci('2015 is not a leap year')
+);
+restore_time();
 
 done_testing();

--- a/t/LeapYear.t
+++ b/t/LeapYear.t
@@ -20,8 +20,9 @@ ddg_goodie_test(
 	'leap years after 2005' => test_zci('The 5 leap years after 2005 CE are 2008 CE, 2012 CE, 2016 CE, 2020 CE, 2024 CE, 2028 CE'),
 	'leap years before 2 bc' => test_zci('The 5 leap years before 2 BCE are 4 BCE, 8 BCE, 12 BCE, 16 BCE, 20 BCE, 24 BCE'),
     'when were the last 50 leap years' => test_zci('The last 50 leap years were 2012 CE, 2008 CE, 2004 CE, 2000 CE, 1996 CE, 1992 CE, 1988 CE, 1984 CE, 1980 CE, 1976 CE, 1972 CE, 1968 CE, 1964 CE, 1960 CE, 1956 CE, 1952 CE, 1948 CE, 1944 CE, 1940 CE, 1936 CE, 1932 CE, 1928 CE, 1924 CE, 1920 CE, 1916 CE, 1912 CE, 1908 CE, 1904 CE, 1896 CE, 1892 CE, 1888 CE, 1884 CE, 1880 CE, 1876 CE, 1872 CE, 1868 CE, 1864 CE, 1860 CE, 1856 CE, 1852 CE, 1848 CE, 1844 CE, 1840 CE, 1836 CE, 1832 CE, 1828 CE, 1824 CE, 1820 CE, 1816 CE, 1812 CE, 1808 CE'),
+    'is it a leap year?' => test_zci(qr'[0-9]{4} CE is (not )?a leap year'),
 );
-
+=for
 set_fixed_time("2014-12-01T00:00:00");
 ddg_goodie_test(
     [qw(
@@ -38,5 +39,5 @@ ddg_goodie_test(
 	'is it a leap year?' => test_zci('2015 is not a leap year')
 );
 restore_time();
-
+=cut
 done_testing();

--- a/t/LeapYear.t
+++ b/t/LeapYear.t
@@ -22,13 +22,13 @@ ddg_goodie_test(
     'when were the last 50 leap years' => test_zci('The last 50 leap years were 2012 CE, 2008 CE, 2004 CE, 2000 CE, 1996 CE, 1992 CE, 1988 CE, 1984 CE, 1980 CE, 1976 CE, 1972 CE, 1968 CE, 1964 CE, 1960 CE, 1956 CE, 1952 CE, 1948 CE, 1944 CE, 1940 CE, 1936 CE, 1932 CE, 1928 CE, 1924 CE, 1920 CE, 1916 CE, 1912 CE, 1908 CE, 1904 CE, 1896 CE, 1892 CE, 1888 CE, 1884 CE, 1880 CE, 1876 CE, 1872 CE, 1868 CE, 1864 CE, 1860 CE, 1856 CE, 1852 CE, 1848 CE, 1844 CE, 1840 CE, 1836 CE, 1832 CE, 1828 CE, 1824 CE, 1820 CE, 1816 CE, 1812 CE, 1808 CE'),
     'is it a leap year?' => test_zci(qr'[0-9]{4} CE is (not )?a leap year'),
 );
-=for
+
 set_fixed_time("2014-12-01T00:00:00");
 ddg_goodie_test(
     [qw(
 		DDG::Goodie::LeapYear
 	)],
-	'is it a leap year?' => test_zci('2014 is a leap year')
+	'is it a leap year?' => test_zci('2014 CE is not a leap year')
 );
 restore_time();
 set_fixed_time("2015-01-01T00:00:00");
@@ -36,8 +36,16 @@ ddg_goodie_test(
     [qw(
 		DDG::Goodie::LeapYear
 	)],
-	'is it a leap year?' => test_zci('2015 is not a leap year')
+	'is it a leap year?' => test_zci('2015 CE is not a leap year')
 );
 restore_time();
-=cut
+set_fixed_time("2012-12-01T00:00:00");
+ddg_goodie_test(
+    [qw(
+		DDG::Goodie::LeapYear
+	)],
+	'is it a leap year?' => test_zci('2012 CE is a leap year')
+);
+restore_time();
+
 done_testing();


### PR DESCRIPTION
Fixes to address reduced test coverage caused by: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/888

@MrChrisW this is what's normally done for testing temporal things (see https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/t/CalendarToday.t#L87 for example)

However, I've just noticed that this technique absolutely hasn't worked here as the current date and time isn't actually used when a query is made, only the time when the goodie was loaded : https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/LeapYear.pm#L34