### PR TITLE
Wavelength: Fix string interpolation in test

### DIFF
--- a/t/Wavelength.t
+++ b/t/Wavelength.t
@@ -37,7 +37,7 @@ sub mk_test {
         $expect,
         structured_answer => {
             input => [],
-            operation => "Wavelength of $freq_value $freq_units ($vf_text\Speed of light in a vacuum)",
+            operation => "Wavelength of $freq_value $freq_units (${vf_text}Speed of light in a vacuum)",
             result => $expect,
         }
     );


### PR DESCRIPTION
'\S' is not a valid escape and makes prove complain to stderr (though
the tests pass). Since it seems the '\S' got only introduced to
separate the variable from the word 'Speed', we proper separate them
by switching from the unrecognized escape to proper curly braces.