### PR TITLE
International Protection Marking Codes [New]

### DIFF
--- a/lib/DDG/Goodie/IPCodes.pm
+++ b/lib/DDG/Goodie/IPCodes.pm
@@ -1,0 +1,61 @@
+package DDG::Goodie::IPCodes;
+# ABSTRACT: International Protection Marking Codes
+
+use DDG::Goodie;
+
+zci answer_type => "ipcodes";
+zci is_cached   => 1;
+
+name "IPCodes";
+description "International Protection Marking Codes";
+primary_example_queries "IP68", "IP4X";
+category "reference";
+topics "special_interest";
+code_url "https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/IPCodes.pm";
+attribution github => ["mattr555", "Matt Ramina"],
+            twitter => "mattr555";
+
+my $regex = qr/^ip\s?([0-6x])([0-8x]|6k|9k)$/;
+triggers query_lc => $regex;
+
+my %particles = (
+	"0" => "None",
+	"1" => "Back of hand",
+	"2" => "Fingers",
+	"3" => "Tools",
+	"4" => "Wire",
+	"5" => "Dust protected",
+	"6" => "Dust tight",
+	"X" => "Unspecified"
+);
+
+my %water = (
+	"0" => "None",
+	"1" => "Dripping water",
+	"2" => "Dripping water, object tilted",
+	"3" => "Spraying water",
+	"4" => "Splashing water",
+	"5" => "Water jets",
+	"6" => "Powerful water jets",
+	"6K" => "Powerful water jets, high pressure",
+	"7" => "Immersion to 1 m",
+	"8" => "Immersion greater than 1 m",
+	"9K" => "Powerful water jets, high temperature, high pressure",
+	"X" => "Unspecified"
+);
+
+handle query_lc => sub {
+    return unless $_ =~ $regex;
+    my $d = uc $1;
+    my $w = uc $2;
+
+    my $answer = "Particle protection: $particles{$d}; Water protection: $water{$w}";
+    return $answer,
+    	structured_answer => {
+    		input => ["IP$d$w"],
+    		operation => "IP Code",
+    		result => $answer
+    	};
+};
+
+1;

--- a/lib/DDG/Goodie/IPCodes.pm
+++ b/lib/DDG/Goodie/IPCodes.pm
@@ -1,6 +1,7 @@
 package DDG::Goodie::IPCodes;
 # ABSTRACT: International Protection Marking Codes
 
+use strict;
 use DDG::Goodie;
 
 zci answer_type => "ipcodes";

--- a/lib/DDG/Goodie/IPCodes.pm
+++ b/lib/DDG/Goodie/IPCodes.pm
@@ -45,9 +45,8 @@ my %water = (
 );
 
 handle query_lc => sub {
-    return unless $_ =~ $regex;
-    my $d = uc $1;
-    my $w = uc $2;
+    return unless $regex;
+    my ($d, $w) = ($1, $2);
 
     my $answer = "Particle protection: $particles{$d}; Water protection: $water{$w}";
     return $answer,

--- a/t/IPCodes.t
+++ b/t/IPCodes.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Goodie;
+
+zci answer_type => "ipcodes";
+zci is_cached   => 1;
+
+my @ip67_ans = test_zci('Particle protection: Dust tight; Water protection: Immersion to 1 m',
+    	structured_answer => {
+    		input => ['IP67'],
+    		operation => "IP Code",
+    		result => "Particle protection: Dust tight; Water protection: Immersion to 1 m"
+    	});
+
+ddg_goodie_test(
+    [qw( DDG::Goodie::IPCodes )],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'IP67' => @ip67_ans,
+    'ip 67' => @ip67_ans,
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'IP 99' => undef,
+    'ip 4K' => undef,
+    'ip address' => undef
+);
+
+done_testing;

--- a/t/IPCodes.t
+++ b/t/IPCodes.t
@@ -8,22 +8,23 @@ use DDG::Test::Goodie;
 zci answer_type => "ipcodes";
 zci is_cached   => 1;
 
-my @ip67_ans = test_zci('Particle protection: Dust tight; Water protection: Immersion to 1 m',
+my @ip68_ans = test_zci('Particle protection: Dust tight; Water protection: Immersion greater than 1 m',
     	structured_answer => {
-    		input => ['IP67'],
+    		input => ['IP68'],
     		operation => "IP Code",
-    		result => "Particle protection: Dust tight; Water protection: Immersion to 1 m"
+    		result => "Particle protection: Dust tight; Water protection: Immersion greater than 1 m"
     	});
 
 ddg_goodie_test(
     [qw( DDG::Goodie::IPCodes )],
-    # At a minimum, be sure to include tests for all:
-    # - primary_example_queries
-    # - secondary_example_queries
-    'IP67' => @ip67_ans,
-    'ip 67' => @ip67_ans,
-    # Try to include some examples of queries on which it might
-    # appear that your answer will trigger, but does not.
+    'IP68' => @ip68_ans,
+    'ip 68' => @ip68_ans,
+    'IP4X' => test_zci('Particle protection: Wire; Water protection: Unspecified',
+    	structured_answer => {
+    		input => ['IP4X'],
+    		operation => "IP Code",
+    		result => "Particle protection: Wire; Water protection: Unspecified"
+    	}),
     'IP 99' => undef,
     'ip 4K' => undef,
     'ip address' => undef


### PR DESCRIPTION
I realized I had never made a `structured_answer` before!

**What does your Instant Answer do?**
Decodes IP Code markings.

**What problem does your Instant Answer solve (Why is it better than organic links)?**
These are a standard and simple for answers.

**What is the data source for your Instant Answer? (Provide a link if possible)**
https://en.wikipedia.org/wiki/IP_Code

**Why did you choose this data source?**
It's correct

**What are some example queries that trigger this Instant Answer?**
`IP68`, `ip 42`

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
People working with machinery/parts that need to be protected from particle ingress (like roboticists)

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
[My own.](https://duck.co/ideas/idea/5227/ip-international-protection-marking-codes)

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![screenshot - 05192015 - 07 13 55 pm](https://cloud.githubusercontent.com/assets/4411471/7715962/4cccdad0-fe5b-11e4-9d10-4e69b52e8454.png)

## Checklist
Please place an 'X' where appropriate.

```
- [x] Added metadata and attribution information (https://duck.co/duckduckhack/metadata)
- [x] Wrote test file and added to t/ directory (https://duck.co/duckduckhack/goodie_tests)
- [x] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
- [x] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
- [] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Debian (Crunchbang)
        - [x] Chrome
```