### PR TITLE
Improve Table CSS for mobile displays

### DIFF
--- a/share/goodie/bpmto_ms/bpmto_ms.css
+++ b/share/goodie/bpmto_ms/bpmto_ms.css
@@ -1,4 +1,10 @@
-@media (max-width: 600px) {
+@media (max-width: 300px) {    
+    .bpmto_ms table td {
+        word-wrap: break-word;
+    }
+}
+
+@media (min-width: 400px) {
     .bpmto_ms table {
         table-layout: fixed;
         width: 100%;
@@ -6,12 +12,6 @@
 
     .bpmto_ms table td {
         word-wrap: break-word;
-    }
-
-    .bpmto_ms .record td.record__cell__key {
-        width: 100px;
-        border-top: solid 1px #DDD;
-        border-bottom: solid 1px #DDD;
     }
 }
 


### PR DESCRIPTION
/cc @abeyang @mintsoft @stefolof

Updated the CSS for slightly improved viewing on mobile screens.

**\< 400px**

Before:
![less than 400px before](https://cloud.githubusercontent.com/assets/873785/6090245/af4cbb64-ae40-11e4-9510-d4dfff5c364d.png)

After:
![less than 400px after](https://cloud.githubusercontent.com/assets/873785/6090248/baffaa2a-ae40-11e4-805f-ff21d41472e8.png)

------

**\> 400px**

Before:

![more than 400px before](https://cloud.githubusercontent.com/assets/873785/6090250/c54e5986-ae40-11e4-9521-dc24aeb90ce5.png)

After:

![more than 400px after](https://cloud.githubusercontent.com/assets/873785/6090253/ca1035c0-ae40-11e4-80ee-0482a4f70b4d.png)
