### PR TITLE
Add SMS cheatsheets 

### DIFF
--- a/share/goodie/cheat_sheets/sms.json
+++ b/share/goodie/cheat_sheets/sms.json
@@ -20,24 +20,24 @@
                 "val":"By The Way"
             },
             {
-                "key": "ASAP",
-                "val": "As Soon As Possible"
+                "key":"ASAP",
+                "val":"As Soon As Possible"
             },
             {
-                "key": "OMG",
-                "val": "Oh My Gosh"
+                "key":"OMG",
+                "val":"Oh My Gosh"
             },
             {
                 "key":"C U or cya",
                 "val":"See You"
             },
             {
-                "key": "LOL",
-                "val": "Laugh Out Loud"
+                "key":"LOL",
+                "val":"Laugh Out Loud"
             },
             {
-                "key": "ROFL or ROTFL",
-                "val": "Rolling On The Floor Laughing"
+                "key":"ROFL or ROTFL",
+                "val":"Rolling On The Floor Laughing"
             },
             {
                 "key":"HAND",
@@ -56,24 +56,24 @@
                 "val":"What are You Doing"
             },
             {
-                "key": "C U L8R",
-                "val": "See you later"
+                "key":"C U L8R",
+                "val":"See you later"
             },
             {
-                "key": "TTYL",
-                "val": "Talk To You Later"
+                "key":"TTYL",
+                "val":"Talk To You Later"
             },
             {
-                "key": "ILU",
-                "val": "I Love You"
+                "key":"ILU",
+                "val":"I Love You"
             },
             {
                 "key":"IDK",
                 "val":"I Don't Know"
             },
             {
-                "key": "hh  ",
-                "val": "Ha Ha"
+                "key":"hh",
+                "val":"Ha Ha"
             },
             {
                 "key":"FYI",
@@ -90,12 +90,12 @@
         ],
         "Others": [
             {
-                "key": "TIME",
-                "val": "Tears in my eyes"
+                "key":"TIME",
+                "val":"Tears in my eyes"
             },
             {
-                "key": "SAL",
-                "val": "Such A Laugh"
+                "key":"SAL",
+                "val":"Such A Laugh"
             },
             {
                 "key":"ATM",
@@ -110,32 +110,32 @@
                 "val":"Stop What You're Doing"
             },
             {
-                "key": "AFAIK",
-                "val": "As Far As I Know"
+                "key":"AFAIK",
+                "val":"As Far As I Know"
             },
             {
-                "key": "AFK",
-                "val": "Away From Keyboard"
+                "key":"AFK",
+                "val":"Away From Keyboard"
             },
             {
                 "key":"KISS",
                 "val":"Keep It Simple,Stupid"
             },
             {
-                "key": "SWAK",
-                "val": "Sealed with A Kiss"
+                "key":"SWAK",
+                "val":"Sealed with A Kiss"
             },
             {
-                "key": "YOYO",
-                "val": "You’re on your own"
+                "key":"YOYO",
+                "val":"You’re on your own"
             },
             {
-                "key": "WDYMBT",
-                "val": "What Do You Mean By That"
+                "key":"WDYMBT",
+                "val":"What Do You Mean By That"
             },
             {
-                "key": "LTWT or LWT or LW",
-                "val": "Loving the weather today"
+                "key":"LTWT or LWT or LW",
+                "val":"Loving the weather today"
             },
             {
                 "key":"SMH",
@@ -155,54 +155,54 @@
             },
             {
                 "key":"WTF",
-                "val":"What The Fuck?"
+                "val":"What The #$%@?"
             },
             {
                 "key":"STFU",
-                "val":"Shut The Fuck Up"
+                "val":"Shut The #$%@ Up"
             }
      
         ],
         "Abbrivated": [
             {
-                "key": "THX",
-                "val": "Thanks"               
+                "key":"THX",
+                "val":"Thanks"               
             }, 
             {
-                "key": "2day",
-                "val": "Today"
+                "key":"2day",
+                "val":"Today"
             },
             {
-                "key":" 2mro or 2moro or 2mrw ",
+                "key":"2mro or 2moro or 2mrw",
                 "val":"Tomorrow"
             },
             {
-                "key": "B4",
-                "val": "Before"
+                "key":"B4",
+                "val":"Before"
             },
             {
-                "key": "4get",
-                "val": "Forget"
+                "key":"4get",
+                "val":"Forget"
             },
             {
                 "key":"LUV",
                 "val":"Love"
             },
             {
-                "key": "B/C",
-                "val": "Because"
+                "key":"B/C",
+                "val":"Because"
             },
             {
                 "key":"njoy",
                 "val":"enjoy"
             },
             {
-                "key": "MSG",
-                "val": "Message"
+                "key":"MSG",
+                "val":"Message"
             },
             {
-                "key": "PLZ",
-                "val": "Please"
+                "key":"PLZ",
+                "val":"Please"
             },
             {
                 "key":"@",
@@ -213,8 +213,8 @@
                 "val":"Easy"
             },
             {
-                "key": "GR8",
-                "val": "Great"
+                "key":"GR8",
+                "val":"Great"
             },
             {
                 "key":"any1 or ne1",

--- a/share/goodie/cheat_sheets/sms.json
+++ b/share/goodie/cheat_sheets/sms.json
@@ -1,0 +1,241 @@
+{
+    "id": "sms_cheat_sheet", 
+    "name": "SMS",
+    "description": "Short Message Service (SMS) Language", 
+    "metadata": { 
+        "sourceName": "SMSCheatSheet",
+        "sourceURL": "https://en.wikipedia.org/wiki/SMS_language"
+        },
+    "section_order": [  
+        "Frequently Used",
+        "Others",
+        "Abbrivated"
+        
+    ],
+    "sections": {
+        "Frequently Used": [
+           
+            {
+                "key":"BTW",
+                "val":"By The Way"
+            },
+            {
+                "key": "ASAP",
+                "val": "As Soon As Possible"
+            },
+            {
+                "key": "OMG",
+                "val": "Oh My Gosh"
+            },
+            {
+                "key":"C U or cya",
+                "val":"See You"
+            },
+            {
+                "key": "LOL",
+                "val": "Laugh Out Loud"
+            },
+            {
+                "key": "ROFL or ROTFL",
+                "val": "Rolling On The Floor Laughing"
+            },
+            {
+                "key":"HAND",
+                "val":"Have A Nice Day"
+            },
+            {
+                "key":"JK",
+                "val":"Just kidding"
+            },
+            {
+                "key":"SWYP",
+                "val":"So what’s your problem?"
+            },
+            {
+                "key":"WYD",
+                "val":"What are You Doing"
+            },
+            {
+                "key": "C U L8R",
+                "val": "See you later"
+            },
+            {
+                "key": "TTYL",
+                "val": "Talk To You Later"
+            },
+            {
+                "key": "ILU",
+                "val": "I Love You"
+            },
+            {
+                "key":"IDK",
+                "val":"I Don't Know"
+            },
+            {
+                "key": "hh  ",
+                "val": "Ha Ha"
+            },
+            {
+                "key":"FYI",
+                "val":"For Your Information"
+            },
+            {
+                "key":"BFN",
+                "val":"Bye For Now"
+            },
+            {
+                "key":"IH8U",
+                "val":"I Hate You"
+            }
+        ],
+        "Others": [
+            {
+                "key": "TIME",
+                "val": "Tears in my eyes"
+            },
+            {
+                "key": "SAL",
+                "val": "Such A Laugh"
+            },
+            {
+                "key":"ATM",
+                "val":"At The Moment"
+            },
+            {
+                "key":"WYA",
+                "val":"Where are You At"
+            },
+            {
+                "key":"SWYD",
+                "val":"Stop What You're Doing"
+            },
+            {
+                "key": "AFAIK",
+                "val": "As Far As I Know"
+            },
+            {
+                "key": "AFK",
+                "val": "Away From Keyboard"
+            },
+            {
+                "key":"KISS",
+                "val":"Keep It Simple,Stupid"
+            },
+            {
+                "key": "SWAK",
+                "val": "Sealed with A Kiss"
+            },
+            {
+                "key": "YOYO",
+                "val": "You’re on your own"
+            },
+            {
+                "key": "WDYMBT",
+                "val": "What Do You Mean By That"
+            },
+            {
+                "key": "LTWT or LWT or LW",
+                "val": "Loving the weather today"
+            },
+            {
+                "key":"SMH",
+                "val":"Shake My Head (disapproval/frustration)"
+            },
+            {
+                "key":"GF",
+                "val":"Girlfriend"
+            },
+            {
+                "key":"BF or BFF",
+                "val":"Best Friend/Boyfriend or Best Friend Forever/Boyfriend Forever"
+            },
+            {
+                "key":"WTH",
+                "val":"What The Hell?"
+            },
+            {
+                "key":"WTF",
+                "val":"What The Fuck?"
+            },
+            {
+                "key":"STFU",
+                "val":"Shut The Fuck Up"
+            }
+     
+        ],
+        "Abbrivated": [
+            {
+                "key": "THX",
+                "val": "Thanks"               
+            }, 
+            {
+                "key": "2day",
+                "val": "Today"
+            },
+            {
+                "key":" 2mro or 2moro or 2mrw ",
+                "val":"Tomorrow"
+            },
+            {
+                "key": "B4",
+                "val": "Before"
+            },
+            {
+                "key": "4get",
+                "val": "Forget"
+            },
+            {
+                "key":"LUV",
+                "val":"Love"
+            },
+            {
+                "key": "B/C",
+                "val": "Because"
+            },
+            {
+                "key":"njoy",
+                "val":"enjoy"
+            },
+            {
+                "key": "MSG",
+                "val": "Message"
+            },
+            {
+                "key": "PLZ",
+                "val": "Please"
+            },
+            {
+                "key":"@",
+                "val":"At"
+            },
+            {
+                "key":"ez",
+                "val":"Easy"
+            },
+            {
+                "key": "GR8",
+                "val": "Great"
+            },
+            {
+                "key":"any1 or ne1",
+                "val":"Anyone"
+            },
+            {
+                "key":"1drfl",
+                "val":"Wonderful"
+            },
+            {
+                "key":"sum1",
+                "val":"Someone"
+            },
+            {
+                "key":"no1",
+                "val":"no one "
+            },
+            {
+                "key":"ur",
+                "val":"your and you're"
+            }
+        ]
+    }
+}

--- a/share/goodie/cheat_sheets/sms.json
+++ b/share/goodie/cheat_sheets/sms.json
@@ -3,239 +3,569 @@
     "name": "SMS",
     "description": "Short Message Service (SMS) Language", 
     "metadata": { 
-        "sourceName": "SMSCheatSheet",
+        "sourceName": "Wikipedia",
         "sourceURL": "https://en.wikipedia.org/wiki/SMS_language"
         },
     "section_order": [  
-        "Frequently Used",
-        "Others",
-        "Abbrivated"
-        
+        "[0-9]",
+	"A",
+	"B",
+	"C",
+	"D",
+	"E",
+	"F",
+	"G",
+	"H",
+	"I",
+	"J",
+	"K",
+	"L",
+	"M",
+	"N",
+	"O",
+	"P",
+	"Q",
+	"R",
+	"S",
+	"T",
+	"U",
+	"V",
+	"W",
+	"X",
+	"Y",
+	"Z"
     ],
     "sections": {
-        "Frequently Used": [
-           
-            {
-                "key":"BTW",
-                "val":"By The Way"
-            },
-            {
-                "key":"ASAP",
-                "val":"As Soon As Possible"
-            },
-            {
-                "key":"OMG",
-                "val":"Oh My Gosh"
-            },
-            {
-                "key":"C U or cya",
-                "val":"See You"
-            },
-            {
-                "key":"LOL",
-                "val":"Laugh Out Loud"
-            },
-            {
-                "key":"ROFL or ROTFL",
-                "val":"Rolling On The Floor Laughing"
-            },
-            {
-                "key":"HAND",
-                "val":"Have A Nice Day"
-            },
-            {
-                "key":"JK",
-                "val":"Just kidding"
-            },
-            {
-                "key":"SWYP",
-                "val":"So what’s your problem?"
-            },
-            {
-                "key":"WYD",
-                "val":"What are You Doing"
-            },
-            {
-                "key":"C U L8R",
-                "val":"See you later"
-            },
-            {
-                "key":"TTYL",
-                "val":"Talk To You Later"
-            },
-            {
-                "key":"ILU",
-                "val":"I Love You"
-            },
-            {
-                "key":"IDK",
-                "val":"I Don't Know"
-            },
-            {
-                "key":"hh",
-                "val":"Ha Ha"
-            },
-            {
-                "key":"FYI",
-                "val":"For Your Information"
-            },
-            {
-                "key":"BFN",
-                "val":"Bye For Now"
-            },
-            {
-                "key":"IH8U",
-                "val":"I Hate You"
-            }
-        ],
-        "Others": [
-            {
-                "key":"TIME",
-                "val":"Tears in my eyes"
-            },
-            {
-                "key":"SAL",
-                "val":"Such A Laugh"
-            },
-            {
-                "key":"ATM",
-                "val":"At The Moment"
-            },
-            {
-                "key":"WYA",
-                "val":"Where are You At"
-            },
-            {
-                "key":"SWYD",
-                "val":"Stop What You're Doing"
-            },
-            {
-                "key":"AFAIK",
-                "val":"As Far As I Know"
-            },
-            {
-                "key":"AFK",
-                "val":"Away From Keyboard"
-            },
-            {
-                "key":"KISS",
-                "val":"Keep It Simple,Stupid"
-            },
-            {
-                "key":"SWAK",
-                "val":"Sealed with A Kiss"
-            },
-            {
-                "key":"YOYO",
-                "val":"You’re on your own"
-            },
-            {
-                "key":"WDYMBT",
-                "val":"What Do You Mean By That"
-            },
-            {
-                "key":"LTWT or LWT or LW",
-                "val":"Loving the weather today"
-            },
-            {
-                "key":"SMH",
-                "val":"Shake My Head (disapproval/frustration)"
-            },
-            {
-                "key":"GF",
-                "val":"Girlfriend"
-            },
-            {
-                "key":"BF or BFF",
-                "val":"Best Friend/Boyfriend or Best Friend Forever/Boyfriend Forever"
-            },
-            {
-                "key":"WTH",
-                "val":"What The Hell?"
-            },
-            {
-                "key":"WTF",
-                "val":"What The #$%@?"
-            },
-            {
-                "key":"STFU",
-                "val":"Shut The #$%@ Up"
-            }
-     
-        ],
-        "Abbrivated": [
-            {
-                "key":"THX",
-                "val":"Thanks"               
-            }, 
-            {
-                "key":"2day",
-                "val":"Today"
-            },
-            {
-                "key":"2mro or 2moro or 2mrw",
-                "val":"Tomorrow"
-            },
-            {
-                "key":"B4",
-                "val":"Before"
-            },
-            {
-                "key":"4get",
-                "val":"Forget"
-            },
-            {
-                "key":"LUV",
-                "val":"Love"
-            },
-            {
-                "key":"B/C",
-                "val":"Because"
-            },
-            {
-                "key":"njoy",
-                "val":"enjoy"
-            },
-            {
-                "key":"MSG",
-                "val":"Message"
-            },
-            {
-                "key":"PLZ",
-                "val":"Please"
-            },
-            {
-                "key":"@",
-                "val":"At"
-            },
-            {
-                "key":"ez",
-                "val":"Easy"
-            },
-            {
-                "key":"GR8",
-                "val":"Great"
-            },
-            {
-                "key":"any1 or ne1",
-                "val":"Anyone"
-            },
-            {
-                "key":"1drfl",
-                "val":"Wonderful"
-            },
-            {
-                "key":"sum1",
-                "val":"Someone"
-            },
-            {
-                "key":"no1",
-                "val":"no one "
-            },
-            {
-                "key":"ur",
-                "val":"your and you're"
-            }
-        ]
+	"[0-9]" : [
+		{
+                	"key":"2DAY",
+                	"val":"Today"
+		},
+		{
+                	"key":"2MRO or 2MORO or 2MRW",
+                	"val":"Tomorrow"
+            	},
+		{
+                	"key":"4GET",
+                	"val":"Forget"
+            	},
+		{
+                	"key":"@",
+                	"val":"At"
+            	},
+		{
+                	"key":"1DRFL",
+                	"val":"Wonderful"
+            	}
+	],
+ 	"A": [
+		{
+                        "key":"ASAP",
+                        "val":"As Soon As Possible"
+		},
+		{
+                        "key":"ANY1 or NE1",
+                        "val":"Anyone"
+		},
+		{
+                        "key":"ATM",
+                        "val":"At The Moment"
+               	},
+		{
+                        "key":"AFAIK",
+                        "val":"As Far As I Know"
+            	},
+		{
+                        "key":"AFK",
+                        "val":"Away From Keyboard"
+            	},
+		{
+                        "key":"ABT",
+                        "val":"About"
+            	},
+		{
+                        "key":"ABBR",
+                        "val":"Abbreviation"
+            	}
+	],
+	"B":[
+		{
+                        "key":"B4",
+                        "val":"Before"
+            	},
+		{
+                        "key":"BTW",
+                        "val":"By The Way"
+            	},
+	 	{	
+                        "key":"BFN",
+                        "val":"Bye For Now"
+            	},
+		{
+                        "key":"BF or BFF",
+                        "val":"Best Friend/Boyfriend or Best Friend Forever/Boyfriend Forever"
+            	},
+		{
+                        "key":"B/C",
+                        "val":"Because"
+            	},
+		{
+                        "key":"BDAY or B'DAY",
+                        "val":"Birthday"
+            	}
+	],
+	"C":[
+		{
+                        "key":"C U or cya",
+                        "val":"See You"
+        	},
+		{
+                        "key":"C U L8R",
+                        "val":"See you later"
+		},
+		{
+                        "key":"CAM",
+                        "val":"Camera"
+		},
+		{
+                        "key":"CHK",
+                        "val":"Check"
+		},
+		{
+                        "key":"CYA",
+                        "val":"See you"
+		}
+	],
+	"D":[
+		{
+                	"key":"DNR",
+                	"val":"Dinner"
+            	},
+		{
+                	"key":"DNT",
+                	"val":"Don't"
+            	},
+		{
+                	"key":"DIKU",
+                	"val":"Do I Know You"
+            	}
+	],
+	"E":[
+		{
+                	"key":"EZ or EZY",
+                	"val":"Easy"
+            	},
+		{
+                	"key":"ENUF",
+                	"val":"Enough"
+            	},
+		{
+                	"key":"EOD",
+                	"val":"End Of Day/Discussion"
+            	},
+		{
+                	"key":"ETA",
+                	"val":"Estimated Time of Arrival"
+            	}
+	],
+	"F":[
+		{
+                	"key":"FYI",
+                	"val":"For Your Information"
+            	},
+		{
+                	"key":"FAQ",
+                	"val":"Frequently asked questions"
+            	},
+		{
+                	"key":"FBFR",
+                	"val":"Facebook Friend"
+            	}
+	],
+	"G":[	
+		{
+                	"key":"GF",
+                	"val":"Girlfriend"
+            	},
+		{
+                	"key":"GR8",
+                	"val":"Great"
+            	},
+		{
+                	"key":"G2G or GTG",
+                	"val":"Got To Go"
+            	},
+		{
+                	"key":"G9",
+                	"val":"Genius"
+            	},
+		{
+                	"key":"GN or GNITE or GNIGHT",
+                	"val":"Good Night"
+            	},
+		{
+                	"key":"GUD",
+                	"val":"Good"
+            	}
+	],
+	"H":[
+		{
+                	"key":"HAND",
+                	"val":"Have A Nice Day"
+        	},
+		{
+                	"key":"HH",
+                	"val":"Ha Ha"
+		},
+                {
+                	"key":"H8",
+                	"val":"Hate"
+		},
+                {
+                	"key":"HBU",
+                	"val":"How About You?"
+		},
+                {
+                	"key":"HW",
+                	"val":"Homework"
+		},
+                {
+                	"key":"HRU",
+                	"val":"How Are You"
+		}
+	],
+	"I":[
+		{
+                        "key":"ILU or ILY",
+                        "val":"I Love You"
+		},
+		{
+                        "key":"IDK",
+                        "val":"I Don't Know"
+        	},
+		{
+                        "key":"IH8U",
+                        "val":"I Hate You"
+            	},
+                {
+                	"key":"IKR",
+                	"val":"I Know Right?"
+		}
+	],
+	"J":[
+		{
+                        "key":"JK",
+                        "val":"Just kidding"
+            	},
+                {
+                	"key":"JAM",
+                	"val":"Just A Minute"
+		},
+                {
+                	"key":"JDI",
+                	"val":"Just Do It"
+		}
+	],
+	"K":[
+                {
+                	"key":"K",
+                	"val":"Okay"
+		},		
+                {
+                        "key":"KISS",
+                        "val":"Keep It Simple,Stupid"
+            	},
+                {
+                	"key":"KIA",
+                	"val":"Know It All"
+		}
+	],
+	"L":[
+		{
+                        "key":"LOL",
+                        "val":"Laugh Out Loud"
+            	},
+                {
+                       	"key":"L8R",
+                  	"val":"Later"
+		},
+		{
+                        "key":"LTWT or LWT or LW",
+                        "val":"Loving the weather today"
+              	},
+		{
+                        "key":"LUV",
+                        "val":"Love"
+            	},
+                {
+                	"key":"LMAO",
+                	"val":"Laugh My #$% Out"
+		}
+	],
+	"M":[
+		{
+                        "key":"MSG",
+                        "val":"Message"
+            	},
+		{
+                        "key":"MGMT",
+                        "val":"Management"
+            	},
+		{
+                        "key":"MYT",
+                        "val":"Meet You there"
+            	}
+	],
+	"N":[
+		{
+                        "key":"NJOY",
+                        "val":"Enjoy"
+            	},
+		{
+                        "key":"NO1",
+                        "val":"No one "
+            	},
+		{
+                        "key":"N1",
+                        "val":"Nice One"
+            	},
+		{
+						"key":"NE",
+                        "val":"Any"
+            	},
+		{
+                        "key":"NTHING",
+                        "val":"Nothing"
+            	},
+		{
+                        "key":"NVR",
+                        "val":"Never"
+            	}
+	],
+	"O":[
+		{
+                        "key":"OMG",
+                        "val":"Oh My Gosh"
+            	},
+		{
+                        "key":"O4U",
+                        "val":"Only For You"
+            	},
+		{
+                        "key":"OBV",
+                        "val":"Obviously"
+            	},
+		{
+                        "key":"ORLY",
+                        "val":"Oh Really"
+            	}
+	],
+	"P":[
+		{
+                        "key":"PLZ or PLS",
+                        "val":"Please"
+            	},
+		{
+                        "key":"PCM",
+                        "val":"Please Call Me"
+            	},
+		{
+                        "key":"PEEPS or PPL",
+                        "val":"People"
+            	},
+		{
+                        "key":"PIC",
+                        "val":"Pictutre"
+            	},
+		{
+                        "key":"PM",
+                        "val":"Private Message"
+            	}
+	],
+	"Q":[
+		{
+                        "key":"QT",
+                        "val":"Cute"
+            	},
+		{
+                        "key":"Q",
+                        "val":"Queue"
+            	},
+		{
+                        "key":"QOTD",
+                        "val":"Quote Of The Day"
+            	}
+	],
+	"R":[
+		{
+                        "key":"R8",
+                        "val":"Rate"
+            	},
+		{
+                        "key":"ROFL or ROTFL",
+                        "val":"Rolling On The Floor Laughing"
+            	},
+		{
+                        "key":"RUOK",
+                        "val":"Are You Okay"
+            	},
+		{
+                        "key":"RIP",
+                        "val":"Rest In Peace"
+            	},
+		{
+                        "key":"RBAY",
+                        "val":"Right Back At You"
+            	}
+	],
+	"S":[
+		{
+                        "key":"sum1",
+                        "val":"Someone"
+            	},
+		{
+                        "key":"SWYP",
+                        "val":"So what’s your problem?"
+            	},
+		{
+                        "key":"SAL",
+                        "val":"Such A Laugh"
+          	},
+		{
+                        "key":"SWYD",
+                        "val":"Stop What You're Doing"
+              	},
+		{
+                        "key":"SWAK",
+                        "val":"Sealed with A Kiss"
+            	},
+		{
+                        "key":"SMH",
+                        "val":"Shake My Head (disapproval/frustration)"
+            	},
+		{
+                        "key":"STFU",
+                        "val":"Shut The #$%@ Up"
+           	}
+	],
+	"T":[
+		{
+                        "key":"TTYL",
+                        "val":"Talk To You Later"
+            	},
+	 	{
+                        "key":"TIME",
+                        "val":"Tears in my eyes"
+            	},
+		{
+                        "key":"THX or THNQ",
+                        "val":"Thanks or Thank You"
+            	},
+		{
+                        "key":"T+",
+                        "val":"Think Positive"
+            	},
+		{
+                        "key":"TMB",
+                        "val":"Text Me Back"
+            	}
+	],
+	"U":[
+		{
+                        "key":"ur",
+                        "val":"your and you're"
+            	},
+		{
+                        "key":"UW",
+                        "val":"Your Welcome"
+            	},
+		{
+                        "key":"UT2L",
+                        "val":"You Take Too Long"
+            	},
+		{
+                        "key":"U4E",
+                        "val":"You Forever"
+            	}
+	],
+	"V":[
+		{
+                        "key":"V or VRY",
+                        "val":"Very"
+            	},
+		{
+                        "key":"VIP",
+                        "val":"Very Important Person"
+            	}
+
+	],
+	"W":[
+		{
+                        "key":"W@",
+                        "val":"What?"
+            	},
+		{
+                        "key":"WYD",
+                        "val":"What are You Doing"
+            	},
+		{
+                        "key":"WYA",
+                        "val":"Where are You At"
+            	},
+		{
+                        "key":"WDYMBT",
+                        "val":"What Do You Mean By That"
+            	},
+		{
+                        "key":"WTH",
+                        "val":"What The Hell?"
+            	},
+		{
+                        "key":"WTF",
+                        "val":"What The #$%@?"
+            	}		
+	],
+	"X":[
+		{
+                        "key":"XLNT",
+                        "val":"Excellent"
+            	},
+		{
+                        "key":"XD",
+                        "val":"Really Hard Laugh"
+            	},
+		{
+                        "key":"XME",
+                        "val":"Excuse Me"
+            	}
+	],
+	"Y":[
+		{
+                        "key":"YOYO",
+                        "val":"You’re on your own"
+                },
+                {
+                        "key":"YR",
+                        "val":"Your or Yeah Right "
+            	},
+		{
+                        "key":"YT",
+                        "val":"You There ?"
+            	},
+		{
+                        "key":"YAHOO",
+                        "val":"You Always Have Other Options"
+            	}
+	],
+	"Z":[
+		{
+                        "key":"Z",
+                        "val":"Zero or 'Said'"
+            	},
+		{
+                        "key":"ZZZZZ",
+                        "val":"Sleeping"
+            	}
+	]
     }
 }


### PR DESCRIPTION
**What does your Instant Answer do?**
It provides CheatSheet for SMS Language

**What problem does your Instant Answer solve (Why is it better than organic links)?**
It's better because it's a Zero Click Info

**What is the data source for your Instant Answer? (Provide a link if possible)**
Wikipedia - https://en.wikipedia.org/wiki/SMS_language

**Why did you choose this data source?**
Reliable and constantly updated by the community.

**Are there any other alternative (better) data sources?**
Not required.

**What are some example queries that trigger this Instant Answer?**
"sms cheat sheets"

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Readers 

**Is this Instant Answer connected to a DuckDuckHack Instant Answer idea?**
It's taken from the ideas list provided by @zekiel for a meetup event.

**Which existing Instant Answers will this one supercede/overlap with?**
None

**Are you having any problems? Do you need our help with anything?**
I would like to add few more example queries like "sms cheats" , "sms language" etc .
Its currently not working as I am new to DuckDuckGoHack on IA I do not know how to do this . 
Just learnt this today in the meetup. 

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![screenshot from 2015-07-05 23 05 36](https://cloud.githubusercontent.com/assets/8341726/8512689/333911b6-236c-11e5-9502-0e89d8a1514e.png)
![screenshot from 2015-07-05 23 05 57](https://cloud.githubusercontent.com/assets/8341726/8512679/b4f89fc4-236b-11e5-861e-7faa9722f243.png)

IA Page: https://duck.co/ia/view/sms_cheat_sheet
