### PR TITLE
TimeZoneConverter: Added support for times with no colon, eg. 1600 GMT

### DIFF
--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -9,7 +9,9 @@ use DDG::Goodie;
 use DateTime;
 use POSIX qw(fmod);
 
-attribution github => ['GlitchMr', 'GlitchMr'];
+attribution github => ['GlitchMr', 'GlitchMr'],
+            github => ['https://github.com/samph',      'samph'];
+
 
 primary_example_queries '10:00AM MST to PST';
 secondary_example_queries '19:00 UTC to EST', '1am UTC to PST';
@@ -123,8 +125,10 @@ handle query => sub {
           # Hours
           (?<h>[01]?[0-9] | 2[0-3])
           (?:
+          #Optional colon
+          :?
             # Minutes
-            :(?<m>[0-5] [0-9])
+            (?<m>[0-5] [0-9])
             (?:
               # Seconds
               :(?<s>[0-5] [0-9])

--- a/t/TimezoneConverter.t
+++ b/t/TimezoneConverter.t
@@ -88,6 +88,11 @@ ddg_goodie_test(
         test_zci('11:22 AM (EST, UTC-5) is 4:22 PM (UTC).',
         html => qr/.*11:22 AM.*\(EST, UTC-5\) is.*4:22 PM.*\(UTC\)./
     ),
+      '1600 UTC in BST' =>
+        test_zci('16:00 (UTC) is 17:00 (BST, UTC+1).',
+        html => '-ANY-'
+    ),  
+    
     # Intentional non-answers
     '12 in binary' => undef,
 );


### PR DESCRIPTION
Addressed TimeZoneConverter: Add support for "1600 GMT" #975 https://github.com/duckduckgo/zeroclickinfo-goodies/issues/975

