### PR TITLE
Mac Keyboard Shortcuts cheat sheet

### DIFF
--- a/share/goodie/cheat_sheets/mac-keyboard.json
+++ b/share/goodie/cheat_sheets/mac-keyboard.json
@@ -6,172 +6,151 @@
         "sourceName": "Mac keyboard shortcuts",
         "sourceUrl": "https://support.apple.com/en-us/HT201236"
     },
-    "section_order" : ["Menu Symbols", "General", "Finder", "Text Editing", "Web Browsing (Works on most modern browsers)", "Spotlight", "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)"],
+    "section_order" : ["General", "Finder", "Text Editing", "Web Browsing (Works on most modern browsers)", "Spotlight", "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)"],
     "sections":{
-        "Menu Symbols": [{
-            "key" : "⌘",
-            "val" : "Command/Cmd"
+        "Finder": [{
+            "key" : "[Cmd] + [C]",
+            "val" : "Copy selected files"
         }, {
-            "key" : "⌥",
-            "val" : "Option/Opt"
+            "key" : "[Cmd] + [V]",
+            "val" : "Paste files"
         }, {
-            "key" : "⌃",
-            "val" : "Control/Ctrl (Ctrl+Click = Right-click)"
+            "key" : "[Cmd] + [Opt] + [V]",
+            "val" : "Move the copied files to current directory"
         }, {
-            "key" : "⇧",
-            "val" : "Shift Key"
+            "key" : "[Cmd] + [Del]",
+            "val" : "Delete selected folder or file"
         }, {
-            "key" : "⇪",
-            "val" : "Caps Lock"
+            "key" : "Return/Enter",
+            "val" : "Rename the selected file/folder"
         }, {
-            "key" : "⇥",
-            "val" : "Tab Key"
+            "key" : "[Cmd] + [1~4]",
+            "val" : "Switch Finder views (Icon, List, Column, Cover Flow)"
         }, {
-            "key" : "↑",
-            "val" : "Up arrow"
+            "key" : "[Cmd] + [↓]",
+            "val" : "Go into selected folder or open the selected file"
         }, {
-            "key" : "↓",
-            "val" : "Down arrow"
+            "key" : "[Cmd] + [↑]",
+            "val" : "Go to parent folder"
         }, {
-            "key" : "←",
-            "val" : "Left arrow"
+            "key" : "[Cmd] + [T]",
+            "val" : "Open new Finder tab"
         }, {
-            "key" : "→",
-            "val" : "Right arrow"
+            "key" : "[Cmd] + [W]",
+            "val" : "Close current tab"
         }, {
-            "key" : "↩",
-            "val" : "Return/Enter"
+            "key" : "[Cmd] + [Shift] + [W]",
+            "val" : "Close current window"
+        }, {
+            "key" : "[Cmd] + [N]",
+            "val" : "Open new Finder window"
+        }, {
+            "key" : "[Ctrl] + [Tab]",
+            "val" : "Cycle through tabs"
+        }, {
+            "key" : "Spacebar",
+            "val" : "Preview selected item using Quick Look"
         }], "Spotlight": [{
-            "key" : "[⌘] + [Space]",
+            "key" : "[Cmd] + [Space]",
             "val" : "Open Spotlight"
         }, {
             "key" : "Enter",
             "val" : "Open selected item"
         }, {
-            "key" : "[⌘] + [Enter]",
+            "key" : "[Cmd] + [Enter]",
             "val" : "Open selected item in Finder"
         }, {
-            "key" : "[⌘] + [↑/↓]",
+            "key" : "[Cmd] + [↑/↓]",
             "val" : "Skip to next/previous result category"
-        }], "Finder": [{
-            "key" : "[⌘] + [T]",
-            "val" : "Open new Finder tab"
-        }, {
-            "key" : "[⌘] + [W]",
-            "val" : "Close current tab"
-        }, {
-            "key" : "[⌘] + [⇧] + [W]",
-            "val" : "Close current window"
-        }, {
-            "key" : "[⌘] + [N]",
-            "val" : "Open new Finder window"
-        }, {
-            "key" : "[⌃] + [⇥]",
-            "val" : "Cycle through tabs"
-        }, {
-            "key" : "[⌘] + [Del]",
-            "val" : "Delete selected folder or file"
-        }, {
-            "key" : "[⌘] + [C], [⌘] + [V]",
-            "val" : "Copy and paste files"
-        }, {
-            "key" : "[⌘] + [C], [⌘] + [⌥] + [V]",
-            "val" : "Cut and paste files (move files)"
-        }, {
-            "key" : "[⌘] + [1~4]",
-            "val" : "Switch Finder views (Icon, List, Column, Cover Flow)"
-        }, {
-            "key" : "Return/Enter",
-            "val" : "Rename the selected file/folder"
-        }, {
-            "key" : "Spacebar",
-            "val" : "Preview selected item using Quick Look"
-        }, {
-            "key" : "[⌘] + [↓]",
-            "val" : "Go into selected folder or open the selected file"
-        }, {
-            "key" : "[⌘] + [↑]",
-            "val" : "Go to parent folder"
         }], "Text Editing" :[{
-            "key" : "[⌘] + [A]",
+            "key" : "[Cmd] + [A]",
             "val" : "Select all"
         }, {
-            "key" : "[⌘] + [X]",
+            "key" : "[Cmd] + [X]",
             "val" : "Cut"
         }, {
-            "key" : "[⌘] + [C]",
+            "key" : "[Cmd] + [C]",
             "val" : "Copy"
         }, {
-            "key" : "[⌘] + [V]",
+            "key" : "[Cmd] + [V]",
             "val" : "Paste"
         }, {
-            "key" : "[⌘] + [Z]",
+            "key" : "[Cmd] + [Z]",
             "val" : "Undo"
         }, {
-            "key" : "[⌘] + [⇧] + [Z]",
+            "key" : "[Cmd] + [Shift] + [Z]",
             "val" : "Redo"
         }, {
-            "key" : "[⌘] + [←/→]",
+            "key" : "[Cmd] + [←/→]",
             "val" : "Go to beginning/end of line"
         }, {
-            "key" : "[⌥] + [←]",
+            "key" : "[Cmd] + [↑]",
+            "val" : "Go to beginning of document"
+        }, {
+            "key" : "[Cmd] + [↓]",
+            "val" : "Go to end of document"
+        }, {
+            "key" : "[Opt] + [←]",
             "val" : "Go to beginning of previous word"
         }, {
-            "key" : "[⌥] + [→]",
+            "key" : "[Opt] + [→]",
             "val" : "Go to end of next word"
         }], "General" : [{
-            "key" : "[⌘] + [⇥]",
-            "val" : "Switch between apps. Holding ⇧ reverses."
+            "key" : "[Cmd] + [Tab]",
+            "val" : "Switch between apps. Holding Shift reverses."
         }, {
-            "key" : "[⌘] + [~]",
-            "val" : "Switch to next window of current app. Holding ⇧ reverses."
+            "key" : "[Cmd] + [~]",
+            "val" : "Switch to next window of current app. Holding Shift reverses."
         }, {
-            "key" : "[⌘] + [Q]",
+            "key" : "[Cmd] + [Q]",
             "val" : "Quit app"
         }, {
-            "key" : "[⌘] + [H]",
+            "key" : "[Cmd] + [H]",
             "val" : "Hide windows of current app"
         }, {
-            "key" : "[⌘] + [M]",
+            "key" : "[Cmd] + [M]",
             "val" : "Minimize windows of current app"
         }, {
-            "key" : "[⌘] + [,]",
+            "key" : "[Cmd] + [,]",
             "val" : "Open Preferences (if available)"
         }, {
-            "key" : "[⌃] + [←/→]",
+            "key" : "[Ctrl] + [←/→]",
             "val" : "Move one desktop left or right"
         }, {
-            "key" : "[⌘] + [⌥] + [Esc]",
+            "key" : "[Cmd] + [Opt] + [Esc]",
             "val" : "Open force quit dialog"
         }], "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)" : [{
-            "key" : "[⌘] + [⇧] + [3]",
+            "key" : "[Cmd] + [Shift] + [3]",
             "val" : "Take picture of the entire screen"
         }, {
-            "key" : "[⌘] + [⇧] + [4]",
+            "key" : "[Cmd] + [Shift] + [4]",
             "val" : "Take picture of a selected area"
         }, {
-            "key" : "[⌘] + [⇧] + [4], [Spacebar]",
+            "key" : "[Cmd] + [Shift] + [4], [Spacebar]",
             "val" : "Take picture of a specific window/object"
         }], "Web Browsing (Works on most modern browsers)" : [{
-            "key" : "[⌘] + [T]",
+            "key" : "[Cmd] + [T]",
             "val" : "Open a new tab"
         }, {
-            "key" : "[⌘] + [W]",
-            "val" : "Close curren tab"
+            "key" : "[Cmd] + [W]",
+            "val" : "Close current tab"
         }, {
-            "key" : "[⌘] + [L]",
+            "key" : "[Cmd] + [L]",
             "val" : "Focus on browser's location bar"
         }, {
-            "key" : "[⌘] + [←]",
+            "key" : "[Cmd] + [R]",
+            "val" : "Refresh"
+        }, {
+            "key" : "[Cmd] + [←]",
             "val" : "Go back a page"
         }, {
-            "key" : "[⌘] + [→]",
+            "key" : "[Cmd] + [→]",
             "val" : "Go forward a page"
         }, {
-            "key" : "[⌃] + [⇥]",
+            "key" : "[Ctrl] + [Tab]",
             "val" : "Cycle through tabs. Holding Shift reverses."
         }, {
-            "key" : "[⌘] + [F]",
+            "key" : "[Cmd] + [F]",
             "val" : "Find"
         }]
     }

--- a/share/goodie/cheat_sheets/mac-keyboard.json
+++ b/share/goodie/cheat_sheets/mac-keyboard.json
@@ -6,7 +6,7 @@
         "sourceName": "Mac keyboard shortcuts",
         "sourceUrl": "https://support.apple.com/en-us/HT201236"
     },
-    "section_order" : ["Menu Symbols", "General", "Finder", "Text Editing", "Web Browsing", "Spotlight", "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)"],
+    "section_order" : ["Menu Symbols", "General", "Finder", "Text Editing", "Web Browsing (Works on most modern browsers)", "Spotlight", "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)"],
     "sections":{
         "Menu Symbols": [{
             "key" : "⌘",

--- a/share/goodie/cheat_sheets/mac-keyboard.json
+++ b/share/goodie/cheat_sheets/mac-keyboard.json
@@ -1,0 +1,178 @@
+{
+    "id": "mac_keyboard_shortcuts", 
+    "name": "Mac Keyboard Shortcuts",
+    "description": "List of useful keyboard shortcuts for Mac", 
+    "metadata": { 
+        "sourceName": "Mac keyboard shortcuts",
+        "sourceUrl": "https://support.apple.com/en-us/HT201236"
+    },
+    "section_order" : ["Menu Symbols", "General", "Finder", "Text Editing", "Web Browsing", "Spotlight", "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)"],
+    "sections":{
+        "Menu Symbols": [{
+            "key" : "⌘",
+            "val" : "Command/Cmd"
+        }, {
+            "key" : "⌥",
+            "val" : "Option/Opt"
+        }, {
+            "key" : "⌃",
+            "val" : "Control/Ctrl (Ctrl+Click = Right-click)"
+        }, {
+            "key" : "⇧",
+            "val" : "Shift Key"
+        }, {
+            "key" : "⇪",
+            "val" : "Caps Lock"
+        }, {
+            "key" : "⇥",
+            "val" : "Tab Key"
+        }, {
+            "key" : "↑",
+            "val" : "Up arrow"
+        }, {
+            "key" : "↓",
+            "val" : "Down arrow"
+        }, {
+            "key" : "←",
+            "val" : "Left arrow"
+        }, {
+            "key" : "→",
+            "val" : "Right arrow"
+        }, {
+            "key" : "↩",
+            "val" : "Return/Enter"
+        }], "Spotlight": [{
+            "key" : "[⌘] + [Space]",
+            "val" : "Open Spotlight"
+        }, {
+            "key" : "Enter",
+            "val" : "Open selected item"
+        }, {
+            "key" : "[⌘] + [Enter]",
+            "val" : "Open selected item in Finder"
+        }, {
+            "key" : "[⌘] + [↑/↓]",
+            "val" : "Skip to next/previous result category"
+        }], "Finder": [{
+            "key" : "[⌘] + [T]",
+            "val" : "Open new Finder tab"
+        }, {
+            "key" : "[⌘] + [W]",
+            "val" : "Close current tab"
+        }, {
+            "key" : "[⌘] + [⇧] + [W]",
+            "val" : "Close current window"
+        }, {
+            "key" : "[⌘] + [N]",
+            "val" : "Open new Finder window"
+        }, {
+            "key" : "[⌃] + [⇥]",
+            "val" : "Cycle through tabs"
+        }, {
+            "key" : "[⌘] + [Del]",
+            "val" : "Delete selected folder or file"
+        }, {
+            "key" : "[⌘] + [C], [⌘] + [V]",
+            "val" : "Copy and paste files"
+        }, {
+            "key" : "[⌘] + [C], [⌘] + [⌥] + [V]",
+            "val" : "Cut and paste files (move files)"
+        }, {
+            "key" : "[⌘] + [1~4]",
+            "val" : "Switch Finder views (Icon, List, Column, Cover Flow)"
+        }, {
+            "key" : "Return/Enter",
+            "val" : "Rename the selected file/folder"
+        }, {
+            "key" : "Spacebar",
+            "val" : "Preview selected item using Quick Look"
+        }, {
+            "key" : "[⌘] + [↓]",
+            "val" : "Go into selected folder or open the selected file"
+        }, {
+            "key" : "[⌘] + [↑]",
+            "val" : "Go to parent folder"
+        }], "Text Editing" :[{
+            "key" : "[⌘] + [A]",
+            "val" : "Select all"
+        }, {
+            "key" : "[⌘] + [X]",
+            "val" : "Cut"
+        }, {
+            "key" : "[⌘] + [C]",
+            "val" : "Copy"
+        }, {
+            "key" : "[⌘] + [V]",
+            "val" : "Paste"
+        }, {
+            "key" : "[⌘] + [Z]",
+            "val" : "Undo"
+        }, {
+            "key" : "[⌘] + [⇧] + [Z]",
+            "val" : "Redo"
+        }, {
+            "key" : "[⌘] + [←/→]",
+            "val" : "Go to beginning/end of line"
+        }, {
+            "key" : "[⌥] + [←]",
+            "val" : "Go to beginning of previous word"
+        }, {
+            "key" : "[⌥] + [→]",
+            "val" : "Go to end of next word"
+        }], "General" : [{
+            "key" : "[⌘] + [⇥]",
+            "val" : "Switch between apps. Holding ⇧ reverses."
+        }, {
+            "key" : "[⌘] + [~]",
+            "val" : "Switch to next window of current app. Holding ⇧ reverses."
+        }, {
+            "key" : "[⌘] + [Q]",
+            "val" : "Quit app"
+        }, {
+            "key" : "[⌘] + [H]",
+            "val" : "Hide windows of current app"
+        }, {
+            "key" : "[⌘] + [M]",
+            "val" : "Minimize windows of current app"
+        }, {
+            "key" : "[⌘] + [,]",
+            "val" : "Open Preferences (if available)"
+        }, {
+            "key" : "[⌃] + [←/→]",
+            "val" : "Move one desktop left or right"
+        }, {
+            "key" : "[⌘] + [⌥] + [Esc]",
+            "val" : "Open force quit dialog"
+        }], "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)" : [{
+            "key" : "[⌘] + [⇧] + [3]",
+            "val" : "Take picture of the entire screen"
+        }, {
+            "key" : "[⌘] + [⇧] + [4]",
+            "val" : "Take picture of a selected area"
+        }, {
+            "key" : "[⌘] + [⇧] + [4], [Spacebar]",
+            "val" : "Take picture of a specific window/object"
+        }], "Web Browsing (Works on most modern browsers)" : [{
+            "key" : "[⌘] + [T]",
+            "val" : "Open a new tab"
+        }, {
+            "key" : "[⌘] + [W]",
+            "val" : "Close curren tab"
+        }, {
+            "key" : "[⌘] + [L]",
+            "val" : "Focus on browser's location bar"
+        }, {
+            "key" : "[⌘] + [←]",
+            "val" : "Go back a page"
+        }, {
+            "key" : "[⌘] + [→]",
+            "val" : "Go forward a page"
+        }, {
+            "key" : "[⌃] + [⇥]",
+            "val" : "Cycle through tabs. Holding Shift reverses."
+        }, {
+            "key" : "[⌘] + [F]",
+            "val" : "Find"
+        }]
+    }
+}

--- a/share/goodie/cheat_sheets/mac-keyboard.json
+++ b/share/goodie/cheat_sheets/mac-keyboard.json
@@ -1,5 +1,5 @@
 {
-    "id": "mac_keyboard_shortcuts", 
+    "id": "mac_keyboard_cheat_sheet", 
     "name": "Mac Keyboard Shortcuts",
     "description": "List of useful keyboard shortcuts for Mac", 
     "metadata": { 


### PR DESCRIPTION
**What does your Instant Answer do?**
A cheat sheet that lists useful Mac keyboard shortcuts.

**What problem does your Instant Answer solve (Why is it better than organic links)?**
It summarizes all the most commonly used shortcuts so you don't have to go through several links/sources.

**What is the data source for your Instant Answer? (Provide a link if possible)**
[Apple.com](https://support.apple.com/en-us/HT201236),  [How-To-Geek](http://www.howtogeek.com/188530/a-windows-users-guide-to-mac-os-x-keyboard-shortcuts/) and [Dan Rodney's](http://www.danrodney.com/mac/). I'm using Apple.com on the metadata source URL since it's the official one.

**Why did you choose this data source?**
They list all the most commonly used Mac keyboard shortcuts. They are also categorized nicely. (e.g. Finder, Web Browsing etc.)

**What are some example queries that trigger this Instant Answer?**
- mac keyboard shortcuts
- mac keyboard cheat sheet

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Mostly Macbook users who loves using keyboard shortcuts.

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
No.

**Which existing Instant Answers will this one supercede/overlap with?**
None that I know of.

**Are you having any problems? Do you need our help with anything?**
Nope :)

**Where did you hear about DuckDuckHack? (For first time contributors)**
I read some blog posts about their switch to DuckDuckGo as their default search engine, then I found donttrack.us.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![screen shot 2015-06-08 at 10 24 10 am](https://cloud.githubusercontent.com/assets/3041475/8027330/ab26bdf4-0dc8-11e5-8edd-6fa42ad161e7.png)


I have tested this on Google Chrome, Safari, Firefox and on Android's Native Browser.

------

IA Page: https://duck.co/ia/view/mac_keyboard_cheat_sheet