### PR TITLE
Uppercase: Should not return if the input isn't upper-case-able

### DIFF
--- a/lib/DDG/Goodie/Uppercase.pm
+++ b/lib/DDG/Goodie/Uppercase.pm
@@ -28,6 +28,7 @@ handle remainder => sub {
     my $input = shift;
 
     return unless $input;
+    return if $input eq uc($input);
 
     my $upper = uc $input;
 

--- a/t/Uppercase.t
+++ b/t/Uppercase.t
@@ -36,6 +36,8 @@ ddg_goodie_test(
     ),
     'that string all caps'    => undef,
     'is this uppercase, sir?' => undef,
+    'uppercase HELLO'         => undef,
+    'uppercase 123'           => undef
 );
 
 done_testing;


### PR DESCRIPTION
Fixes: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/1028