### PR TITLE
PeriodicTable.pm: Add `url` to the data.

### DIFF
--- a/lib/DDG/Goodie/PeriodicTable.pm
+++ b/lib/DDG/Goodie/PeriodicTable.pm
@@ -73,7 +73,8 @@ handle query_lc => sub {
         data => {
             badge => $element_symbol,
             title => $title,
-            subtitle => $subtitle
+            subtitle => $subtitle,
+            url => "https://en.wikipedia.org/wiki/$element_name",
         },
         meta => {
             sourceName => "Wikipedia",

--- a/t/PeriodicTable.t
+++ b/t/PeriodicTable.t
@@ -330,7 +330,8 @@ sub make_structured_answer {
         data => {
             badge => $badge,
             title => $title,
-            subtitle => $subtitle
+            subtitle => $subtitle,
+            url => "https://en.wikipedia.org/wiki/$element_name",
         },        
         meta => {
             sourceName => "Wikipedia",


### PR DESCRIPTION
The title would link nowhere if we don't add this.

![screen shot 2015-05-15 at 7 28 51 am](https://cloud.githubusercontent.com/assets/81969/7651932/0eec86f0-fad4-11e4-8b2a-7da55154515d.png)
