### PR TITLE
Fix for Issue #951: missing diagram labels on the y-axis.

### DIFF
--- a/lib/DDG/Goodie/FrequencySpectrum.pm
+++ b/lib/DDG/Goodie/FrequencySpectrum.pm
@@ -583,7 +583,7 @@ sub add_major_range {
         'text-anchor' => $anchor,
         class => 'major_range_label'
     );
-    $majorRangeLabel->tag('tspan', -cdata => ucfirst($label));
+    $majorRangeLabelText->tag('tspan', -cdata => ucfirst($label));
 
     return $plot;
 }


### PR DESCRIPTION
This should show the frequency-range labels on the y-axis (#951). The corresponding tspan elements are now children of text elements instead of being their siblings in the SVG.