### PR TITLE
Improve markup for resistor colour codes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -89,6 +89,7 @@ Marpa::R2 = 0
 ; For pre-fetch Goodies only.
 LWP::Simple = 0
 Business::CUSIP = 1.03
+Lingua::Any::Numbers = 0
 
 [Prereqs / TestRequires]
 Test::EOL = 0

--- a/lib/DDG/Goodie/ResistorColors.pm
+++ b/lib/DDG/Goodie/ResistorColors.pm
@@ -176,7 +176,7 @@ sub render {
     }
     $html .= "</div></div>"
         . "<br/>"
-        . "<a href='http://resisto.rs/#$formatted_value' class='resistorlink'>"
+        . "<a href='http://resisto.rs/#$formatted_value' class='zci__more-at'>"
         . "More at resisto.rs</a></div>";
 
     return $text, html => $html;

--- a/lib/DDG/Goodie/ResistorColors.pm
+++ b/lib/DDG/Goodie/ResistorColors.pm
@@ -11,6 +11,7 @@ package DDG::Goodie::ResistorColors;
 use DDG::Goodie;
 use Math::Round;
 use POSIX qw(abs floor log10 pow);
+use Lingua::Any::Numbers qw(:std);
 use utf8;
 
 # \x{2126} is the unicode ohm symbol
@@ -129,18 +130,23 @@ sub render {
     my ($value, $digits) = @_;
     my $formatted_value = format_value($value);
     my $ohms = $formatted_value eq '1' ? 'ohm' : 'ohms';
-    my $text = "$formatted_value\x{2126} ($ohms) resistor colors:";
-    my $html = "<div class='zci--resistor-colors'><span class='resistor'>"
-             . "$formatted_value&#x2126; ($ohms) resistor colors:</span>";
+    my $text = "$formatted_value\x{2126}";
+    my $bands = ucfirst to_string(scalar @$digits);
+    my $html = "<div class='zci__body'>" .
+                    "<div class='zci--resistor-colors'>" .
+                        "<h3 class='zci__header'>$text</h3>" .
+                        "<h4 class='zci__subheader'>$bands Bands</h4>" .
+                        "<div class='zci__content'>";
+    $text .= " ($ohms) resistor colors:";
 
     #while (my ($index, $digit) = each @$digits) {
     my $index = 0;
     foreach my $digit (@$digits) {
         if (exists $digits_to_colors{$digit}) {
-            my $name  = $digits_to_colors{$digit}{name};
+            my $class  = $digits_to_colors{$digit}{name};
+            my $name = ucfirst $class;
             my $hex   = $digits_to_colors{$digit}{hex};
             my $label = $digits_to_colors{$digit}{label};
-            my $style = "background-color:$hex;color:$label;";
             my ($text_prefix, $html_prefix, $display_digit);
             if ($index == scalar(@$digits) - 2) {
                 # multiplier digit
@@ -158,17 +164,18 @@ sub render {
                 $html_prefix = '';
                 $display_digit = $digit;
             }
-            $text .= " $name ($text_prefix$display_digit)";
+            $text .= " $class ($text_prefix$display_digit)";
             if ($index != scalar(@$digits - 1)) {
                 $text .= ','; # Comma delimit all but last
             }
-            $html .= " <span class='resistorcolors' style='$style'>$name ($html_prefix$display_digit)</span>";
+            $html .= "<span class='resistor-band $class'>$name $html_prefix$display_digit</span>";
         } else {
             return;
         }
         $index++;
     }
-    $html .= "<br/>"
+    $html .= "</div></div>"
+        . "<br/>"
         . "<a href='http://resisto.rs/#$formatted_value' class='resistorlink'>"
         . "More at resisto.rs</a></div>";
 

--- a/share/goodie/resistor_colors/resistor_colors.css
+++ b/share/goodie/resistor_colors/resistor_colors.css
@@ -1,15 +1,57 @@
-.zci--answer .zci--resistor-colors .resistor {
-    margin-right: 4px;
-}
-
-.zci--answer .zci--resistor-colors .colors {
+.zci--resistor-colors .resistor-band {
+    padding: 5px 15px;
     display: inline-block;
-    border: 1px solid #c8c8c8;
-    margin-top: -1px;
-    padding: 0px 5px 3px;
-    border-radius: 4px;
+    margin-right: 5px;
+    color: #333;
 }
 
-.zci--answer .zci--resistor-colors .link {
-    font-size: 92.8%;
+.zci--resistor-colors .resistor-band.silver {
+    background-color: #c0c0c0;
+}
+
+.zci--resistor-colors .resistor-band.gold {
+    background-color: #cfb53b;
+}
+
+.zci--resistor-colors .resistor-band.black {
+    background-color: #000000;
+    color: #ffffff;
+}
+
+.zci--resistor-colors .resistor-band.brown {
+    background-color: #964b00;
+    color: #ffffff;
+}
+
+.zci--resistor-colors .resistor-band.red {
+    background-color: #ff0000;
+    color: #ffffff;
+}
+
+.zci--resistor-colors .resistor-band.orange {
+    background-color: #ffa500;
+}
+
+.zci--resistor-colors .resistor-band.yellow {
+    background-color: #ffff00;
+}
+
+.zci--resistor-colors .resistor-band.green {
+    background-color: #9acd32;
+}
+
+.zci--resistor-colors .resistor-band.blue {
+    background-color: #6495ed;
+}
+
+.zci--resistor-colors .resistor-band.purple {
+    background-color: #ee82ee;
+}
+
+.zci--resistor-colors .resistor-band.gray {
+    background-color: #a0a0a0;
+}
+
+.zci--resistor-colors .resistor-band.white {
+    background-color: #ffffff;
 }

--- a/share/goodie/resistor_colors/resistor_colors.css
+++ b/share/goodie/resistor_colors/resistor_colors.css
@@ -1,57 +1,60 @@
-.zci--resistor-colors .resistor-band {
+.zci--answer .zci--resistor-colors .resistor-band {
     padding: 5px 15px;
     display: inline-block;
     margin-right: 5px;
     color: #333;
 }
 
-.zci--resistor-colors .resistor-band.silver {
-    background-color: #c0c0c0;
+.zci--answer .zci--resistor-colors .resistor-band.silver {
+    background-color: #d0d0d0;
 }
 
-.zci--resistor-colors .resistor-band.gold {
-    background-color: #cfb53b;
+.zci--answer .zci--resistor-colors .resistor-band.gold {
+    background-color: #f2d374;
 }
 
-.zci--resistor-colors .resistor-band.black {
-    background-color: #000000;
+.zci--answer .zci--resistor-colors .resistor-band.black {
+    background-color: #333333;
     color: #ffffff;
 }
 
-.zci--resistor-colors .resistor-band.brown {
-    background-color: #964b00;
+.zci--answer .zci--resistor-colors .resistor-band.brown {
+    background-color: #726258;
     color: #ffffff;
 }
 
-.zci--resistor-colors .resistor-band.red {
-    background-color: #ff0000;
+.zci--answer .zci--resistor-colors .resistor-band.red {
+    background-color: #de4f33;
     color: #ffffff;
 }
 
-.zci--resistor-colors .resistor-band.orange {
-    background-color: #ffa500;
+.zci--answer .zci--resistor-colors .resistor-band.orange {
+    background-color: #f4912d;
 }
 
-.zci--resistor-colors .resistor-band.yellow {
-    background-color: #ffff00;
+.zci--answer .zci--resistor-colors .resistor-band.yellow {
+    background-color: #ffc240;
 }
 
-.zci--resistor-colors .resistor-band.green {
-    background-color: #9acd32;
+.zci--answer .zci--resistor-colors .resistor-band.green {
+    background-color: #8fc547;
 }
 
-.zci--resistor-colors .resistor-band.blue {
-    background-color: #6495ed;
+.zci--answer .zci--resistor-colors .resistor-band.blue {
+    background-color: #4a96d1;
+    color: #ffffff;
 }
 
-.zci--resistor-colors .resistor-band.purple {
-    background-color: #ee82ee;
+.zci--answer .zci--resistor-colors .resistor-band.purple {
+    background-color: #8461a7;
+    color: #ffffff;
 }
 
-.zci--resistor-colors .resistor-band.gray {
+.zci--answer .zci--resistor-colors .resistor-band.gray {
     background-color: #a0a0a0;
+    color: #ffffff;
 }
 
-.zci--resistor-colors .resistor-band.white {
+.zci--answer .zci--resistor-colors .resistor-band.white {
     background-color: #ffffff;
 }

--- a/t/ResistorColors.t
+++ b/t/ResistorColors.t
@@ -95,7 +95,7 @@ ddg_goodie_test(
     # Check the HTML. Just once.
     "4.7k ohm" => test_zci(
         "4.7K\x{2126} (ohms) resistor colors: yellow (4), purple (7), red (\x{00D7}100), gold (\x{00B1}5%)",
-        html => "<div class='zci__body'><div class='zci--resistor-colors'><h3 class='zci__header'>4.7K\x{2126}</h3><h4 class='zci__subheader'>Four Bands</h4><div class='zci__content'><span class='resistor-band yellow'>Yellow 4</span><span class='resistor-band purple'>Purple 7</span><span class='resistor-band red'>Red &times;100</span><span class='resistor-band gold'>Gold &plusmn;5%</span></div></div><br/><a href='http://resisto.rs/#4.7K' class='resistorlink'>More at resisto.rs</a></div>"
+        html => "<div class='zci__body'><div class='zci--resistor-colors'><h3 class='zci__header'>4.7K\x{2126}</h3><h4 class='zci__subheader'>Four Bands</h4><div class='zci__content'><span class='resistor-band yellow'>Yellow 4</span><span class='resistor-band purple'>Purple 7</span><span class='resistor-band red'>Red &times;100</span><span class='resistor-band gold'>Gold &plusmn;5%</span></div></div><br/><a href='http://resisto.rs/#4.7K' class='zci__more-at'>More at resisto.rs</a></div>"
     ),
 );
 

--- a/t/ResistorColors.t
+++ b/t/ResistorColors.t
@@ -27,7 +27,7 @@ ddg_goodie_test(
     "330ohm resistor" => test_zci("330\x{2126} (ohms) resistor colors: orange (3), orange (3), brown (\x{00D7}10), gold (\x{00B1}5%)", html => qr/./),
     "330\x{2126} resistor" => test_zci("330\x{2126} (ohms) resistor colors: orange (3), orange (3), brown (\x{00D7}10), gold (\x{00B1}5%)", html => qr/./),
     "330 resistor" => test_zci("330\x{2126} (ohms) resistor colors: orange (3), orange (3), brown (\x{00D7}10), gold (\x{00B1}5%)", html => qr/./),
-    
+
     # Various multipliers
     "472000 ohms" => test_zci("470K\x{2126} (ohms) resistor colors: yellow (4), purple (7), yellow (\x{00D7}10K), gold (\x{00B1}5%)", html => qr/./),
     "400000 ohms" => test_zci("400K\x{2126} (ohms) resistor colors: yellow (4), black (0), yellow (\x{00D7}10K), gold (\x{00B1}5%)", html => qr/./),
@@ -95,7 +95,7 @@ ddg_goodie_test(
     # Check the HTML. Just once.
     "4.7k ohm" => test_zci(
         "4.7K\x{2126} (ohms) resistor colors: yellow (4), purple (7), red (\x{00D7}100), gold (\x{00B1}5%)",
-        html => "<div class='zci--resistor-colors'><span class='resistor'>4.7K&#x2126; (ohms) resistor colors:</span> <span class='resistorcolors' style='background-color:#ffff00;color:#000;'>yellow (4)</span> <span class='resistorcolors' style='background-color:#ee82ee;color:#000;'>purple (7)</span> <span class='resistorcolors' style='background-color:#ff0000;color:#fff;'>red (&times;100)</span> <span class='resistorcolors' style='background-color:#cfb53b;color:#000;'>gold (&plusmn;5%)</span><br/><a href='http://resisto.rs/#4.7K' class='resistorlink'>More at resisto.rs</a></div>"
+        html => "<div class='zci__body'><div class='zci--resistor-colors'><h3 class='zci__header'>4.7K\x{2126}</h3><h4 class='zci__subheader'>Four Bands</h4><div class='zci__content'><span class='resistor-band yellow'>Yellow 4</span><span class='resistor-band purple'>Purple 7</span><span class='resistor-band red'>Red &times;100</span><span class='resistor-band gold'>Gold &plusmn;5%</span></div></div><br/><a href='http://resisto.rs/#4.7K' class='resistorlink'>More at resisto.rs</a></div>"
     ),
 );
 


### PR DESCRIPTION
This improves the markup for the resistor colour codes goodie as per #851.

![screen shot 2015-01-15 at 2 56 42 am](https://cloud.githubusercontent.com/assets/4298494/5747965/2bda8c06-9c62-11e4-897b-0a64bcedd358.png)

Is there a standard `zci__something` class/style for the link at the bottom?
