### PR TITLE
Trigger Pi goodie with π

### DIFF
--- a/lib/DDG/Goodie/Pi.pm
+++ b/lib/DDG/Goodie/Pi.pm
@@ -2,6 +2,7 @@ package DDG::Goodie::Pi;
 # ABSTRACT: This Goodie returns 'pi' to a user-specified number of decimal places
 
 use DDG::Goodie;
+use utf8;
 
 zci answer_type => "pi";
 zci is_cached   => 1;

--- a/t/Pi.t
+++ b/t/Pi.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use Test::More;
 use DDG::Test::Goodie;
+use utf8;
 
 zci answer_type => "pi";
 zci is_cached   => 1;
@@ -28,6 +29,24 @@ ddg_goodie_test(
 		input => [],
 		operation => ["First 12 digits of Pi"],
 		result => "3.141592653589"
+	}),
+    '12 digits of π' => test_zci("3.141592653589",
+	structured_answer => {
+		input => [],
+		operation => ["First 12 digits of Pi"],
+		result => "3.141592653589"
+	}),
+    'pi to 6 digits' => test_zci("3.141592",
+	structured_answer => {
+		input => [],
+		operation => ["First 6 digits of Pi"],
+		result => "3.141592"
+	}),
+    'π to 6 digits' => test_zci("3.141592",
+	structured_answer => {
+		input => [],
+		operation => ["First 6 digits of Pi"],
+		result => "3.141592"
 	}),
 
 	'pi ff' => undef,


### PR DESCRIPTION
as discussed with @mintsoft, adding `use utf8` did the trick.

Also added some new tests for the trigger :dart: 

How it looks before the fix:

![before](https://cloud.githubusercontent.com/assets/104916/8271898/fee101aa-17fc-11e5-8936-fb85a96cd83f.png)

And after:

![after](https://cloud.githubusercontent.com/assets/104916/8271900/498eb9b8-17fd-11e5-9db1-fee7fd7cf6b7.png)

should fix #1037