### PR TITLE
Allow "unix" and "files?" in UnixPermissions trigger

### DIFF
--- a/lib/DDG/Goodie/UnixPermissions.pm
+++ b/lib/DDG/Goodie/UnixPermissions.pm
@@ -21,7 +21,7 @@ category 'computing_tools';
 handle query => sub {
     my $query = $_;
 
-    s/\s*(chmod|permissions?)\s*//g;
+    s/\s*(unix|files?|chmod|permissions?)\s*//g;
     return unless /^(0|1|2|4|6|7)?([0-7]{3})$/;
 
     my $plain_output;

--- a/t/UnixPermissions.t
+++ b/t/UnixPermissions.t
@@ -6,6 +6,28 @@ use DDG::Test::Goodie;
 zci answer_type => 'unix_permissions';
 zci is_cached => 1;
 
+sub _expected_result {
+    return {
+            id => 'UnixPermissions',
+            description => 'Unix file permission',
+            meta => {
+                sourceName => 'wikipedia',
+                sourceUrl => 'https://en.wikipedia.org/wiki/Permissions#Notation_of_traditional_Unix_permissions'
+            },
+            templates => {
+                group => 'list',
+                options => {
+                    content => 'record',
+                },
+            },
+            data => {
+                title => 'Unix file permissions',
+                record_keys => ["symbolic", "user", "group", "others", "attributes",],
+                record_data => (@_),
+            },
+        }
+}
+
 ddg_goodie_test(
     [qw(
         DDG::Goodie::UnixPermissions
@@ -17,31 +39,13 @@ User: read, write and execute
 Group: read and execute
 Others: read and execute
 ',
-        structured_answer => {
-            id => 'UnixPermissions',
-            description => 'Unix file permission',
-            meta => {
-                sourceName => 'wikipedia',
-                sourceUrl => 'https://en.wikipedia.org/wiki/Permissions#Notation_of_traditional_Unix_permissions'
-            },
-            templates => {
-                group => 'list',
-                options => {
-                    content => 'record',
-                },
-            },
-            data => {
-                title => 'Unix file permissions',
-                record_keys => ["symbolic", "user", "group", "others", "attributes",],
-                record_data => {
-                    symbolic => 'rwxr-xr-x',
-                    user => 'read, write and execute',
-                    group => 'read and execute',
-                    others => 'read and execute',
-                    attributes => undef,
-                },
-            },
-        },
+        structured_answer => _expected_result({
+            symbolic => 'rwxr-xr-x',
+            user => 'read, write and execute',
+            group => 'read and execute',
+            others => 'read and execute',
+            attributes => undef,
+        }),
     ),
 
     'permission 0644' => test_zci(
@@ -51,31 +55,13 @@ User: read and write
 Group: read
 Others: read
 ',
-        structured_answer => {
-            id => 'UnixPermissions',
-            description => 'Unix file permission',
-            meta => {
-                sourceName => 'wikipedia',
-                sourceUrl => 'https://en.wikipedia.org/wiki/Permissions#Notation_of_traditional_Unix_permissions'
-            },
-            templates => {
-                group => 'list',
-                options => {
-                    content => 'record',
-                },
-            },
-            data => {
-                title => 'Unix file permissions',
-                record_keys => ["symbolic", "user", "group", "others", "attributes",],
-                record_data => {
-                    symbolic => 'rw-r--r--',
-                    user => 'read and write',
-                    group => 'read',
-                    others => 'read',
-                    attributes => undef,
-                },
-            },
-        },
+        structured_answer => _expected_result({
+            symbolic => 'rw-r--r--',
+            user => 'read and write',
+            group => 'read',
+            others => 'read',
+            attributes => undef,
+        })
     ),
 
     'permission 7644' => test_zci(
@@ -86,31 +72,13 @@ Group: read
 Others: read
 Attributes: sticky, setuid and setgid
 ',
-        structured_answer => {
-            id => 'UnixPermissions',
-            description => 'Unix file permission',
-            meta => {
-                sourceName => 'wikipedia',
-                sourceUrl => 'https://en.wikipedia.org/wiki/Permissions#Notation_of_traditional_Unix_permissions'
-            },
-            templates => {
-                group => 'list',
-                options => {
-                    content => 'record',
-                },
-            },
-            data => {
-                title => 'Unix file permissions',
-                record_keys => ["symbolic", "user", "group", "others", "attributes",],
-                record_data => {
-                    symbolic => 'rwSr-Sr-T',
-                    user => 'read and write',
-                    group => 'read',
-                    others => 'read',
-                    attributes => 'sticky, setuid and setgid',
-                },
-            },
-        },
+        structured_answer => _expected_result({
+            symbolic => 'rwSr-Sr-T',
+            user => 'read and write',
+            group => 'read',
+            others => 'read',
+            attributes => 'sticky, setuid and setgid',
+        })
     ),
 
     'permission 9644' => undef,

--- a/t/UnixPermissions.t
+++ b/t/UnixPermissions.t
@@ -80,6 +80,21 @@ Attributes: sticky, setuid and setgid
             attributes => 'sticky, setuid and setgid',
         })
     ),
+    'unix file permissions chmod 777' => test_zci(
+'777 (octal)
+rwxrwxrwx (symbolic)
+User: read, write and execute
+Group: read, write and execute
+Others: read, write and execute
+',
+        structured_answer => _expected_result({
+            symbolic => 'rwxrwxrwx',
+            user => 'read, write and execute',
+            group => 'read, write and execute',
+            others => 'read, write and execute',
+            attributes => undef,
+        }),
+    ),
 
     'permission 9644' => undef,
 );


### PR DESCRIPTION
As reported in #1202, if "unix", "file" or "files" was in the query, the IA was triggered but then discarded:

![notfixed](https://cloud.githubusercontent.com/assets/104916/8549048/9f720f42-2496-11e5-95fb-9d7fdcebb07c.png)

This fixes it:

![now](https://cloud.githubusercontent.com/assets/104916/8549052/a558e69c-2496-11e5-99ad-6976aa21c74b.png)
