### PR TITLE
Whacking use strict into all goodies

### DIFF
--- a/lib/DDG/Goodie/ABC.pm
+++ b/lib/DDG/Goodie/ABC.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::ABC;
 # ABSTRACT: Randomly pick one of several different choices delimited by "or"
 
+use strict;
 use DDG::Goodie;
 use List::AllUtils qw/none/;
 

--- a/lib/DDG/Goodie/AltCalendars.pm
+++ b/lib/DDG/Goodie/AltCalendars.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::AltCalendars;
 # ABSTRACT: Convert non-Gregorian years to the Gregorian calendar
 
+use strict;
 use DDG::Goodie;
 
 primary_example_queries 'heisei 24';

--- a/lib/DDG/Goodie/Anagram.pm
+++ b/lib/DDG/Goodie/Anagram.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Anagram;
 # ABSTRACT: Returns an anagram based on the supplied query.
 
+use strict;
 use DDG::Goodie;
 use List::Util qw( shuffle );
 

--- a/lib/DDG/Goodie/Ascii.pm
+++ b/lib/DDG/Goodie/Ascii.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Ascii;
 # ABSTRACT: ASCII
 
+use strict;
 use DDG::Goodie;
 
 triggers end => "ascii";

--- a/lib/DDG/Goodie/AspectRatio.pm
+++ b/lib/DDG/Goodie/AspectRatio.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::AspectRatio;
 # ABSTRACT: Calculates aspect ratio based on previously defined one
 
+use strict;
 use DDG::Goodie;
 
 triggers start => "aspect ratio";

--- a/lib/DDG/Goodie/Atbash.pm
+++ b/lib/DDG/Goodie/Atbash.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Atbash;
 # ABSTRACT: A simple substitution cipher using a reversed alphabet
 
+use strict;
 use DDG::Goodie;
 
 primary_example_queries 'atbash hello';

--- a/lib/DDG/Goodie/Average.pm
+++ b/lib/DDG/Goodie/Average.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Average;
 # ABSTRACT: take statistics for a list of numbers
 
+use strict;
 use DDG::Goodie;
 
 triggers startend => "avg", "average", "mean", "median", "root mean square";

--- a/lib/DDG/Goodie/BPMToMs.pm
+++ b/lib/DDG/Goodie/BPMToMs.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::BPMToMs;
 # ABSTRACT: Displays common note values in milliseconds for a given tempo measured in quarter notes per minute.
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "bpmto_ms";

--- a/lib/DDG/Goodie/Base.pm
+++ b/lib/DDG/Goodie/Base.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Base;
 # ABSTRACT: convert numbers between arbitrary bases
 
+use strict;
 use DDG::Goodie;
 
 use Math::Int2Base qw/int2base/;

--- a/lib/DDG/Goodie/Base64.pm
+++ b/lib/DDG/Goodie/Base64.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Base64;
 # ABSTRACT: Base64 <-> Unicode
 
+use strict;
 use DDG::Goodie;
 
 use MIME::Base64;

--- a/lib/DDG/Goodie/Binary.pm
+++ b/lib/DDG/Goodie/Binary.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Binary;
 # ABSTRACT: Convert decimal, hex and string to binary.
 
+use strict;
 use DDG::Goodie;
 
 use Bit::Vector;

--- a/lib/DDG/Goodie/BinaryLogic.pm
+++ b/lib/DDG/Goodie/BinaryLogic.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::BinaryLogic;
 # ABSTRACT: bit-wise logical operations.
 
+use strict;
 use DDG::Goodie;
 use utf8;
 

--- a/lib/DDG/Goodie/BirthStone.pm
+++ b/lib/DDG/Goodie/BirthStone.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::BirthStone;
 # ABSTRACT: Returns the birthstone of the queried month
 
+use strict;
 use DDG::Goodie;
 
 triggers startend => 'birthstone', 'birth stone';

--- a/lib/DDG/Goodie/BloodDonor.pm
+++ b/lib/DDG/Goodie/BloodDonor.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::BloodDonor;
 # ABSTRACT: Returns available donors for a blood type
 
+use strict;
 use DDG::Goodie;
 
 use strict;

--- a/lib/DDG/Goodie/Braille.pm
+++ b/lib/DDG/Goodie/Braille.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Braille;
 # ABSTRACT: Braille <-> ASCII/Unicode
 
+use strict;
 use DDG::Goodie;
 
 use Convert::Braille;

--- a/lib/DDG/Goodie/CalcRoots.pm
+++ b/lib/DDG/Goodie/CalcRoots.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::CalcRoots;
 # ABSTRACT: compute the n-th root of a number
 
+use strict;
 use DDG::Goodie;
 use Lingua::EN::Numericalize;
 

--- a/lib/DDG/Goodie/Calculator.pm
+++ b/lib/DDG/Goodie/Calculator.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Calculator;
 # ABSTRACT: do simple arthimetical calculations
 
+use strict;
 use DDG::Goodie;
 with 'DDG::GoodieRole::NumberStyler';
 

--- a/lib/DDG/Goodie/CalendarConversion.pm
+++ b/lib/DDG/Goodie/CalendarConversion.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::CalendarConversion;
 # ABSTRACT: convert between various calendars.
 
+use strict;
 use DDG::Goodie;
 with 'DDG::GoodieRole::Dates';
 

--- a/lib/DDG/Goodie/CalendarToday.pm
+++ b/lib/DDG/Goodie/CalendarToday.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::CalendarToday;
 # ABSTRACT: Print calendar of current / given month and highlight (to)day
 
+use strict;
 use DDG::Goodie;
 use DateTime;
 use Try::Tiny;

--- a/lib/DDG/Goodie/CallingCodes.pm
+++ b/lib/DDG/Goodie/CallingCodes.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::CallingCodes;
 # ABSTRACT: Matches country names to international calling codes
 
+use strict;
 use DDG::Goodie;
 use Locale::Country qw/country2code code2country/;
 use Telephony::CountryDialingCodes;

--- a/lib/DDG/Goodie/CanadaPost.pm
+++ b/lib/DDG/Goodie/CanadaPost.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::CanadaPost;
 # ABSTRACT: Track a package through Canada Post
 
+use strict;
 use DDG::Goodie;
 
 primary_example_queries 'canada post 123456789';

--- a/lib/DDG/Goodie/Chars.pm
+++ b/lib/DDG/Goodie/Chars.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Chars;
 # ABSTRACT: Give the number of characters (length) of the query.
 
+use strict;
 use DDG::Goodie;
 
 triggers startend =>

--- a/lib/DDG/Goodie/Chess960.pm
+++ b/lib/DDG/Goodie/Chess960.pm
@@ -2,7 +2,6 @@ package DDG::Goodie::Chess960;
 # ABSTRACT: return a random Chess 960 starting position.
 
 use strict;
-
 use DDG::Goodie;
 
 triggers any => 'random', 'chess960';

--- a/lib/DDG/Goodie/ChineseZodiac.pm
+++ b/lib/DDG/Goodie/ChineseZodiac.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::ChineseZodiac;
 # ABSTRACT: Return the Chinese zodiac animal for a given year.
 
+use strict;
 use DDG::Goodie;
 with 'DDG::GoodieRole::Dates';
 use DateTime::Calendar::Chinese;

--- a/lib/DDG/Goodie/Coin.pm
+++ b/lib/DDG/Goodie/Coin.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Coin;
 # ABSTRACT: flip a (fair) coin.
 
+use strict;
 use DDG::Goodie;
 
 zci is_cached => 0;

--- a/lib/DDG/Goodie/ColorCodes.pm
+++ b/lib/DDG/Goodie/ColorCodes.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::ColorCodes;
 # ABSTRACT: Copious information about various ways ofencoding colors.
 
+use strict;
 use DDG::Goodie;
 
 use Color::Library;

--- a/lib/DDG/Goodie/Combination.pm
+++ b/lib/DDG/Goodie/Combination.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Combination;
 # ABSTRACT: Compute combinations and permutations
 
+use strict;
 use DDG::Goodie;
 with 'DDG::GoodieRole::NumberStyler';
 

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Conversions;
 # ABSTRACT: convert between various units of measurement
 
+use strict;
 use DDG::Goodie;
 with 'DDG::GoodieRole::NumberStyler';
 

--- a/lib/DDG/Goodie/ConvertLatLon.pm
+++ b/lib/DDG/Goodie/ConvertLatLon.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::ConvertLatLon;
 # ABSTRACT: Convert between latitudes and longitudes expressed in degrees of arc and decimal
 
+use strict;
 use DDG::Goodie;
 use utf8;
 use Geo::Coordinates::DecimalDegrees;

--- a/lib/DDG/Goodie/CountryCodes.pm
+++ b/lib/DDG/Goodie/CountryCodes.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::CountryCodes;
 # ABSTRACT: Matches country names to ISO 3166 codes and vice versa
 
+use strict;
 use DDG::Goodie;
 use Locale::Country qw/country2code code2country/;
 

--- a/lib/DDG/Goodie/CrontabCheatSheet.pm
+++ b/lib/DDG/Goodie/CrontabCheatSheet.pm
@@ -1,8 +1,7 @@
 package DDG::Goodie::CrontabCheatSheet;
 # ABSTRACT: Some examples of crontab syntax
 
-# Adapted from VimCheatSheet.pm
-
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "cron_cheat";

--- a/lib/DDG/Goodie/CryptHashCheck.pm
+++ b/lib/DDG/Goodie/CryptHashCheck.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::CryptHashCheck;
 # ABSTRACT: Identifies cryptographic hash type.
 
+use strict;
 use DDG::Goodie;
 
 # A comprehensive reference for hashing functions from Wikipedia.

--- a/lib/DDG/Goodie/CurrencyIn.pm
+++ b/lib/DDG/Goodie/CurrencyIn.pm
@@ -17,6 +17,7 @@ package DDG::Goodie::CurrencyIn;
 # currency in Russia
 # What type of currency do I need for Russia?
 
+use strict;
 use DDG::Goodie;
 use Locale::SubCountry;
 

--- a/lib/DDG/Goodie/Cusip.pm
+++ b/lib/DDG/Goodie/Cusip.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Cusip;
 # ABSTRACT: Validate a CUSIP ID's check digit.
 
+use strict;
 use DDG::Goodie;
 use Business::CUSIP;
 

--- a/lib/DDG/Goodie/DHL.pm
+++ b/lib/DDG/Goodie/DHL.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::DHL;
 # ABSTRACT: track a package through DHL.
 
+use strict;
 use DDG::Goodie;
 
 zci is_cached => 1;

--- a/lib/DDG/Goodie/DateMath.pm
+++ b/lib/DDG/Goodie/DateMath.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::DateMath;
 # ABSTRACT: add/subtract days/weeks/months/years to/from a date
 
+use strict;
 use DDG::Goodie;
 with 'DDG::GoodieRole::Dates';
 use DateTime::Duration;

--- a/lib/DDG/Goodie/DaysBetween.pm
+++ b/lib/DDG/Goodie/DaysBetween.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::DaysBetween;
 # ABSTRACT: Give the number of days between two given dates.
 
+use strict;
 use DDG::Goodie;
 with 'DDG::GoodieRole::Dates';
 

--- a/lib/DDG/Goodie/Dessert.pm
+++ b/lib/DDG/Goodie/Dessert.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Dessert;
 # ABSTRACT: find desserts starting with a given letter.
 
+use strict;
 use DDG::Goodie;
 use utf8;
 use warnings;

--- a/lib/DDG/Goodie/Dewey.pm
+++ b/lib/DDG/Goodie/Dewey.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Dewey;
 # ABSTRACT: Identify and find dewey decimal system numbers
 
+use strict;
 use DDG::Goodie;
 
 triggers any => 'dewey';

--- a/lib/DDG/Goodie/Dice.pm
+++ b/lib/DDG/Goodie/Dice.pm
@@ -2,6 +2,7 @@ package DDG::Goodie::Dice;
 # ABSTRACT: roll a number of (abstract) dice.
 # https://en.wikipedia.org/wiki/Dice_notation
 
+use strict;
 use DDG::Goodie;
 
 triggers start => "roll", "throw";

--- a/lib/DDG/Goodie/DuckDuckGo.pm
+++ b/lib/DDG/Goodie/DuckDuckGo.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::DuckDuckGo;
 # ABSTRACT: Return hard-coded descriptions for DuckDuckGo terms
 
+use strict;
 use DDG::Goodie;
 
 use YAML qw( Load );

--- a/lib/DDG/Goodie/EmToPx.pm
+++ b/lib/DDG/Goodie/EmToPx.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::EmToPx;
 # ABSTRACT: em <-> px for font sizes.
 
+use strict;
 use DDG::Goodie;
 
 triggers any => "em", "px";

--- a/lib/DDG/Goodie/EmailValidator.pm
+++ b/lib/DDG/Goodie/EmailValidator.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::EmailValidator;
 # ABSTRACT: Checks given email address
 
+use strict;
 use DDG::Goodie;
 use Email::Valid;
 

--- a/lib/DDG/Goodie/FIGlet.pm
+++ b/lib/DDG/Goodie/FIGlet.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::FIGlet;
 # ABSTRACT: Uses FIGlet to make large letters out of ordinary text.
 
+use strict;
 use utf8;
 use DDG::Goodie;
 use Text::FIGlet;

--- a/lib/DDG/Goodie/Factors.pm
+++ b/lib/DDG/Goodie/Factors.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Factors;
 # ABSTRACT: Returns the factors of the entered number
 
+use strict;
 use DDG::Goodie;
 
 use Math::Prime::Util 'divisors';

--- a/lib/DDG/Goodie/FedEx.pm
+++ b/lib/DDG/Goodie/FedEx.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::FedEx;
 # ABSTRACT: Track a package through FedEx
 
+use strict;
 use DDG::Goodie;
 
 zci is_cached => 1;

--- a/lib/DDG/Goodie/FlipText.pm
+++ b/lib/DDG/Goodie/FlipText.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::FlipText;
 # ABSTRACT: appear to flip text upside down via UNICODE.
 
+use strict;
 use DDG::Goodie;
 
 use Text::UpsideDown;

--- a/lib/DDG/Goodie/Fortune.pm
+++ b/lib/DDG/Goodie/Fortune.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Fortune;
 # ABSTRACT: UNIX fortune quips.
 
+use strict;
 use DDG::Goodie;
 use Fortune;
 

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Frequency;
 # ABSTRACT: Displays frequency of alphabet character (a-z)
 
+use strict;
 use DDG::Goodie;
 
 triggers start => 'frequency', 'freq';

--- a/lib/DDG/Goodie/GUID.pm
+++ b/lib/DDG/Goodie/GUID.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::GUID;
 # ABSTRACT: Generated a GUID on-demand.
 
+use strict;
 use DDG::Goodie;
 use Data::GUID;
 

--- a/lib/DDG/Goodie/GenerateMAC.pm
+++ b/lib/DDG/Goodie/GenerateMAC.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::GenerateMAC;
 # ABSTRACT: generates a random network MAC address
 
+use strict;
 use DDG::Goodie;
 
 triggers startend => "generate mac addr",

--- a/lib/DDG/Goodie/GimpCheatSheet.pm
+++ b/lib/DDG/Goodie/GimpCheatSheet.pm
@@ -1,8 +1,7 @@
 package DDG::Goodie::GimpCheatSheet;
 # ABSTRACT: Some GIMP keyboard and mouse shortcuts
 
-# Adapted from CrontabCheatSheet.pm
-
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "gimp_cheat";

--- a/lib/DDG/Goodie/GoldenRatio.pm
+++ b/lib/DDG/Goodie/GoldenRatio.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::GoldenRatio;
 # ABSTRACT: find number related to the given number by the Golden Ratio.
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "golden_ratio";

--- a/lib/DDG/Goodie/GreatestCommonFactor.pm
+++ b/lib/DDG/Goodie/GreatestCommonFactor.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::GreatestCommonFactor;
 # ABSTRACT: Returns the greatest common factor of the two numbers entered
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "greatest_common_factor";

--- a/lib/DDG/Goodie/HKDK.pm
+++ b/lib/DDG/Goodie/HKDK.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::HKDK;
 # ABSTRACT: Track a package through HKDK.
 
+use strict;
 use DDG::Goodie;
 
 zci is_cached => 1;

--- a/lib/DDG/Goodie/HTMLEntitiesDecode.pm
+++ b/lib/DDG/Goodie/HTMLEntitiesDecode.pm
@@ -2,6 +2,7 @@ package DDG::Goodie::HTMLEntitiesDecode;
 # ABSTRACT: Decode HTML Entities.
 # HTML Entity Encoding has been moved to a separate module
 
+use strict;
 use DDG::Goodie;
 use HTML::Entities 'decode_entities';
 use Unicode::UCD 'charinfo';

--- a/lib/DDG/Goodie/HTMLEntitiesEncode.pm
+++ b/lib/DDG/Goodie/HTMLEntitiesEncode.pm
@@ -1,9 +1,9 @@
 package DDG::Goodie::HTMLEntitiesEncode;
 # ABSTRACT: Displays the HTML entity code for the query name.
 
-use DDG::Goodie;
 use strict;
 use warnings;
+use DDG::Goodie;
 
 # '&' and ';' not included in the hash value -- they are added in make_text() and make_html()
 my %codes = (

--- a/lib/DDG/Goodie/HelpLine.pm
+++ b/lib/DDG/Goodie/HelpLine.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::HelpLine;
 # ABSTRACT: Provide localized suicide intervention phone numbers.
 
+use strict;
 use DDG::Goodie;
 
 use YAML::XS qw( Load );

--- a/lib/DDG/Goodie/HexToASCII.pm
+++ b/lib/DDG/Goodie/HexToASCII.pm
@@ -2,8 +2,8 @@ package DDG::Goodie::HexToASCII;
 # ABSTRACT: Returns the ASCII representaion of a given hexadecimal value. (If printbale of course).
 
 use strict;
-
 use DDG::Goodie;
+
 # Used to restrict long generated outputs
 use constant MAX_INPUT_CHARS => 128;
 

--- a/lib/DDG/Goodie/HexToDec.pm
+++ b/lib/DDG/Goodie/HexToDec.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::HexToDec;
 # ABSTRACT: Convert hexidecimal to decimal
 
+use strict;
 use DDG::Goodie;
 use Math::BigInt;
 

--- a/lib/DDG/Goodie/Hiragana.pm
+++ b/lib/DDG/Goodie/Hiragana.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Hiragana;
 # ABSTRACT: converts romaji syllables into hiragana
 
+use strict;
 use DDG::Goodie;
 triggers startend =>'japanese hiragana','hiragana', 'hiragana japanese';
 zci answer_type => 'hiragana';

--- a/lib/DDG/Goodie/IDN.pm
+++ b/lib/DDG/Goodie/IDN.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IDN;
 # ABSTRACT: Convert domain names from/to Punycode.
 
+use strict;
 use DDG::Goodie;
 use Net::IDN::Encode ':all';
 use utf8;

--- a/lib/DDG/Goodie/IPS.pm
+++ b/lib/DDG/Goodie/IPS.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IPS;
 # ABSTRACT: track a package through IPS.
 
+use strict;
 use DDG::Goodie;
 
 zci is_cached => 1;

--- a/lib/DDG/Goodie/ISO639.pm
+++ b/lib/DDG/Goodie/ISO639.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::ISO639;
 # ABSTRACT: ISO 639 language names and codes
 
+use strict;
 use DDG::Goodie;
 use Locale::Language;
 

--- a/lib/DDG/Goodie/IndependenceDay.pm
+++ b/lib/DDG/Goodie/IndependenceDay.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IndependenceDay;
 # ABSTRACT: Goodie answer for different countries' national independence days
 
+use strict;
 use DDG::Goodie;
 use JSON;
 use utf8;

--- a/lib/DDG/Goodie/IsAwesome/TheAdamGalloway.pm
+++ b/lib/DDG/Goodie/IsAwesome/TheAdamGalloway.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IsAwesome::TheAdamGalloway;
 # ABSTRACT: TheAdamGalloway's first Goodie
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "is_awesome_the_adam_galloway";

--- a/lib/DDG/Goodie/IsAwesome/tarun29061990.pm
+++ b/lib/DDG/Goodie/IsAwesome/tarun29061990.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IsAwesome::tarun29061990;
 # ABSTRACT: tarun29061990's first Goodie
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "is_awesome_tarun29061990";

--- a/lib/DDG/Goodie/IsAwesome/thejdeep.pm
+++ b/lib/DDG/Goodie/IsAwesome/thejdeep.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IsAwesome::thejdeep;
 # ABSTRACT: thejdeep's first Goodie !
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "is_awesome_thejdeep";

--- a/lib/DDG/Goodie/IsAwesome/valnermedeiros.pm
+++ b/lib/DDG/Goodie/IsAwesome/valnermedeiros.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IsAwesome::valnermedeiros;
 # ABSTRACT: valnermedeiros's first Goodie
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "is_awesome_valnermedeiros";

--- a/lib/DDG/Goodie/IsAwesome/vedantham.pm
+++ b/lib/DDG/Goodie/IsAwesome/vedantham.pm
@@ -1,5 +1,6 @@
 package DDG::Goodie::IsAwesome::vedantham;
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "is_awesome_vedantham";

--- a/lib/DDG/Goodie/IsAwesome/watermelonwarrior.pm
+++ b/lib/DDG/Goodie/IsAwesome/watermelonwarrior.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IsAwesome::watermelonwarrior;
 # ABSTRACT: Watermelonwarrior's first Goodie
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "is_awesome_watermelonwarrior";

--- a/lib/DDG/Goodie/IsAwesome/xinhhuynh.pm
+++ b/lib/DDG/Goodie/IsAwesome/xinhhuynh.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IsAwesome::xinhhuynh;
 # ABSTRACT: xinhhuynh's first goodie.
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "is_awesome_xinhhuynh";

--- a/lib/DDG/Goodie/IsAwesome/ymzong.pm
+++ b/lib/DDG/Goodie/IsAwesome/ymzong.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IsAwesome::ymzong;
 # ABSTRACT: ymzong's first Goodie!
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "is_awesome_ymzong";

--- a/lib/DDG/Goodie/IsAwesome/zekiel.pm
+++ b/lib/DDG/Goodie/IsAwesome/zekiel.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IsAwesome::zekiel;
 # ABSTRACT: A simple goodie by zekiel
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "is_awesome_zekiel";

--- a/lib/DDG/Goodie/IsAwesome/zhou.pm
+++ b/lib/DDG/Goodie/IsAwesome/zhou.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IsAwesome::zhou;
 # ABSTRACT: zhou's first Goodie
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "is_awesome_zhou";

--- a/lib/DDG/Goodie/Jira.pm
+++ b/lib/DDG/Goodie/Jira.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Jira;
 # ABSTRACT: returns the URL of an Apache or Codehaus JIRA bug ticket according to its identifier
 
+use strict;
 use DDG::Goodie;
 use utf8;
 

--- a/lib/DDG/Goodie/JsKeycodes.pm
+++ b/lib/DDG/Goodie/JsKeycodes.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::JsKeycodes;
 # ABSTRACT: Give the equivalent JavaScript Keycode.
 
+use strict;
 use DDG::Goodie;
 
 triggers any => 'keycode', 'keycodes', 'char', 'chars', 'charcode', 'charcodes';

--- a/lib/DDG/Goodie/KernelTaint.pm
+++ b/lib/DDG/Goodie/KernelTaint.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::KernelTaint;
 # ABSTRACT: Parses and explains the OR'd values of /proc/sys/kernel/tainted
 
+use strict;
 use DDG::Goodie;
 
 primary_example_queries 'kernel taint 5121', 'kernel taint description 2';

--- a/lib/DDG/Goodie/LaserShip.pm
+++ b/lib/DDG/Goodie/LaserShip.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::LaserShip;
 # ABSTRACT: Track a package through Lasership
 
+use strict;
 use DDG::Goodie;
 
 zci is_cached => 1;

--- a/lib/DDG/Goodie/Latex.pm
+++ b/lib/DDG/Goodie/Latex.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Latex;
 # ABSTRACT: Show the Latex command for a keyword
 
+use strict;
 use DDG::Goodie;
 
 triggers startend => 'latex', 'tex';

--- a/lib/DDG/Goodie/LeapYear.pm
+++ b/lib/DDG/Goodie/LeapYear.pm
@@ -1,8 +1,8 @@
 package DDG::Goodie::LeapYear;
 # ABSTRACT: Check if a year is leap year
 
+use strict;
 use DDG::Goodie;
-
 use Date::Leapyear;
 
 zci answer_type => "leap_year";

--- a/lib/DDG/Goodie/LeetSpeak.pm
+++ b/lib/DDG/Goodie/LeetSpeak.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::LeetSpeak;
 # ABSTRACT: Translate the query into leet speak.
 
+use strict;
 use DDG::Goodie;
 
 triggers startend => 'leetspeak', 'l33tsp34k', 'l33t', 'leet speak', 'l33t sp34k';

--- a/lib/DDG/Goodie/Loan.pm
+++ b/lib/DDG/Goodie/Loan.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Loan;
 # ABSTRACT: Calculate monthly payment and total interest payment for a conventional mortgage loan
 
+use strict;
 use DDG::Goodie;
 use Locale::Currency::Format;
 

--- a/lib/DDG/Goodie/Lowercase.pm
+++ b/lib/DDG/Goodie/Lowercase.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Lowercase;
 # ABSTRACT: Convert a string into lowercase.
 
+use strict;
 use DDG::Goodie;
 
 name "Lowercase";

--- a/lib/DDG/Goodie/MD5.pm
+++ b/lib/DDG/Goodie/MD5.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::MD5;
 # ABSTRACT: Calculate the MD5 digest of a string.
 
+use strict;
 use utf8;
 use DDG::Goodie;
 use Digest::MD5 qw(md5_base64 md5_hex);

--- a/lib/DDG/Goodie/MacAddress.pm
+++ b/lib/DDG/Goodie/MacAddress.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::MacAddress;
 # ABSTRACT: Vendor information lookup for MAC addresses
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "mac_address";

--- a/lib/DDG/Goodie/MakeMeASandwich.pm
+++ b/lib/DDG/Goodie/MakeMeASandwich.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::MakeMeASandwich;
 # ABSTRACT: XKCD #149 Easter Egg
 
+use strict;
 use DDG::Goodie;
 
 name 'Make Me A Sandwich';

--- a/lib/DDG/Goodie/MarkdownCheatSheet.pm
+++ b/lib/DDG/Goodie/MarkdownCheatSheet.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::MarkdownCheatSheet;
 # ABSTRACT: Provide a cheatsheet for common Markdown syntax
 
+use strict;
 use DDG::Goodie;
 use HTML::Entities;
 

--- a/lib/DDG/Goodie/Meta.pm
+++ b/lib/DDG/Goodie/Meta.pm
@@ -1,5 +1,6 @@
 package DDG::Goodie::Meta;
 
+use strict;
 use DDG::Goodie;
 
 triggers start => "///***never trigger***///";

--- a/lib/DDG/Goodie/Minecraft.pm
+++ b/lib/DDG/Goodie/Minecraft.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Minecraft;
 # ABSTRACT: Minecraft crafting recipes.
 
+use strict;
 use DDG::Goodie;
 use JSON;
 use utf8;

--- a/lib/DDG/Goodie/MoonPhases.pm
+++ b/lib/DDG/Goodie/MoonPhases.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::MoonPhases;
 # ABSTRACT: answer queries for the current phase of the moon.
 
+use strict;
 use DDG::Goodie;
 use Astro::MoonPhase;
 

--- a/lib/DDG/Goodie/Morse.pm
+++ b/lib/DDG/Goodie/Morse.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Morse;
 # ABSTRACT: Converts to/from Morse code
 
+use strict;
 use DDG::Goodie;
 use Convert::Morse qw(is_morse as_ascii as_morse);
 

--- a/lib/DDG/Goodie/NLetterWords.pm
+++ b/lib/DDG/Goodie/NLetterWords.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::NLetterWords;
 # ABSTRACT: find words of a certain length
 
+use strict;
 use DDG::Goodie;
 use Lingua::EN::Numericalize;
 

--- a/lib/DDG/Goodie/POTUS.pm
+++ b/lib/DDG/Goodie/POTUS.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::POTUS;
 # ABSTRACT: Returns requested President of the United States
 
+use strict;
 use DDG::Goodie;
 use Lingua::EN::Numbers::Ordinate qw(ordsuf ordinate);
 use Lingua::EN::Words2Nums;

--- a/lib/DDG/Goodie/Palindrome.pm
+++ b/lib/DDG/Goodie/Palindrome.pm
@@ -2,6 +2,7 @@ package DDG::Goodie::Palindrome;
 # ABSTRACT: Return if the a string is a palindrome, formatted requests:
 #    'is <string> a[n] palindrome[?]' or 'isPalindrome <string>'
 
+use strict;
 use DDG::Goodie;
 
 triggers any => 'palindrome';

--- a/lib/DDG/Goodie/Paper.pm
+++ b/lib/DDG/Goodie/Paper.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Paper;
 # ABSTRACT: Return the dimensions of a defined paper size
 
+use strict;
 use DDG::Goodie;
 use YAML;
 

--- a/lib/DDG/Goodie/Parcelforce.pm
+++ b/lib/DDG/Goodie/Parcelforce.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Parcelforce;
 # ABSTRACT: track a package through Parcelforce.
 
+use strict;
 use DDG::Goodie;
 
 zci is_cached   => 1;

--- a/lib/DDG/Goodie/Passphrase.pm
+++ b/lib/DDG/Goodie/Passphrase.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Passphrase;
 # ABSTRACT: Randomly generate a passphrase with the selected number of words.
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => 'random_passphrase';

--- a/lib/DDG/Goodie/Password.pm
+++ b/lib/DDG/Goodie/Password.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Password;
 # ABSTRACT: Generate a random password.
 
+use strict;
 use DDG::Goodie;
 
 use List::MoreUtils qw( none );

--- a/lib/DDG/Goodie/PercentError.pm
+++ b/lib/DDG/Goodie/PercentError.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::PercentError;
 # ABSTRACT: find the percent error given accepted and experimental values
 
+use strict;
 use DDG::Goodie;
 
 triggers start => "percent error", "% error", "%err", "%error", "percenterror", "percent err", "%-error";

--- a/lib/DDG/Goodie/PercentOf.pm
+++ b/lib/DDG/Goodie/PercentOf.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::PercentOf;
-# Operations with percentuals
+# ABSTRACT: Operations with percentuals
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "percent_of";

--- a/lib/DDG/Goodie/Perimeter.pm
+++ b/lib/DDG/Goodie/Perimeter.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Perimeter;
 # ABSTRACT: Compute the perimeter of basic shapes.
 
+use strict;
 use DDG::Goodie;
 
 triggers start => "perimeter", "circumference";

--- a/lib/DDG/Goodie/PeriodicTable.pm
+++ b/lib/DDG/Goodie/PeriodicTable.pm
@@ -1,7 +1,7 @@
 package DDG::Goodie::PeriodicTable;
-
 # ABSTRACT: Atomic masses and numbers for chemical elements
 
+use strict;
 use DDG::Goodie;
 use YAML::XS qw(Load);
 use List::Util qw(first);

--- a/lib/DDG/Goodie/PhoneAlphabet.pm
+++ b/lib/DDG/Goodie/PhoneAlphabet.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::PhoneAlphabet;
 # ABSTRACT: Taking a phone number with letters in it and returning the phone number
 
+use strict;
 use POSIX;
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/Phonetic.pm
+++ b/lib/DDG/Goodie/Phonetic.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Phonetic;
 # ABSTRACT: Take a string and spell it out phonetically using the NATO alphabet
 
+use strict;
 use DDG::Goodie;
 
 triggers start => 'phonetic';

--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::PigLatin;
 # ABSTRACT: convert a given string to pig latin
 
+use strict;
 use DDG::Goodie;
 use Lingua::PigLatin 'piglatin';
 

--- a/lib/DDG/Goodie/Poker.pm
+++ b/lib/DDG/Goodie/Poker.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Poker;
 # ABSTRACT: Returns requested statistic for the requested poker hand
 
+use strict;
 use DDG::Goodie;
 
 triggers any => 'poker';

--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::PrimeFactors;
 # ABSTRACT: Returns all the prime factors of the entered number
 
+use strict;
 use DDG::Goodie;
 
 use Math::Prime::Util 'factor_exp', 'is_prime';

--- a/lib/DDG/Goodie/PrivateNetwork.pm
+++ b/lib/DDG/Goodie/PrivateNetwork.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::PrivateNetwork;
 # ABSTRACT: show non-Internet routable IP addresses.
 
+use strict;
 use DDG::Goodie;
 
 triggers start => "private network", "private ip", "private networks", "private ips";

--- a/lib/DDG/Goodie/PublicDNS.pm
+++ b/lib/DDG/Goodie/PublicDNS.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::PublicDNS;
 # ABSTRACT: Display a list of DNS servers which accept public queries.
 
+use strict;
 use DDG::Goodie;
 
 use List::Util qw(max);

--- a/lib/DDG/Goodie/Rafl.pm
+++ b/lib/DDG/Goodie/Rafl.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Rafl;
 # ABSTRACT: rafl is so everywhere, there's a DuckDuckGo.com "!rafl" bang syntax
 
+use strict;
 use DDG::Goodie;
 
 use Acme::rafl::Everywhere;

--- a/lib/DDG/Goodie/Randagram.pm
+++ b/lib/DDG/Goodie/Randagram.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Randagram;
 # ABSTRACT: Take a query and spit it out randomly.
 
+use strict;
 use DDG::Goodie;
 use List::Util 'shuffle';
 

--- a/lib/DDG/Goodie/RandomName.pm
+++ b/lib/DDG/Goodie/RandomName.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::RandomName;
 # ABSTRACT: Return random first and last name
 
+use strict;
 use DDG::Goodie;
 
 use Data::RandomPerson;

--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::RandomNumber;
 # ABSTRACT: generate a random number in the requested range.
 
+use strict;
 use DDG::Goodie;
 
 primary_example_queries 'random number between 1 and 12', 'random number';

--- a/lib/DDG/Goodie/Regexp.pm
+++ b/lib/DDG/Goodie/Regexp.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Regexp;
 # ABSTRACT: Parse a regexp.
 
+use strict;
 use DDG::Goodie;
 
 use Safe;

--- a/lib/DDG/Goodie/ResistorColors.pm
+++ b/lib/DDG/Goodie/ResistorColors.pm
@@ -8,6 +8,7 @@ package DDG::Goodie::ResistorColors;
 # - show surface mount resistor markings
 # - detect if query contains tolerance (e.g. 10%) and use appropriate color
 
+use strict;
 use DDG::Goodie;
 use Math::Round;
 use POSIX qw(abs floor log10 pow);

--- a/lib/DDG/Goodie/Reverse.pm
+++ b/lib/DDG/Goodie/Reverse.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Reverse;
 # ABSTRACT: Reverse the order of chars in the remainder
 
+use strict;
 use DDG::Goodie;
 
 primary_example_queries 'reverse text esrever';

--- a/lib/DDG/Goodie/ReverseComplement.pm
+++ b/lib/DDG/Goodie/ReverseComplement.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::ReverseComplement;
 # ABSTRACT: Give the DNA reverse complement of a DNA or RNA sequence.
 
+use strict;
 use DDG::Goodie;
 use feature 'state';
 

--- a/lib/DDG/Goodie/ReverseResistorColours.pm
+++ b/lib/DDG/Goodie/ReverseResistorColours.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::ReverseResistorColours;
 #ABSTRACT: Do the reverse of what ResistorColors.pm does.
 
+use strict;
 use DDG::Goodie;
 use utf8;
 

--- a/lib/DDG/Goodie/Roman.pm
+++ b/lib/DDG/Goodie/Roman.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Roman;
 # ABSTRACT: Convert between Roman and Arabic numeral systems.
 
+use strict;
 use DDG::Goodie;
 
 use Roman;

--- a/lib/DDG/Goodie/Rot13.pm
+++ b/lib/DDG/Goodie/Rot13.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Rot13;
 # ABSTRACT: Rotate chars by 13  letters
 
+use strict;
 use DDG::Goodie;
 
 primary_example_queries 'rot13 thirteen';

--- a/lib/DDG/Goodie/RouterPasswords.pm
+++ b/lib/DDG/Goodie/RouterPasswords.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::RouterPasswords;
 # ABSTRACT: Return default passwords forvarious routers.
 
+use strict;
 use DDG::Goodie;
 
 primary_example_queries 'belkin f5d6130 default password';

--- a/lib/DDG/Goodie/RubiksCubePatterns.pm
+++ b/lib/DDG/Goodie/RubiksCubePatterns.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::RubiksCubePatterns;
 # ABSTRACT: Create interesting patterns from a solved Rubik's Cube.
 
+use strict;
 use DDG::Goodie;
 
 

--- a/lib/DDG/Goodie/Sha.pm
+++ b/lib/DDG/Goodie/Sha.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Sha;
 # ABSTRACT: Compute a SHA sum for a provided string.
 
+use strict;
 use DDG::Goodie;
 use Digest::SHA;
 

--- a/lib/DDG/Goodie/Shortcut.pm
+++ b/lib/DDG/Goodie/Shortcut.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Shortcut;
 # ABSTRACT: Display keyboard shortcut for an action.
 
+use strict;
 use DDG::Goodie;
 use utf8;
 

--- a/lib/DDG/Goodie/SigFigs.pm
+++ b/lib/DDG/Goodie/SigFigs.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::SigFigs;
 # ABSTRACT: Count the significant figures in a number.
 
+use strict;
 use DDG::Goodie;
 
 primary_example_queries 'sigfigs 01.1234000';

--- a/lib/DDG/Goodie/SumOfNaturalNumbers.pm
+++ b/lib/DDG/Goodie/SumOfNaturalNumbers.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::SumOfNaturalNumbers;
 # ABSTRACT: Returns the sum of the numbers between the first and second provided integers
 
+use strict;
 use DDG::Goodie;
 use bignum;
 

--- a/lib/DDG/Goodie/SunInfo.pm
+++ b/lib/DDG/Goodie/SunInfo.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::SunInfo;
 # ABSTRACT: sunrise and sunset information for the client location
 
+use strict;
 use DDG::Goodie;
 with 'DDG::GoodieRole::Dates';
 with 'DDG::GoodieRole::ImageLoader';

--- a/lib/DDG/Goodie/Teredo.pm
+++ b/lib/DDG/Goodie/Teredo.pm
@@ -3,6 +3,7 @@ package DDG::Goodie::Teredo;
 # NAT IPv4 address, and port number encoded in a given
 # Teredo tunnel IPv6 address.
 
+use strict;
 use DDG::Goodie;
 use Net::IP;
 use Math::BaseConvert;

--- a/lib/DDG/Goodie/Tips.pm
+++ b/lib/DDG/Goodie/Tips.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Tips;
 # ABSTRACT: calculate a tip on a bill
 
+use strict;
 use DDG::Goodie;
 with 'DDG::GoodieRole::NumberStyler';
 

--- a/lib/DDG/Goodie/TitleCase.pm
+++ b/lib/DDG/Goodie/TitleCase.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::TitleCase;
 # ABSTRACT: Convert a string to title case.
 
+use strict;
 use DDG::Goodie;
 
 triggers start => 'titlecase', 'title case';

--- a/lib/DDG/Goodie/TmuxCheatSheet.pm
+++ b/lib/DDG/Goodie/TmuxCheatSheet.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::TmuxCheatSheet;
 # ABSTRACT: Provide a cheatsheet for common tmux commands
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => 'tmux_cheat';

--- a/lib/DDG/Goodie/TwelveOclock.pm
+++ b/lib/DDG/Goodie/TwelveOclock.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::TwelveOclock;
 # ABSTRACT: Determine whether 12:00 is midnight or noon.
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "twelve_oclock";

--- a/lib/DDG/Goodie/UN.pm
+++ b/lib/DDG/Goodie/UN.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::UN;
 # ABSTRACT: Gives a description for a given UN number
 
+use strict;
 use DDG::Goodie;
 use Number::UN 'get_un';
 

--- a/lib/DDG/Goodie/UPS.pm
+++ b/lib/DDG/Goodie/UPS.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::UPS;
 # ABSTRACT: Track a package through United Parcel Service.
 
+use strict;
 use DDG::Goodie;
 
 zci is_cached => 1;

--- a/lib/DDG/Goodie/USPS.pm
+++ b/lib/DDG/Goodie/USPS.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::USPS;
 # ABSTRACT: Track a package through the US postal service.
 
+use strict;
 use DDG::Goodie;
 
 zci is_cached => 1;

--- a/lib/DDG/Goodie/UltimateAnswer.pm
+++ b/lib/DDG/Goodie/UltimateAnswer.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::UltimateAnswer;
 # ABSTRACT: A Hitchhiker's Guide to the Galaxy easter egg.
 
+use strict;
 use DDG::Goodie;
 triggers start => 'what is the ultimate answer', 'what is the ultimate answer to life the universe and everything', 'what is the answer to the ultimate question of life the universe and everything';
 

--- a/lib/DDG/Goodie/Unicode.pm
+++ b/lib/DDG/Goodie/Unicode.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Unicode;
 # ABSTRACT: unicode character information lookup
 
+use strict;
 use DDG::Goodie;
 
 use Unicode::UCD qw/charinfo/;

--- a/lib/DDG/Goodie/UnicodeFuzzySearch.pm
+++ b/lib/DDG/Goodie/UnicodeFuzzySearch.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::UnicodeFuzzySearch;
 # ABSTRACT: returns unicode symbols matching the input
 
+use strict;
 use DDG::Goodie;
 use URI::Escape::XS;
 

--- a/lib/DDG/Goodie/Unicornify.pm
+++ b/lib/DDG/Goodie/Unicornify.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Unicornify;
 # ABSTRACT: Return Gravatar image given an email address
 
+use strict;
 use DDG::Goodie;
 use CGI qw/img/;
 use Email::Valid;

--- a/lib/DDG/Goodie/Unidecode.pm
+++ b/lib/DDG/Goodie/Unidecode.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Unidecode;
 # ABSTRACT: return an ASCII version of the search query
 
+use strict;
 use DDG::Goodie;
 use Text::Unidecode;
 use utf8;

--- a/lib/DDG/Goodie/UnixTime.pm
+++ b/lib/DDG/Goodie/UnixTime.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::UnixTime;
 # ABSTRACT: epoch -> human readable time
 
+use strict;
 use DDG::Goodie;
 
 use DateTime;

--- a/lib/DDG/Goodie/Uppercase.pm
+++ b/lib/DDG/Goodie/Uppercase.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Uppercase;
 # ABSTRACT: uppercase a provided string.
 
+use strict;
 use DDG::Goodie;
 
 triggers start => 'uppercase', 'upper case', 'allcaps', 'all caps', 'strtoupper', 'toupper';

--- a/lib/DDG/Goodie/Uptime.pm
+++ b/lib/DDG/Goodie/Uptime.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::Uptime;
 # Given an uptime percentage, display various average downtime durations 
 
+use strict;
 use DDG::Goodie;
 use Time::Duration;
 use Time::Seconds;

--- a/lib/DDG/Goodie/VIN.pm
+++ b/lib/DDG/Goodie/VIN.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::VIN;
 # ABSTRACT: extract information about vehicle identification numbers
 
+use strict;
 use DDG::Goodie;
 
 zci is_cached => 1;

--- a/lib/DDG/Goodie/ValarMorghulis.pm
+++ b/lib/DDG/Goodie/ValarMorghulis.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::ValarMorghulis;
 # ABSTRACT: A Game of Thrones / A Song of Ice and Fire easter egg.
 
+use strict;
 use utf8;
 use DDG::Goodie;
 

--- a/lib/DDG/Goodie/VimCheatSheet.pm
+++ b/lib/DDG/Goodie/VimCheatSheet.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::VimCheatSheet;
 # ABSTRACT: Provide a cheatsheet for common vim syntax
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "vim_cheat";

--- a/lib/DDG/Goodie/WhereAmI.pm
+++ b/lib/DDG/Goodie/WhereAmI.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::WhereAmI;
 # ABSTRACT: Display the user's perceived location from GeoIP
 
+use strict;
 use DDG::Goodie;
 
 zci is_cached => 0;

--- a/lib/DDG/Goodie/ZappBrannigan.pm
+++ b/lib/DDG/Goodie/ZappBrannigan.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::ZappBrannigan;
 # ABSTRACT: Zapp Brannigan quotes.
 
+use strict;
 use DDG::Goodie;
 
 use YAML::XS qw(Load);


### PR DESCRIPTION
This should force linguist to detect them as Perl 5 rather than 6 which will also fix the highlighting.

ref: https://github.com/github/linguist/issues/2149

cc @moollaza @jagtalon