### PR TITLE
Chess960: Use HTML output provided by FenViewer

### DIFF
--- a/lib/DDG/Goodie/Chess960.pm
+++ b/lib/DDG/Goodie/Chess960.pm
@@ -3,7 +3,7 @@ package DDG::Goodie::Chess960;
 
 use strict;
 use DDG::Goodie;
-use DDG::Goodie::FenViewer qw(parse_position draw_chessboard_html draw_chessboard_ascii);
+with 'DDG::GoodieRole::Chess';
 
 triggers any => 'random', 'chess960';
 zci is_cached => 0;

--- a/lib/DDG/Goodie/FenViewer.pm
+++ b/lib/DDG/Goodie/FenViewer.pm
@@ -6,10 +6,8 @@ package DDG::Goodie::FenViewer;
 
 use DDG::Goodie;
 use strict;
-use Scalar::Util qw(looks_like_number);
 use Try::Tiny;
-use Exporter qw(import);
-our @EXPORT_OK = qw(parse_position draw_chessboard_html draw_chessboard_ascii);
+with 'DDG::GoodieRole::Chess';
 
 zci answer_type => "fen_viewer";
 zci is_cached   => 1;
@@ -25,119 +23,6 @@ attribution github => ["rouzbeh", "Ali Neishabouri"],
             twitter => "Rou7_beh";
 
 triggers start => "fen";
-
-# Parse the FEN string into an array of length 64.
-sub parse_position {
-    my ($i) = 0;
-    my ($position) = @_;
-    $position =~ s/^\s+|\s+$//g;
-    my (@cases) = ();
-    for (my $char = 0 ; $char < length($position) ; $char++ ) {
-        my $fenchar = substr($position, $char, 1);
-        if ($fenchar eq ' ') {
-            return @cases;
-        }
-        if (looks_like_number($fenchar)) {
-            for ($i = 0; $i < $fenchar; $i++){
-                push(@cases, 'e');
-            }
-        }
-        elsif ($fenchar ne '/') {
-            push(@cases, $fenchar);
-        }
-    }
-    return @cases;
-}
-
-# Generate a chessboard as a HTML table.
-sub draw_chessboard_html {
-    my (@position) = @_;
-    my ($i) = 0;
-    my ($j) = 0;
-    my ($counter) = 0;
-    my (@arr) = ("A".."Z");
-    my (%class_dict) = (
-        'r' => 'black rook',
-        'n' => 'black knight',
-        'b' => 'black bishop',
-        'q' => 'black queen',
-        'k' => 'black king',
-        'p' => 'black pawn',
-        'e' => 'empty',
-        'R' => 'white rook',
-        'N' => 'white knight',
-        'B' => 'white bishop',
-        'Q' => 'white queen',
-        'K' => 'white king',
-        'P' => 'white pawn',
-    );
-    
-    my (%unicode_dict) = (
-        'r' => '&#9820;',
-        'n' => '&#9822;',
-        'b' => '&#9821;',
-        'q' => '&#9819;',
-        'k' => '&#9818;',
-        'p' => '&#9823;',
-        'e' => '',
-        'R' => '&#9814;',
-        'N' => '&#9816;',
-        'B' => '&#9815;',
-        'Q' => '&#9813;',
-        'K' => '&#9812;',
-        'P' => '&#9817;',
-        );
-    
-    my ($html_chessboard) = '<div class="zci--fenviewer"><table class="chess_board" cellpadding="0" cellspacing="0">';
-    for ($i = 0; $i < 8; $i++){
-        # Rows
-        $html_chessboard .= '<tr>';
-        for ($j = 0; $j < 8; $j++){
-            # Columns
-            $html_chessboard .= '<td id="'.$arr[$j].(8-$i).'">';
-            $html_chessboard .= '<a href="#" class="'.$class_dict{$position[$counter]};
-            $html_chessboard .= '">'.$unicode_dict{$position[$counter]}.'</a>';
-            $html_chessboard .= '</td>';
-            $counter++;
-        }
-        $html_chessboard .= '</tr>';
-    }
-    $html_chessboard .= '</table></div>';
-    return $html_chessboard;
-}
-
-# Generate a chessboard in ASCII, with the same format as
-# 'text output from Chess::PGN::EPD
-sub draw_chessboard_ascii {
-    my (@position) = @_;
-    my ($i) = 0;
-    my ($j) = 0;
-    my ($counter) = 0;
-    my ($ascii_chessboard) = "";
-    for ($i = 0; $i < 8; $i++){
-        # Rows
-        for ($j = 0; $j < 8; $j++){
-            # Columns
-            if ($position[$counter] ne 'e') {
-                # Occupied square
-                $ascii_chessboard .= $position[$counter];
-            }
-            elsif ($j % 2 != $i % 2) {
-                # Black square
-                $ascii_chessboard .= '-';
-            }
-            else {
-                # White square
-                $ascii_chessboard .= ' ';
-            }
-            $counter++;
-        }
-        if($counter < 63) {
-            $ascii_chessboard .= "\n";
-        }
-    }
-    return $ascii_chessboard;
-}
 
 handle remainder => sub {
     my ($query) = $_;

--- a/lib/DDG/Goodie/FenViewer.pm
+++ b/lib/DDG/Goodie/FenViewer.pm
@@ -8,6 +8,8 @@ use DDG::Goodie;
 use strict;
 use Scalar::Util qw(looks_like_number);
 use Try::Tiny;
+use Exporter qw(import);
+our @EXPORT_OK = qw(parse_position draw_chessboard_html draw_chessboard_ascii);
 
 zci answer_type => "fen_viewer";
 zci is_cached   => 1;

--- a/lib/DDG/GoodieRole/Chess.pm
+++ b/lib/DDG/GoodieRole/Chess.pm
@@ -1,0 +1,123 @@
+package DDG::GoodieRole::Chess;
+# ABSTRACT: Helper function to parse a FEN string and draw a chessboard. 
+# We could in principle use Chess::PGN::EPD, but that module does not provide
+# the HTML output, so we just implement what we need and don't add a dependecny.
+
+use strict;
+use Scalar::Util qw(looks_like_number);
+use Moo::Role;
+
+# Parse the FEN string into an array of length 64.
+sub parse_position {
+    my ($i) = 0;
+    my ($position) = @_;
+    $position =~ s/^\s+|\s+$//g;
+    my (@cases) = ();
+    for (my $char = 0 ; $char < length($position) ; $char++ ) {
+        my $fenchar = substr($position, $char, 1);
+        if ($fenchar eq ' ') {
+            return @cases;
+        }
+        if (looks_like_number($fenchar)) {
+            for ($i = 0; $i < $fenchar; $i++){
+                push(@cases, 'e');
+            }
+        }
+        elsif ($fenchar ne '/') {
+            push(@cases, $fenchar);
+        }
+    }
+    return @cases;
+}
+
+# Generate a chessboard as a HTML table.
+sub draw_chessboard_html {
+    my (@position) = @_;
+    my ($i) = 0;
+    my ($j) = 0;
+    my ($counter) = 0;
+    my (@arr) = ("A".."Z");
+    my (%class_dict) = (
+        'r' => 'black rook',
+        'n' => 'black knight',
+        'b' => 'black bishop',
+        'q' => 'black queen',
+        'k' => 'black king',
+        'p' => 'black pawn',
+        'e' => 'empty',
+        'R' => 'white rook',
+        'N' => 'white knight',
+        'B' => 'white bishop',
+        'Q' => 'white queen',
+        'K' => 'white king',
+        'P' => 'white pawn',
+    );
+    
+    my (%unicode_dict) = (
+        'r' => '&#9820;',
+        'n' => '&#9822;',
+        'b' => '&#9821;',
+        'q' => '&#9819;',
+        'k' => '&#9818;',
+        'p' => '&#9823;',
+        'e' => '',
+        'R' => '&#9814;',
+        'N' => '&#9816;',
+        'B' => '&#9815;',
+        'Q' => '&#9813;',
+        'K' => '&#9812;',
+        'P' => '&#9817;',
+        );
+    
+    my ($html_chessboard) = '<div class="zci--fenviewer"><table class="chess_board" cellpadding="0" cellspacing="0">';
+    for ($i = 0; $i < 8; $i++){
+        # Rows
+        $html_chessboard .= '<tr>';
+        for ($j = 0; $j < 8; $j++){
+            # Columns
+            $html_chessboard .= '<td id="'.$arr[$j].(8-$i).'">';
+            $html_chessboard .= '<a href="#" class="'.$class_dict{$position[$counter]};
+            $html_chessboard .= '">'.$unicode_dict{$position[$counter]}.'</a>';
+            $html_chessboard .= '</td>';
+            $counter++;
+        }
+        $html_chessboard .= '</tr>';
+    }
+    $html_chessboard .= '</table></div>';
+    return $html_chessboard;
+}
+
+# Generate a chessboard in ASCII, with the same format as
+# 'text output from Chess::PGN::EPD
+sub draw_chessboard_ascii {
+    my (@position) = @_;
+    my ($i) = 0;
+    my ($j) = 0;
+    my ($counter) = 0;
+    my ($ascii_chessboard) = "";
+    for ($i = 0; $i < 8; $i++){
+        # Rows
+        for ($j = 0; $j < 8; $j++){
+            # Columns
+            if ($position[$counter] ne 'e') {
+                # Occupied square
+                $ascii_chessboard .= $position[$counter];
+            }
+            elsif ($j % 2 != $i % 2) {
+                # Black square
+                $ascii_chessboard .= '-';
+            }
+            else {
+                # White square
+                $ascii_chessboard .= ' ';
+            }
+            $counter++;
+        }
+        if($counter < 63) {
+            $ascii_chessboard .= "\n";
+        }
+    }
+    return $ascii_chessboard;
+};
+
+1;

--- a/share/goodie/chess960/chess960.css
+++ b/share/goodie/chess960/chess960.css
@@ -1,0 +1,24 @@
+.zci--answer .zci--fenviewer a {
+	color:#333;
+	display:block;
+	font-size:27px;
+	height:40px;
+	position:relative;
+	text-decoration:none;
+	width:40px;
+    line-height: 1.5;
+}
+
+.zci--answer .zci--fenviewer .chess_board { border: 2px solid #333; }
+.zci--answer .zci--fenviewer .chess_board td {
+	background:#fff;
+	height:40px;
+	text-align:center;
+	vertical-align:middle;
+	width:40px;
+}
+
+.zci--answer .zci--fenviewer .chess_board tr:nth-child(odd) td:nth-child(even),
+.zci--answer .zci--fenviewer .chess_board tr:nth-child(even) td:nth-child(odd) {
+	background-color: #ddd;
+}

--- a/t/Chess960.t
+++ b/t/Chess960.t
@@ -13,19 +13,15 @@ ddg_goodie_test(
 		DDG::Goodie::Chess960
 	)],
     map {
-        $_ => test_zci(qr/^Position \d{1,3}:
-White: ([BKNQRP] ?){1,8}
-       ([BKNQRP] ?){0,8}
-Black: ([BKNQRP] ?){1,8}
-       ([BKNQRP] ?){0,8}
-
-\(where B is for bishop,
-       K is for king,
-       N is for knight,
-       Q is for queen,
-       R is for rook, and
-       P is for pawn\)$/,
-            html    => qr|^<img src='/iu/\?u=http://www\.apronus\.com/chess/stilldiagram.php\?d=[KNQRPB]{17}________________________________[knqrpb]{16}0\.jpg&w=8&h=8'/>$|,
+        $_ => test_zci(qr/^[qrkbn]{1,8}
+pppppppp
+ - - - -
+- - - - 
+ - - - -
+- - - - 
+PPPPPPPP
+[QRBKN]{1,8}$/,
+            html    => qr/^<div class="zci--fenviewer"><table class="chess_board" cellpadding="0" cellspacing="0">(<tr>(<td id="[A-H][1-8]"><a href="#" class="[a-z ]*">.*<\/a><\/td>){1,8}<\/tr>){1,8}<\/table><\/div>$/,
             heading => qr/^Position \d+ \(Chess960\)$/,
         )
     } ('random chess960 position', 'chess960 random')


### PR DESCRIPTION
This changes the output of the Chess960 IA to use the same format as FenViewer, purely done in HTML instead of querying an external website for an image to display.