### PR TITLE
Pull Request Template: Remove IE 7

### DIFF
--- a/pull_request_template_goodie.md
+++ b/pull_request_template_goodie.md
@@ -64,7 +64,6 @@ Please place an 'X' where appropriate.
         - [] IE 10
 
     - Windows XP
-        - [] IE 7
         - [] IE 8
 
     - Mac OSX

--- a/pull_request_template_goodie.md
+++ b/pull_request_template_goodie.md
@@ -54,6 +54,7 @@ Please place an 'X' where appropriate.
         - [] Firefox
         - [] Opera
         - [] IE 10
+        - [] IE 11
 
     - Windows 7
         - [] Google Chrome
@@ -62,9 +63,7 @@ Please place an 'X' where appropriate.
         - [] IE 8
         - [] IE 9
         - [] IE 10
-
-    - Windows XP
-        - [] IE 8
+        - [] IE 11
 
     - Mac OSX
         - [] Google Chrome


### PR DESCRIPTION
We don't use IE 7 so we probably shouldn't list it in here.

@moollaza Why do we have Windows 7, 8, and XP? Maybe it should just be Windows? Does the Windows version matter?