### PR TITLE
Remove Locale::Country alias/renaming

### DIFF
--- a/lib/DDG/Goodie/CallingCodes.pm
+++ b/lib/DDG/Goodie/CallingCodes.pm
@@ -38,45 +38,6 @@ foreach my $cw (@codewords) {
 
 triggers any => @triggers;
 
-Locale::Country::rename_country('ae' => 'the United Arab Emirates');
-Locale::Country::rename_country('do' => 'the Dominican Republic');
-Locale::Country::rename_country('gb' => 'the United Kingdom');
-Locale::Country::rename_country('kr' => "the Republic of Korea");                     # South Korea
-Locale::Country::rename_country('kp' => "the Democratic People's Republic of Korea"); # North Korea
-Locale::Country::rename_country('ky' => 'the Cayman Islands');
-Locale::Country::rename_country('mp' => 'the Northern Mariana Islands');
-Locale::Country::rename_country('nl' => 'the Netherlands');
-Locale::Country::rename_country('ph' => 'the Philippines');
-Locale::Country::rename_country('ru' => 'the Russian Federation');
-Locale::Country::rename_country('tw' => 'Taiwan');
-Locale::Country::rename_country('us' => 'the United States');
-Locale::Country::rename_country('va' => 'the Holy See (Vatican City State)');
-Locale::Country::rename_country('vg' => 'the British Virgin Islands');
-Locale::Country::rename_country('vi' => 'the US Virgin Islands');
-
-# These are the only 2 countries which officially have 'The' in their name
-# Source: http://www.bbc.co.uk/news/magazine-18233844
-Locale::Country::rename_country('gm' => 'The Gambia');
-Locale::Country::rename_country('bs' => 'The Bahamas');
-
-Locale::Country::add_country_alias('Antigua and Barbuda'  => 'Antigua');
-Locale::Country::add_country_alias('Antigua and Barbuda'  => 'Barbuda');
-Locale::Country::add_country_alias('Russian Federation'   => 'Russia');
-Locale::Country::add_country_alias('Trinidad and Tobago'  => 'Tobago');
-Locale::Country::add_country_alias('Trinidad and Tobago'  => 'Trinidad');
-Locale::Country::add_country_alias('Vatican City'         => 'Vatican');
-Locale::Country::add_country_alias('Virgin Islands, U.S.' => 'US Virgin Islands');
-
-# Source: http://www.bbc.co.uk/news/magazine-18233844
-Locale::Country::add_country_alias('United States' => 'America');
-
-
-# Easter eggs
-Locale::Country::add_country_alias('Russian Federation' => 'Kremlin');
-Locale::Country::add_country_alias('United States' => 'murica');
-Locale::Country::add_country_alias('Canada' => 'Canadia');
-Locale::Country::add_country_alias('Australia' => 'down under');
-
 handle remainder => sub {
     my $query = shift;
 

--- a/lib/DDG/Goodie/CountryCodes.pm
+++ b/lib/DDG/Goodie/CountryCodes.pm
@@ -23,16 +23,6 @@ attribution github  => ["killerfish", "Usman Raza"],
 
 triggers any => 'country code', 'iso code', 'iso 3166';
 
-# Adding alias for country names not present in Local::Country
-Locale::Country::add_country_alias('Antigua and Barbuda'  => 'Antigua');
-Locale::Country::add_country_alias('Antigua and Barbuda'  => 'Barbuda');
-Locale::Country::add_country_alias('Russian Federation'   => 'Russia');
-Locale::Country::add_country_alias('Trinidad and Tobago'  => 'Tobago');
-Locale::Country::add_country_alias('Trinidad and Tobago'  => 'Trinidad');
-Locale::Country::add_country_alias('United States'        => 'America');
-Locale::Country::add_country_alias('Vatican City'         => 'Vatican');
-Locale::Country::add_country_alias('Virgin Islands, U.S.' => 'US Virgin Islands');
-
 my %numbers    = (two   => 2, three => 3);
 my $connectors = qr/of|for/;
 my $counts     = join('|', values %numbers, keys %numbers);


### PR DESCRIPTION
To clear up warnings from Locale::Country that countries are being renamed/aliased multiple times we need to centralize those calls.  

This PR will need to be coordinated with https://github.com/duckduckgo/duckduckgo/pull/125