### PR TITLE
Improve DuckDuckGo's hiring links

### DIFF
--- a/share/goodie/duck_duck_go/responses.yml
+++ b/share/goodie/duck_duck_go/responses.yml
@@ -87,7 +87,7 @@ hiring:
   aliases:
     - job
     - jobs
-  base_format: 'Check out the DuckDuckGo [hiring article]'
+  base_format: 'Check out [DuckDuckGo''s article on how we hire and what we''re looking for]'
   info_url: https://duck.co/help/company/hiring
 ia:
   aliases:


### PR DESCRIPTION
I shot my mouth off on Twitter, so: here's a better link. That said, I think this is actually at least partially underlying lousy visual styling.