### PR TITLE
Switching cheatsheets to use a more straightforward slurp

### DIFF
--- a/lib/DDG/Goodie/CrontabCheatSheet.pm
+++ b/lib/DDG/Goodie/CrontabCheatSheet.pm
@@ -37,27 +37,14 @@ triggers startend => (
 
 attribution github  => ["nkorth", "Nathan Korth"];
 
+my $HTML = share("crontab_cheat_sheet.html")->slurp(iomode => '<:encoding(UTF-8)');
+my $TEXT = share("crontab_cheat_sheet.txt")->slurp(iomode => '<:encoding(UTF-8)');
+
 handle remainder => sub {
     return
         heading => 'Cron Cheat Sheet',
-        html    => html_cheat_sheet(),
-        answer  => text_cheat_sheet(),
+        html    => $HTML,
+        answer  => $TEXT,
 };
-
-my $HTML;
-
-sub html_cheat_sheet {
-    $HTML //= share("crontab_cheat_sheet.html")
-        ->slurp(iomode => '<:encoding(UTF-8)');
-    return $HTML;
-}
-
-my $TEXT;
-
-sub text_cheat_sheet {
-    $TEXT //= share("crontab_cheat_sheet.txt")
-        ->slurp(iomode => '<:encoding(UTF-8)');
-    return $TEXT;
-}
 
 1;

--- a/lib/DDG/Goodie/GimpCheatSheet.pm
+++ b/lib/DDG/Goodie/GimpCheatSheet.pm
@@ -28,28 +28,15 @@ triggers startend => (
 
 attribution github  => ["elebow", "Eddie Lebow"];
 
+my $HTML = share("gimp_cheat_sheet.html")->slurp(iomode => "<:encoding(UTF-8)");
+my $TEXT = share("gimp_cheat_sheet.txt")->slurp(iomode => "<:encoding(UTF-8)");;
+
 handle remainder => sub {
     return
         heading => "GIMP Shortcut Cheat Sheet",
-        html    => html_cheat_sheet(),
-        answer  => text_cheat_sheet(),
+        html    => $HTML,
+        answer  => $TEXT,
 };
-
-my $HTML;
-
-sub html_cheat_sheet {
-    $HTML //= share("gimp_cheat_sheet.html")
-        ->slurp(iomode => "<:encoding(UTF-8)");
-    return $HTML;
-}
-
-my $TEXT;
-
-sub text_cheat_sheet {
-    $TEXT //= share("gimp_cheat_sheet.txt")
-        ->slurp(iomode => "<:encoding(UTF-8)");
-    return $TEXT;
-}
 
 1;
 

--- a/lib/DDG/Goodie/TmuxCheatSheet.pm
+++ b/lib/DDG/Goodie/TmuxCheatSheet.pm
@@ -36,27 +36,14 @@ attribution github  => ["charles-l",            "Charles Saternos"],
             twitter => ["theninjacharlie",           "Charles Saternos"],
             web     => ["http://charles-l.github.io", "Charles Saternos"];
 
+my $HTML = share("tmux_cheat_sheet.html")->slurp(iomode => '<:encoding(UTF-8)');
+my $TEXT= share("tmux_cheat_sheet.txt")->slurp(iomode => '<:encoding(UTF-8)');
+
 handle remainder => sub {
     return
         heading => 'Tmux Cheat Sheet',
-        html    => html_cheat_sheet(),
-        answer   => text_cheat_sheet(),
+        html    => $HTML,
+        answer   => $TEXT,
 };
-
-my $HTML;
-
-sub html_cheat_sheet {
-    $HTML //= share("tmux_cheat_sheet.html")
-        ->slurp(iomode => '<:encoding(UTF-8)');
-    return $HTML;
-}
-
-my $TEXT;
-
-sub text_cheat_sheet {
-    $TEXT //= share("tmux_cheat_sheet.txt")
-        ->slurp(iomode => '<:encoding(UTF-8)');
-    return $TEXT;
-}
 
 1;

--- a/lib/DDG/Goodie/VimCheatSheet.pm
+++ b/lib/DDG/Goodie/VimCheatSheet.pm
@@ -37,27 +37,14 @@ attribution github  => ["kablamo",            "Eric Johnson"],
             twitter => ["kablamo_",           "Eric Johnson"],
             web     => ["http://kablamo.org", "Eric Johnson"];
 
+my $HTML = share("vim_cheat_sheet.html")->slurp(iomode => '<:encoding(UTF-8)');
+my $TEXT = share("vim_cheat_sheet.txt")->slurp(iomode => '<:encoding(UTF-8)');
+
 handle remainder => sub {
     return
         heading => 'Vim Cheat Sheet',
-        html    => html_cheat_sheet(),
-        answer  => text_cheat_sheet(),
+        html    => $HTML,
+        answer  => $TEXT,
 };
-
-my $HTML;
-
-sub html_cheat_sheet {
-    $HTML //= share("vim_cheat_sheet.html")
-        ->slurp(iomode => '<:encoding(UTF-8)');
-    return $HTML;
-}
-
-my $TEXT;
-
-sub text_cheat_sheet {
-    $TEXT //= share("vim_cheat_sheet.txt")
-        ->slurp(iomode => '<:encoding(UTF-8)');
-    return $TEXT;
-}
 
 1;


### PR DESCRIPTION
Following on from the conversation on https://github.com/duckduckgo/zeroclickinfo-goodies/pull/949
leading to https://github.com/jim-brighter/zeroclickinfo-goodies/commit/08b7dd21a34b9c4374f046d88e01c14586ff0421
Personally I think the current implementation is a little confusing, especially for perl newbies, without any real advantage. Plus it seems to be spreading:
https://github.com/duckduckgo/zeroclickinfo-goodies/pull/938/files#diff-dfe7ab125d58a2abb86dd17c0b4448cfR37
