### PR TITLE
Show marker label at the top in FrequencySpectrum

### DIFF
--- a/lib/DDG/Goodie/FrequencySpectrum.pm
+++ b/lib/DDG/Goodie/FrequencySpectrum.pm
@@ -616,7 +616,7 @@ sub add_marker {
         'text-anchor' => 'middle',
         class => 'marker_label'
     );
-    $markerLabel->tag('tspan', id => 'marker_label', -cdata => ucfirst($freq_formatted));
+    $markerLabelText->tag('tspan', id => 'marker_label', -cdata => ucfirst($freq_formatted));
 
     #Add marker line
     $plot->{svg}->group(


### PR DESCRIPTION
This is a follow-up fix for #951. This bug didn't show up in duckpan because empty tags weren't recognized and rewritten. It's the same issue as for the y-axis labels.