### PR TITLE
Do not trigger USPS goodie when query contains other chars besides expected

### DIFF
--- a/lib/DDG/Goodie/USPS.pm
+++ b/lib/DDG/Goodie/USPS.pm
@@ -19,14 +19,14 @@ attribution web => [ 'https://www.duckduckgo.com', 'DuckDuckGo' ],
             twitter => ['duckduckgo', 'DuckDuckGo'];
 
 # Regex for usps.
-my $usps_qr = qr/u(?:nited|)s(?:states|)(?:p(?:ostal|)s(?:ervice|)|)/io;
+my $usps_qr = qr/u(?:nited|)s(?:states|)(?:p(?:ostal|)s(?:ervice|))/io;
 my $tracking_qr = qr/package|track(?:ing|)|num(?:ber|)|\#/i;
 
-triggers query_nowhitespace_nodash => qr/^
-                                         $usps_qr.*?([\d]{9,})\s*$|
-                                         ^([\d]{9,}).*?$usps_qr$|
+triggers query_nowhitespace_nodash => qr/
+                                         ^$usps_qr\s*([\d]{9,})\s*$|
+                                         ^([\d]{9,})\s*$usps_qr\s*$|
                                          ^$usps_qr?([a-z]{2}\d{9}us)$usps_qr?$|
-                                         ^(?:$tracking_qr|$usps_qr|)*([\d]{20,30})(?:$tracking_qr|$usps_qr|)*$
+                                         ^(?:$tracking_qr|$usps_qr|)*\s*([\d]{20,30})\s*(?:$tracking_qr|$usps_qr|)*$
                                         /xio;
 
 handle query_nowhitespace_nodash => sub {

--- a/t/USPS.t
+++ b/t/USPS.t
@@ -20,6 +20,23 @@ ddg_goodie_test(
         	heading => 'USPS Shipment Tracking',
         	html => qq(Track this shipment at <a href="https://tools.usps.com/go/TrackConfirmAction.action?tLabels=70000000000000000000">USPS</a>.)
         ),
+        '70000000000000000000' => test_zci(
+            "70000000000000000000",
+            heading => 'USPS Shipment Tracking',
+            html => qq(Track this shipment at <a href="https://tools.usps.com/go/TrackConfirmAction.action?tLabels=70000000000000000000">USPS</a>.)
+        ),
+        'usps 37346365253153' => test_zci(
+            "37346365253153",
+            heading => 'USPS Shipment Tracking',
+            html => qq(Track this shipment at <a href="https://tools.usps.com/go/TrackConfirmAction.action?tLabels=37346365253153">USPS</a>.)
+        ),
+
+        # test that numbers with other text around don't trigger
+        '70000000000000000000 eur to us' => undef,
+        'what is 70000000000000000000' => undef,
+
+        # test that numbers that don't pass the checksum don't trigger
+        '70000000000000000001' => undef,
 );
 
 done_testing;


### PR DESCRIPTION
add some more tests, and make regexes allow whitespaces but not other chars

Should solve #1175