### PR TITLE
GNOME Keyboard Shortcuts cheat sheet

### DIFF
--- a/share/goodie/cheat_sheets/gnome-keyboard.json
+++ b/share/goodie/cheat_sheets/gnome-keyboard.json
@@ -1,0 +1,75 @@
+{
+    "id": "gnome_cheat_sheet", 
+    "name": "GNOME Keyboard Shortcuts",
+    "description": "List of useful keyboard shortcuts for GNOME", 
+    "metadata": {
+        "sourceName": "GNOME Help",
+        "sourceUrl": "https://help.gnome.org/users/gnome-help/stable/shell-keyboard-shortcuts.html.en"
+    },
+    "section_order": ["Desktop Shortcuts", "Common Editing", "Screen Capturing"],
+    "sections": {
+        "Desktop Shortcuts": [{
+            "val": "Switch between the Activities overview and desktop",
+            "key": "[Alt]+[F1] or [Super]"
+        }, {
+            "val": "Pop up command window",
+            "key": "[Alt]+[F2] "
+        }, {
+            "val": "Quickly switch between windows",
+            "key": "[Super]+[Tab] "
+        }, {
+            "val": "Switch between windows from the same application",
+            "key": "[Super]+[`] "
+        }, {
+            "val": "Give keyboard focus to the top bar",
+            "key": "[Ctrl]+[Alt]+[Tab] "
+        }, {
+            "val": "Show the list of applications",
+            "key": "[Super]+[A] "
+        }, {
+            "val": "Switch between workspaces",
+            "key": "[Super]+[Page Up] \/ [Page Down]"
+        }, {
+            "val": "Move the current window to a different workspace",
+            "key": "[Super]+[Shift]+[Page Up] \/ [Page Down]"
+        }, {
+            "val": "Power Off",
+            "key": "[Ctrl]+[Alt]+[Delete] "
+        }, {
+            "val": "Lock the screen",
+            "key": "[Super]+[L] "
+        }, {
+            "val": "Open the message tray",
+            "key": "[Super]+[M] "
+        }],
+         "Common Editing": [{
+            "val": "Select all text or items in a list",
+            "key": "[Ctrl]+[A] "
+        }, {
+            "val": "Cut selected text or items and place it on the clipboard",
+            "key": "[Ctrl]+[X] "
+        }, {
+            "val": "Copy selected text or items to the clipboard",
+            "key": "[Ctrl]+[C] "
+        }, {
+            "val": "Paste the contents of the clipboard",
+            "key": "[Ctrl]+[V] "
+        }, {
+            "val": "Undo the last action",
+            "key": "[Ctrl]+[Z] "
+        }],
+         "Screen Capturing": [{
+            "val": "Take a screenshot",
+            "key": "[Prnt Scrn]"
+        }, {
+            "val": "Take a screenshot of a window",
+            "key": "[Alt]+[Prnt Scrn]"
+        }, {
+            "val": "Take a screenshot of an area of the screen",
+            "key": "[Shift]+[Prnt Scrn]"
+        }, {
+            "val": "Start and end screencast recording",
+            "key": "[Ctrl]+[Alt]+[Shift]+[R] "
+        }]
+    }
+}

--- a/share/goodie/cheat_sheets/gnome-keyboard.json
+++ b/share/goodie/cheat_sheets/gnome-keyboard.json
@@ -1,5 +1,5 @@
 {
-    "id": "gnome_cheat_sheet", 
+    "id": "gnome_keyboard_cheat_sheet", 
     "name": "GNOME Keyboard Shortcuts",
     "description": "List of useful keyboard shortcuts for GNOME", 
     "metadata": {
@@ -10,66 +10,66 @@
     "sections": {
         "Desktop Shortcuts": [{
             "val": "Switch between the Activities overview and desktop",
-            "key": "[Alt]+[F1] or [Super]"
+            "key": "[Alt] + [F1] or [Super]"
         }, {
             "val": "Pop up command window",
-            "key": "[Alt]+[F2] "
+            "key": "[Alt] + [F2] "
         }, {
             "val": "Quickly switch between windows",
-            "key": "[Super]+[Tab] "
+            "key": "[Super] + [Tab] "
         }, {
             "val": "Switch between windows from the same application",
-            "key": "[Super]+[`] "
+            "key": "[Super] + [`] "
         }, {
             "val": "Give keyboard focus to the top bar",
-            "key": "[Ctrl]+[Alt]+[Tab] "
+            "key": "[Ctrl] + [Alt] + [Tab] "
         }, {
             "val": "Show the list of applications",
-            "key": "[Super]+[A] "
+            "key": "[Super] + [A] "
         }, {
             "val": "Switch between workspaces",
-            "key": "[Super]+[Page Up] \/ [Page Down]"
+            "key": "[Super] + [Page Up] \/ [Page Down]"
         }, {
             "val": "Move the current window to a different workspace",
-            "key": "[Super]+[Shift]+[Page Up] \/ [Page Down]"
+            "key": "[Super] + [Shift]+[Page Up] \/ [Page Down]"
         }, {
             "val": "Power Off",
-            "key": "[Ctrl]+[Alt]+[Delete] "
+            "key": "[Ctrl] + [Alt] + [Delete] "
         }, {
             "val": "Lock the screen",
-            "key": "[Super]+[L] "
+            "key": "[Super] + [L] "
         }, {
             "val": "Open the message tray",
-            "key": "[Super]+[M] "
+            "key": "[Super] + [M] "
         }],
          "Common Editing": [{
             "val": "Select all text or items in a list",
-            "key": "[Ctrl]+[A] "
+            "key": "[Ctrl] + [A] "
         }, {
             "val": "Cut selected text or items and place it on the clipboard",
-            "key": "[Ctrl]+[X] "
+            "key": "[Ctrl] + [X] "
         }, {
             "val": "Copy selected text or items to the clipboard",
-            "key": "[Ctrl]+[C] "
+            "key": "[Ctrl] + [C] "
         }, {
             "val": "Paste the contents of the clipboard",
-            "key": "[Ctrl]+[V] "
+            "key": "[Ctrl] + [V] "
         }, {
             "val": "Undo the last action",
-            "key": "[Ctrl]+[Z] "
+            "key": "[Ctrl] + [Z] "
         }],
          "Screen Capturing": [{
             "val": "Take a screenshot",
             "key": "[Prnt Scrn]"
         }, {
             "val": "Take a screenshot of a window",
-            "key": "[Alt]+[Prnt Scrn]"
+            "key": "[Alt] + [Prnt Scrn]"
         }, {
             "val": "Take a screenshot of an area of the screen",
-            "key": "[Shift]+[Prnt Scrn]"
+            "key": "[Shift] + [Prnt Scrn]"
         }, {
             "val": "Start and end screencast recording",
-            "key": "[Ctrl]+[Alt]+[Shift]+[R] "
+            "key": "[Ctrl] + [Alt] + [Shift] + [R] "
         }]
     }
 }


### PR DESCRIPTION
**What does your Instant Answer do?**
A cheat sheet that lists useful GNOME keyboard shortcuts.

**What problem does your Instant Answer solve (Why is it better than organic links)?**
It summarizes all the most commonly used shortcuts so you don't have to go through several links/sources.

**What is the data source for your Instant Answer? (Provide a link if possible)**
[GNOME](https://help.gnome.org/users/gnome-help/stable/shell-keyboard-shortcuts.html.en) official help website.

**Why did you choose this data source?**
They list all the most commonly used GNOME keyboard shortcuts.

**What are some example queries that trigger this Instant Answer?**
* GNOME keyboard shortcuts
* GNOME keyboard cheat sheet

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Linux users who use GNOME desktop environment.

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
No

**Which existing Instant Answers will this one supersede/overlap with?**
None

**Are you having any problems? Do you need our help with anything?**
No

**What are the terms of use for the API? Will DuckDuckGo need specific authorization (e.g. an API key)? Are there any costs associated with API usage?**
No

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**

![gnome-keyboard-shortcuts](http://i.imgur.com/BHq6jJ3.png)

I have tested this on Google Chrome and Firefox.

------

IA Page: https://duck.co/ia/view/gnome_keyboard_cheat_sheet