### PR TITLE
Fix returning error as structured content in ParseCron, e.g.

### DIFF
--- a/lib/DDG/Goodie/ParseCron.pm
+++ b/lib/DDG/Goodie/ParseCron.pm
@@ -280,12 +280,7 @@ handle remainder => sub {
             result => $time
         };
     } catch {
-        chomp;
-        return $_, structured_answer => {
-            input => [$line],
-            operation => 'Crontab',
-            result => $_
-        };
+        return '';
     }
     
 };


### PR DESCRIPTION
Crontab a * * * * *