### PR TITLE
Migrate IndependenceDay goodie from html to structured_answer

### DIFF
--- a/lib/DDG/Goodie/IndependenceDay.pm
+++ b/lib/DDG/Goodie/IndependenceDay.pm
@@ -73,16 +73,16 @@ handle query_clean => sub {
     }
 
 
-    # html formatted answer
-    my $html = '<div>';
-    $html .= '<div class="zci__caption">' . $date_str . '</div>';
-    $html .= '<div class="zci__subheader">' . $prolog . '</div>';
-    $html .= '</div>';
-    # plain text answer
+
     my $text = $prolog  . ' ' . $date_str;
 
-    return $text, html => $html;
-
+    return $text,
+      structured_answer => {
+        input     => [],
+        operation => $prolog,
+        result    => $date_str
+      };
+    
 };
 
 1;

--- a/t/IndependenceDay.t
+++ b/t/IndependenceDay.t
@@ -13,26 +13,139 @@ ddg_goodie_test(
 		DDG::Goodie::IndependenceDay
 	)],
 	# primary example queries
-	'what is the independence day of norway' => test_zci('Independence Day of Norway May 17th, 1814', html=>qr/.*/),
-	'independence day, papua new guinea' => test_zci('Independence Day of Papua New Guinea September 16th, 1975', html=>qr/.*/),
+	'what is the independence day of norway' => test_zci(
+		'Independence Day of Norway May 17th, 1814',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Norway',
+			result    => 'May 17th, 1814',
+		}
+	),
+	'independence day, papua new guinea' => test_zci(
+		'Independence Day of Papua New Guinea September 16th, 1975',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Papua New Guinea',
+			result    => 'September 16th, 1975',
+		}
+	),
+
 	# question marks
-	'what is the independence day of norway?' => test_zci('Independence Day of Norway May 17th, 1814', html=>qr/.*/),
+	'what is the independence day of norway?' => test_zci(
+		'Independence Day of Norway May 17th, 1814',
+		structured_answer =>{
+			input     => [],
+			operation => 'Independence Day of Norway',
+			result    => 'May 17th, 1814',
+		}
+	),
 	# some aliases
-	'when is the independence day of republic of congo' => test_zci('Independence Day of Republic of the Congo August 15th, 1960', html=>qr/.*/),
-	'when is the independence day of republic of the congo' => test_zci('Independence Day of Republic of the Congo August 15th, 1960', html=>qr/.*/),
-	'gambia independence day' => test_zci('Independence Day of The Gambia February 18th, 1965', html=>qr/.*/),
-	'the gambia independence day' => test_zci('Independence Day of The Gambia February 18th, 1965', html=>qr/.*/),
-	'usa independence day' => test_zci('Independence Day of United States of America July 4th, 1776', html=>qr/.*/),
+	'when is the independence day of republic of congo' => test_zci(
+		'Independence Day of Republic of the Congo August 15th, 1960',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Republic of the Congo',
+			result    => 'August 15th, 1960',
+		}
+	),
+	'when is the independence day of republic of the congo' => test_zci(
+		'Independence Day of Republic of the Congo August 15th, 1960',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Republic of the Congo',
+			result    => 'August 15th, 1960',
+		}
+	),
+	'gambia independence day' => test_zci(
+		'Independence Day of The Gambia February 18th, 1965',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of The Gambia',
+			result    => 'February 18th, 1965',
+		}
+	),
+	'the gambia independence day' => test_zci(
+		'Independence Day of The Gambia February 18th, 1965',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of The Gambia',
+			result    => 'February 18th, 1965',
+		}
+	),
+	'usa independence day' => test_zci(
+		'Independence Day of United States of America July 4th, 1776',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of United States of America',
+			result    => 'July 4th, 1776',
+		}
+	),
 	# data points with two dates
-	'independence day of panama' => test_zci('Independence Day of Panama November 28th, 1821 and November 3rd, 1903', html=>qr/.*/),
-	'independence day of armenia' => test_zci('Independence Day of Armenia May 28th, 1918 and September 21th, 1991', html=>qr/.*/),
+	'independence day of panama' => test_zci(
+		'Independence Day of Panama November 28th, 1821 and November 3rd, 1903',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Panama',
+			result    => 'November 28th, 1821 and November 3rd, 1903',
+		}
+	),
+	'independence day of armenia' => test_zci(
+		'Independence Day of Armenia May 28th, 1918 and September 21th, 1991',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Armenia',
+			result    => 'May 28th, 1918 and September 21th, 1991',
+		}
+	),
 	# miscellaneous
-	'independence day of papua new guinea' => test_zci('Independence Day of Papua New Guinea September 16th, 1975', html=>qr/.*/),
-	'day of independence of sri lanka' => test_zci('Independence Day of Sri Lanka February 4th, 1948', html=>qr/.*/),
-	'when is the day of independence for norway' => test_zci('Independence Day of Norway May 17th, 1814', html=>qr/.*/),
-	'day of independence, norway' => test_zci('Independence Day of Norway May 17th, 1814', html=>qr/.*/),
-	'norway independence day' => test_zci('Independence Day of Norway May 17th, 1814', html=>qr/.*/),
-	'what day is the independence day of norway' => test_zci('Independence Day of Norway May 17th, 1814', html=>qr/.*/),
+	'independence day of papua new guinea' => test_zci(
+		'Independence Day of Papua New Guinea September 16th, 1975',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Papua New Guinea',
+			result    => 'September 16th, 1975',
+		}
+	),
+	'day of independence of sri lanka' => test_zci(
+		'Independence Day of Sri Lanka February 4th, 1948',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Sri Lanka',
+			result    => 'February 4th, 1948',
+		}
+	),
+	'when is the day of independence for norway' => test_zci(
+		'Independence Day of Norway May 17th, 1814',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Norway',
+			result    => 'May 17th, 1814',
+		}
+	),
+	'day of independence, norway' => test_zci(
+		'Independence Day of Norway May 17th, 1814',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Norway',
+			result    => 'May 17th, 1814',
+		}
+	),
+	'norway independence day' => test_zci(
+		'Independence Day of Norway May 17th, 1814',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Norway',
+			result    => 'May 17th, 1814',
+		}
+	),
+	'what day is the independence day of norway' => test_zci(
+		'Independence Day of Norway May 17th, 1814',
+		structured_answer => {
+			input     => [],
+			operation => 'Independence Day of Norway',
+			result    => 'May 17th, 1814',
+		}
+	),
 
 );
 


### PR DESCRIPTION
From what I have read from the duckduckhack mailing list. `structured_answer`s are preferred to html. This PR migrates the independence day goodie to  `structured_answer` and modifies tests appropriately.

The output looks identical to the earlies version.
before:
![before](https://cloud.githubusercontent.com/assets/3074453/8115548/d6362c50-1084-11e5-9b9a-36d08a7ed92f.png)
after:
![after](https://cloud.githubusercontent.com/assets/3074453/8115549/d75c03de-1084-11e5-8730-7006e3b6f67a.png)

Would it be more suitable if the name of the country is in the `input` part of the answer? (I chose not to put it there as to not alter the appearance of the output)