### PR TITLE
Cheatsheets: Adding hover over full tr

### DIFF
--- a/share/goodie/cheat_sheets/cheat_sheets.css
+++ b/share/goodie/cheat_sheets/cheat_sheets.css
@@ -19,6 +19,14 @@
     margin-bottom: 30px;
 }
 
+.zci--cheat_sheets table {
+    width: 100%;
+}
+
+.zci--cheat_sheets tr:hover {
+    background: #e0e0e0;
+}
+
 .zci--cheat_sheets td {
     vertical-align: top;
 }


### PR DESCRIPTION
Hey guys!

This is my first pull request in a long time.

I was looking over the regex cheat sheet, and thought since there was so many it would be nice to have the ability to hover and have a simple background over the full `<tr>`.

I've attached a screenshot of the change in browser. 

![screen shot 2015-06-28 at 7 48 58 pm](https://cloud.githubusercontent.com/assets/1043478/8399224/319351d4-1dcf-11e5-9328-12c0ab09bdf2.png)

I'm trying to amp up my javascript skills to help with some more with instant answers, but would be more than happy to help clean up some styles if y'all know of any. 

Thanks for creating an awesome web experience, and I hope I can help contribute to making it awesome!