### PR TITLE
Remove dynamic generation of .travis.yml from dzil

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 ---
+sudo: false
+addons:
+  apt_packages:
+    - libmpfr-dev
 before_install:
   - export HARNESS_OPTIONS=j10:c HARNESS_TIMER=1
-  - rm .travis.yml
   - git config --global user.name "Dist Zilla Plugin TravisCI"
   - git config --global user.email $HOSTNAME":not-for-mail@travis-ci.org"
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libmpfr-dev
 install:
   - cpanm  --quiet  --notest --skip-installed Dist::Zilla
   - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm  --quiet   --notest  --skip-installed

--- a/dist.ini
+++ b/dist.ini
@@ -137,12 +137,3 @@ tag_format = %v
 
 [Git::Push]
 push_to = origin master
-
-[TravisCI]
-perl_version = 5.16
-perl_version = 5.18
-extra_dep = App::DuckPAN
-extra_dep = autodie
-after_install = duckpan DDG
-before_install = sudo apt-get update -qq
-before_install = sudo apt-get install -y libmpfr-dev


### PR DESCRIPTION
* Remove the generation of .travis.yml from dzil.
* Add Travis container routing to .travis.yml so that we can hopefully speed things up and take advantage of caching.