### PR TITLE
Created ScreenResolution, to view your resolution

### DIFF
--- a/lib/DDG/Goodie/ScreenResolution.pm
+++ b/lib/DDG/Goodie/ScreenResolution.pm
@@ -20,14 +20,14 @@ triggers startend => "screen resolution", "display resolution", "resolution of m
 handle remainder => sub {
     return unless /^((what\'?s|what is)?\s?(the|my|current))?$/;
 
-    return 'Javascript required', structured_answer => {
+    return structured_answer => {
         id => 'screen_resolution',
         name => 'Screen Resolution',
         data => {
             title => "Your screen resolution is [Loading...]"
         },
         templates => {
-            group => 'text',
+            group => 'icon',
             item => 0,
             options => {
                 moreAt => 0

--- a/lib/DDG/Goodie/ScreenResolution.pm
+++ b/lib/DDG/Goodie/ScreenResolution.pm
@@ -15,10 +15,10 @@ code_url "https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DD
 attribution twitter => 'mattr555',
             github => ['mattr555', 'Matt Ramina'];
 
-triggers startend => "screen resolution", "display resolution";
+triggers startend => "screen resolution", "display resolution", "resolution of my screen";
 
 handle remainder => sub {
-    return unless $_ eq '' || $_ eq 'what is my';
+    return unless /^((what\'?s|what is)?\s?(the|my|current))?$/;
 
     return 'Javascript required', structured_answer => {
         id => 'screen_resolution',

--- a/lib/DDG/Goodie/ScreenResolution.pm
+++ b/lib/DDG/Goodie/ScreenResolution.pm
@@ -1,0 +1,39 @@
+package DDG::Goodie::ScreenResolution;
+# ABSTRACT: Return the current screen resolution using javascript
+
+use DDG::Goodie;
+use strict;
+
+zci answer_type => "screen_resolution";
+zci is_cached   => 1;
+
+name "Screen Resolution";
+description "Displays the current screen resolution using javascript";
+primary_example_queries "screen resolution";
+secondary_example_queries "what is my display resolution";
+code_url "https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/ScreenResolution.pm";
+attribution twitter => 'mattr555',
+            github => ['mattr555', 'Matt Ramina'];
+
+triggers startend => "screen resolution", "display resolution";
+
+handle remainder => sub {
+    return unless $_ eq '' || $_ eq 'what is my';
+
+    return 'Javascript required', structured_answer => {
+        id => 'screen_resolution',
+        name => 'Screen Resolution',
+        data => {
+            title => "Your screen resolution is [Loading...]"
+        },
+        templates => {
+            group => 'text',
+            item => 0,
+            options => {
+                moreAt => 0
+            }
+        }
+    };
+};
+
+1;

--- a/share/goodie/screen_resolution/screen_resolution.js
+++ b/share/goodie/screen_resolution/screen_resolution.js
@@ -1,11 +1,13 @@
 DDH.screen_resolution = DDH.screen_resolution || {};
 
 DDH.screen_resolution.build = function(ops){
-    var res = 'Your screen resolution is ' + window.screen.width + 'x' + window.screen.height;
+    var title = window.screen.width + ' × ' + window.screen.height,
+        sub = ['Your Screen Resolution'];
     if (window.devicePixelRatio && window.devicePixelRatio > 1){
-        res += ' (pixel ratio x' + window.devicePixelRatio + ')';
+        sub.push('Pixel Ratio: x' + window.devicePixelRatio);
     }
 
-    ops.data.title = res;
+    ops.data.title = title;
+    ops.data.subtitle = sub;
     return ops;
 }

--- a/share/goodie/screen_resolution/screen_resolution.js
+++ b/share/goodie/screen_resolution/screen_resolution.js
@@ -1,13 +1,11 @@
 DDH.screen_resolution = DDH.screen_resolution || {};
 
 DDH.screen_resolution.build = function(ops){
-    return {
-        onShow: function(){
-            var res = 'Your screen resolution is ' + window.screen.width + 'x' + window.screen.height;
-            if (window.devicePixelRatio && window.devicePixelRatio > 1){
-                res += ' (pixel ratio x' + window.devicePixelRatio + ')';
-            }
-            $('#zci-screen_resolution').find('h3').html(res);
-        }
+    var res = 'Your screen resolution is ' + window.screen.width + 'x' + window.screen.height;
+    if (window.devicePixelRatio && window.devicePixelRatio > 1){
+        res += ' (pixel ratio x' + window.devicePixelRatio + ')';
     }
+
+    ops.data.title = res;
+    return ops;
 }

--- a/share/goodie/screen_resolution/screen_resolution.js
+++ b/share/goodie/screen_resolution/screen_resolution.js
@@ -1,0 +1,13 @@
+DDH.screen_resolution = DDH.screen_resolution || {};
+
+DDH.screen_resolution.build = function(ops){
+    return {
+        onShow: function(){
+            var res = 'Your screen resolution is ' + window.screen.width + 'x' + window.screen.height;
+            if (window.devicePixelRatio && window.devicePixelRatio > 1){
+                res += ' (pixel ratio x' + window.devicePixelRatio + ')';
+            }
+            $('#zci-screen_resolution').find('h3').html(res);
+        }
+    }
+}

--- a/t/ScreenResolution.t
+++ b/t/ScreenResolution.t
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Goodie;
+
+zci answer_type => "screen_resolution";
+zci is_cached   => 1;
+
+my @answer = test_zci('Javascript required', structured_answer => {
+    id => 'screen_resolution',
+    name => 'Screen Resolution',
+    data => {
+        title => "Your screen resolution is [Loading...]"
+    },
+    templates => {
+        group => 'text',
+        item => 0,
+        options => {
+            moreAt => 0
+        }
+    }
+});
+
+ddg_goodie_test(
+    [qw( DDG::Goodie::ScreenResolution )],
+    'screen resolution' => @answer,
+    'what is my display resolution' => @answer,
+    'blah blah screen resolution' => undef,
+);
+
+done_testing;

--- a/t/ScreenResolution.t
+++ b/t/ScreenResolution.t
@@ -27,6 +27,10 @@ ddg_goodie_test(
     [qw( DDG::Goodie::ScreenResolution )],
     'screen resolution' => @answer,
     'what is my display resolution' => @answer,
+    'whats my screen resolution' => @answer,
+    'what is my screen resolution' => @answer,
+    'what is the resolution of my screen?' => @answer,
+    'my screen resolution' => @answer,
     'blah blah screen resolution' => undef,
 );
 


### PR DESCRIPTION
**What does your Instant Answer do?**
Displays the screen resolution to the user in a succinct readout

**What problem does your Instant Answer solve (Why is it better than organic links)?**
Reduces the need to clickthrough to whatismyscreenresolution.com or similar

**What are some example queries that trigger this Instant Answer?**
`screen resolution`, `what is my display resolution` (any more potential triggers?)

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Computer users

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
[My own](https://duck.co/ideas/idea/5096/screen-resolution)

**Which existing Instant Answers will this one supercede/overlap with?**
The wiki summary for "display resolution"

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![screenshot - 06022015 - 08 57 13 pm](https://cloud.githubusercontent.com/assets/4411471/7950532/f9dbeffe-0969-11e5-880f-e567bfa2a374.png)

On devices where the pixel density is doubled, it is noted as such:
![mobile](http://i.imgur.com/Dno8Z5w.png)

## Checklist
Please place an 'X' where appropriate.

```
- [x] Added metadata and attribution information (https://duck.co/duckduckhack/metadata)
- [x] Wrote test file and added to t/ directory (https://duck.co/duckduckhack/goodie_tests)
- [x] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
- [x] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
- [] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Crunchbang (Debian)
        - [x] Google Chrome

    - iOS (iPhone)
        - [x] Safari Mobile
```

IA Page: https://duck.co/ia/view/screen_resolution