### PR TITLE
Conversions: Tweaks to tests around rounding and accuracy

### DIFF
--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -191,11 +191,11 @@ ddg_goodie_test(
         }
     ),
     '500 miles in metres' => test_zci(
-        '500 miles = 804,672.249 meters',
+        '500 miles = 804,672 meters',
         structured_answer => {
             input     => ['500 miles'],
             operation => 'Convert',
-            result    => '804,672.249 meters'
+            result    => '804,672 meters'
         }
     ),
     '25 cm in inches' => test_zci(
@@ -600,11 +600,11 @@ ddg_goodie_test(
         }
     ),
     '3.5e-2 miles to inches' => test_zci(
-        '3.5 * 10^-2 miles = 2,217.602 inches',
+        '3.5 * 10^-2 miles = 2,217.601 inches',
         structured_answer => {
             input     => ['3.5 * 10<sup>-2</sup> miles'],
             operation => 'Convert',
-            result    => '2,217.602 inches'
+            result    => '2,217.601 inches'
         }
     ),
     # Areas and volumes


### PR DESCRIPTION
The upgrade has broken the tests for Conversions due to small changes in rounding, this fixes it! 

Unfortunately currently there isn't a good workflow that can be used for this as it's quite awkward to test the accuracy of Conversions based on an unreleased module and it's difficult to coordinate the module being updated and the tests at the same time.

cc @moollaza @MrChrisW 