### PR TITLE
Fixed errors in Dice tests

### DIFF
--- a/lib/DDG/Goodie/Dice.pm
+++ b/lib/DDG/Goodie/Dice.pm
@@ -1,5 +1,6 @@
 package DDG::Goodie::Dice;
 # ABSTRACT: roll a number of (abstract) dice.
+# https://en.wikipedia.org/wiki/Dice_notation
 
 use DDG::Goodie;
 

--- a/t/Dice.t
+++ b/t/Dice.t
@@ -81,11 +81,11 @@ ddg_goodie_test(
                 html => qr/./,
                 heading => $heading
         ),
-        "roll 2d6 and 3d12 - 4" => test_zci(qr/^\d (\+|-) \d = \d+<br\/>\d{1,2} (\+|-) \d{1,2} (\+|-) \d{1,2} (\+|-) \d{1,2} = \d+<br\/>Total: \d+$/,
+        "roll 2d6 and 3d12 - 4" => test_zci(qr/^\d (\+|-) \d = \d+<br\/>\d{1,2} (\+|-) \d{1,2} (\+|-) \d{1,2} (\+|-) \d{1,2} = -?\d+<br\/>Total: \d+$/,
                 html => qr/./,
                 heading => $heading
         ),
-        "throw 3d12 - 4 and 2d6" => test_zci(qr/^\d{1,2} (\+|-) \d{1,2} (\+|-) \d{1,2} (\+|-) \d{1,2} = \d{1,2}<br\/>\d (\+|-) \d = \d+<br\/>Total: \d+$/,
+        "throw 3d12 - 4 and 2d6" => test_zci(qr/^\d{1,2} (\+|-) \d{1,2} (\+|-) \d{1,2} (\+|-) \d{1,2} = -?\d{1,2}<br\/>\d (\+|-) \d = \d+<br\/>Total: \d+$/,
                 html => qr/./,
                 heading => $heading
         ),


### PR DESCRIPTION
There is an error in Dice.t tests:
3d12 - 4 can be -1 if all three dices show one.

The probability of this error is 1/(12**3) = 0.06% so it seldom appears.

This error was triggered in the Travis build:
https://travis-ci.org/duckduckgo/zeroclickinfo-goodies/jobs/47197374#L1674
(line 1674, search for "Dice.t")
