### PR TITLE
Fix casing of 'suffix' argument for temp files in tests

### DIFF
--- a/t/00-roles.t
+++ b/t/00-roles.t
@@ -475,7 +475,7 @@ subtest 'ImageLoader' => sub {
             use MIME::Base64;
             with 'DDG::GoodieRole::ImageLoader';
             our $tmp_dir = Path::Class::tempdir(CLEANUP => 1);
-            our $tmp_file = file(($tmp_dir->tempfile(TEMPLATE => 'img_XXXXXX', suffix   => '.gif'))[1]);
+            our $tmp_file = file(($tmp_dir->tempfile(TEMPLATE => 'img_XXXXXX', SUFFIX => '.gif'))[1]);
             # Always return the same file for our purposes here.
             sub share     { $tmp_file }
             sub html_enc  { encode_entities(@_) }                                             # Deal with silly symbol table twiddling.


### PR DESCRIPTION
The role tests failed with Perl <5.17.10 installs, due to the used
File::Temp (<0.23) still caring about the casing of the
arguments. Newer versions of File::Temp no longer care about the
casing.

By uppercasing 'suffix' in the tests, we make the tests pass for both
Perl 5.16 and Perl 5.18.