### PR TITLE
SubnetCalc: Updating to use the record template

### DIFF
--- a/lib/DDG/Goodie/SubnetCalc.pm
+++ b/lib/DDG/Goodie/SubnetCalc.pm
@@ -121,7 +121,6 @@ handle query => sub {
     return to_text(\%output, \@output_keys),
 		structured_answer => {
 			id => "subnet_calculator",
-			description => "Calculates IPv4 Subnets to and from CIDR notation",
 			name => "Subnet Calculator",
 			templates => {
 				group => 'list',

--- a/lib/DDG/Goodie/SubnetCalc.pm
+++ b/lib/DDG/Goodie/SubnetCalc.pm
@@ -98,42 +98,42 @@ handle query => sub {
     $which_specified = "Host Only" if ($cidr == 32);
 
     my %output = (
-		"Network" => int_to_str($network) . "/$cidr (Class $class)",
-		"Netmask" => int_to_str($mask),
-		"Specified" => "$which_specified",
+        "Network" => int_to_str($network) . "/$cidr (Class $class)",
+        "Netmask" => int_to_str($mask),
+        "Specified" => "$which_specified",
     );
 
-	my @output_keys = qw(Network Netmask Specified);
+    my @output_keys = qw(Network Netmask Specified);
 	
     unless($cidr > 30) {
-		$output{"Host Address Range"} = int_to_str($start) . "-" . int_to_str($end) . " ($host_count hosts)";
-		$output{"Broadcast"} = int_to_str($broadcast);
-		push @output_keys, "Host Address Range";
-		push @output_keys, "Broadcast";
+        $output{"Host Address Range"} = int_to_str($start) . "-" . int_to_str($end) . " ($host_count hosts)";
+        $output{"Broadcast"} = int_to_str($broadcast);
+        push @output_keys, "Host Address Range";
+        push @output_keys, "Broadcast";
     }
 
-	sub to_text
-	{
-		my ($data, $keys) = @_;
-		return join "\n", map {"$_: $data->{$_}";} @{$keys};
-	}
+    sub to_text
+    {
+        my ($data, $keys) = @_;
+        return join "\n", map {"$_: $data->{$_}";} @{$keys};
+    }
 	
     return to_text(\%output, \@output_keys),
-		structured_answer => {
-			id => "subnet_calculator",
-			name => "Subnet Calculator",
-			templates => {
-				group => 'list',
-				options => {
-					content => 'record'
-				}
-			},
-			data => {
-				title => 'IPv4 Subnet',
-				record_data => \%output,
-				record_keys => \@output_keys,
-			}
-		};
+        structured_answer => {
+            id => "subnet_calculator",
+            name => "Subnet Calculator",
+            templates => {
+                group => 'list',
+                options => {
+                    content => 'record'
+                }
+            },
+            data => {
+                title => 'IPv4 Subnet',
+                record_data => \%output,
+                record_keys => \@output_keys,
+            }
+        };
 };
 
 1;

--- a/lib/DDG/Goodie/SubnetCalc.pm
+++ b/lib/DDG/Goodie/SubnetCalc.pm
@@ -104,7 +104,7 @@ handle query => sub {
     );
 
     my @output_keys = qw(Network Netmask Specified);
-	
+
     unless($cidr > 30) {
         $output{"Host Address Range"} = int_to_str($start) . "-" . int_to_str($end) . " ($host_count hosts)";
         $output{"Broadcast"} = int_to_str($broadcast);
@@ -117,7 +117,7 @@ handle query => sub {
         my ($data, $keys) = @_;
         return join "\n", map {"$_: $data->{$_}";} @{$keys};
     }
-	
+
     return to_text(\%output, \@output_keys),
         structured_answer => {
             id => "subnet_calculator",
@@ -125,7 +125,8 @@ handle query => sub {
             templates => {
                 group => 'list',
                 options => {
-                    content => 'record'
+                    content => 'record',
+                    moreAt => 0
                 }
             },
             data => {

--- a/lib/DDG/Goodie/SubnetCalc.pm
+++ b/lib/DDG/Goodie/SubnetCalc.pm
@@ -7,10 +7,9 @@ use warnings;
 
 use DDG::Goodie;
 
-# TODO: This (sh|c)ould be re-written to be more precise
-triggers query => qr#^([0-9]{1,3}\.){3}([0-9]{1,3})[\s/](([1-3]?[0-9])|(([0-9]{1,3}\.){3}([0-9]{1,3})))$#;
+triggers query => qr#^(?:[0-9]{1,3}\.){3}(?:[0-9]{1,3})[\s/](?:(?:[1-3]?[0-9])|(?:(?:[0-9]{1,3}\.){3}(?:[0-9]{1,3})))$#x;
 
-zci answer_type => "subnet_info";
+zci answer_type => "subnet_calc";
 zci is_cached => 1;
 
 attribution github => ['mintsoft', 'Rob Emery'];
@@ -121,8 +120,9 @@ handle query => sub {
 	
     return to_text(\%output, \@output_keys),
 		structured_answer => {
-			id => "Subnet Calculator",
+			id => "subnet_calculator",
 			description => "Calculates IPv4 Subnets to and from CIDR notation",
+			name => "Subnet Calculator",
 			templates => {
 				group => 'list',
 				options => {

--- a/share/goodie/subnet_calc/subnet_calc.css
+++ b/share/goodie/subnet_calc/subnet_calc.css
@@ -1,0 +1,3 @@
+.record .record__cell--key {
+    width: 9.7em;
+}

--- a/share/goodie/subnet_calc/subnet_calc.css
+++ b/share/goodie/subnet_calc/subnet_calc.css
@@ -1,3 +1,3 @@
-.record .record__cell--key {
+.zci--subnet_calc .record .record__cell--key {
     width: 9.7em;
 }

--- a/t/SubnetCalc.t
+++ b/t/SubnetCalc.t
@@ -15,7 +15,6 @@ sub build_structure
 	return {
 			id => "subnet_calculator",
 			name => "Subnet Calculator",
-			description => "Calculates IPv4 Subnets to and from CIDR notation",
 			templates => {
 				group => 'list',
 				options => {

--- a/t/SubnetCalc.t
+++ b/t/SubnetCalc.t
@@ -15,19 +15,19 @@ ddg_goodie_test(
         'DDG::Goodie::SubnetCalc'
     ],
     "10.0.0.0/24" => test_zci(
-	"Network: 10.0.0.0/24 (Class A)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 10.0.0.1-10.0.0.254 (254 hosts)\nBroadcast: 10.0.0.255\n", html => qr/.*/),
+	"Network: 10.0.0.0/24 (Class A)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 10.0.0.1-10.0.0.254 (254 hosts)\nBroadcast: 10.0.0.255", html => qr/.*/),
 
     "192.168.0.0/24" => test_zci(
-	"Network: 192.168.0.0/24 (Class C)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 192.168.0.1-192.168.0.254 (254 hosts)\nBroadcast: 192.168.0.255\n",html => qr/.*/),
+	"Network: 192.168.0.0/24 (Class C)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 192.168.0.1-192.168.0.254 (254 hosts)\nBroadcast: 192.168.0.255",html => qr/.*/),
 
     "8.8.8.8 255.255.224.0" => test_zci(
-	"Network: 8.8.0.0/19 (Class A)\nNetmask: 255.255.224.0\nSpecified: Host #2056\nHost Address Range: 8.8.0.1-8.8.31.254 (8190 hosts)\nBroadcast: 8.8.31.255\n", html => qr/.*/),
+	"Network: 8.8.0.0/19 (Class A)\nNetmask: 255.255.224.0\nSpecified: Host #2056\nHost Address Range: 8.8.0.1-8.8.31.254 (8190 hosts)\nBroadcast: 8.8.31.255", html => qr/.*/),
 
     '46.51.197.88/255.255.254.0' => test_zci(
-    "Network: 46.51.196.0/23 (Class A)\nNetmask: 255.255.254.0\nSpecified: Host #344\nHost Address Range: 46.51.196.1-46.51.197.254 (510 hosts)\nBroadcast: 46.51.197.255\n", html => qr/.*/),
+    "Network: 46.51.196.0/23 (Class A)\nNetmask: 255.255.254.0\nSpecified: Host #344\nHost Address Range: 46.51.196.1-46.51.197.254 (510 hosts)\nBroadcast: 46.51.197.255", html => qr/.*/),
 
     '176.34.131.233/32' => test_zci(
-    "Network: 176.34.131.233/32 (Class B)\nNetmask: 255.255.255.255\nSpecified: Host Only\n", html => qr/.*/),
+    "Network: 176.34.131.233/32 (Class B)\nNetmask: 255.255.255.255\nSpecified: Host Only", html => qr/.*/),
 );
 
 done_testing;

--- a/t/SubnetCalc.t
+++ b/t/SubnetCalc.t
@@ -9,25 +9,92 @@ use DDG::Test::Goodie;
 zci answer_type => 'subnet_info';
 zci is_cached => 1;
 
+sub build_structure
+{
+	my ($data, $keys) = @_;
+	return {
+			id => "Subnet Calculator",
+			description => "Calculates IPv4 Subnets to and from CIDR notation",
+			templates => {
+				group => 'list',
+				options => {
+					content => 'record'
+				}
+			},
+			data => {
+				title => 'IPv4 Subnet',
+				record_data => $data,
+				record_keys => $keys,
+			}
+		}
+}
+
 ddg_goodie_test(
     [
         # This is the name of the goodie that will be loaded to test.
         'DDG::Goodie::SubnetCalc'
     ],
     "10.0.0.0/24" => test_zci(
-	"Network: 10.0.0.0/24 (Class A)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 10.0.0.1-10.0.0.254 (254 hosts)\nBroadcast: 10.0.0.255", html => qr/.*/),
+		"Network: 10.0.0.0/24 (Class A)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 10.0.0.1-10.0.0.254 (254 hosts)\nBroadcast: 10.0.0.255",
+		structured_answer => build_structure({
+			"Network" => "10.0.0.0/24 (Class A)",
+			"Netmask" => "255.255.255.0",
+			"Specified" => "Network",
+			"Host Address Range" => "10.0.0.1-10.0.0.254 (254 hosts)",
+			"Broadcast" => "10.0.0.255",
+		}, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
+	),
 
     "192.168.0.0/24" => test_zci(
-	"Network: 192.168.0.0/24 (Class C)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 192.168.0.1-192.168.0.254 (254 hosts)\nBroadcast: 192.168.0.255",html => qr/.*/),
+		"Network: 192.168.0.0/24 (Class C)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 192.168.0.1-192.168.0.254 (254 hosts)\nBroadcast: 192.168.0.255",
+		structured_answer => build_structure({
+			"Network" => "192.168.0.0/24 (Class C)",
+			"Netmask" => "255.255.255.0",
+			"Specified" => "Network",
+			"Host Address Range" => "192.168.0.1-192.168.0.254 (254 hosts)",
+			"Broadcast" => "192.168.0.255",
+		}, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
+	),
 
     "8.8.8.8 255.255.224.0" => test_zci(
-	"Network: 8.8.0.0/19 (Class A)\nNetmask: 255.255.224.0\nSpecified: Host #2056\nHost Address Range: 8.8.0.1-8.8.31.254 (8190 hosts)\nBroadcast: 8.8.31.255", html => qr/.*/),
-
+		"Network: 8.8.0.0/19 (Class A)\nNetmask: 255.255.224.0\nSpecified: Host #2056\nHost Address Range: 8.8.0.1-8.8.31.254 (8190 hosts)\nBroadcast: 8.8.31.255",
+		structured_answer => build_structure({
+			"Network" => "8.8.0.0/19 (Class A)",
+			"Netmask" => "255.255.224.0",
+			"Specified" => "Host #2056",
+			"Host Address Range" => "8.8.0.1-8.8.31.254 (8190 hosts)",
+			"Broadcast" => "8.8.31.255",
+		}, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
+	),
+	
     '46.51.197.88/255.255.254.0' => test_zci(
-    "Network: 46.51.196.0/23 (Class A)\nNetmask: 255.255.254.0\nSpecified: Host #344\nHost Address Range: 46.51.196.1-46.51.197.254 (510 hosts)\nBroadcast: 46.51.197.255", html => qr/.*/),
+		"Network: 46.51.196.0/23 (Class A)\nNetmask: 255.255.254.0\nSpecified: Host #344\nHost Address Range: 46.51.196.1-46.51.197.254 (510 hosts)\nBroadcast: 46.51.197.255",
+		structured_answer => build_structure({
+			"Network" => "46.51.196.0/23 (Class A)",
+			"Netmask" => "255.255.254.0",
+			"Specified" => "Host #344",
+			"Host Address Range" => "46.51.196.1-46.51.197.254 (510 hosts)",
+			"Broadcast" => "46.51.197.255",
+		}, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
+	),
 
     '176.34.131.233/32' => test_zci(
-    "Network: 176.34.131.233/32 (Class B)\nNetmask: 255.255.255.255\nSpecified: Host Only", html => qr/.*/),
+		"Network: 176.34.131.233/32 (Class B)\nNetmask: 255.255.255.255\nSpecified: Host Only",
+		structured_answer => build_structure({
+			"Network" => "176.34.131.233/32 (Class B)",
+			"Netmask" => "255.255.255.255",
+			"Specified" => "Host Only",
+		}, ["Network", "Netmask", "Specified"])
+	),
+    
+	'10.10.10.10/31' => test_zci(
+		"Network: 10.10.10.10/31 (Class A)\nNetmask: 255.255.255.254\nSpecified: Point-To-Point (10.10.10.10, 10.10.10.11)",
+		structured_answer => build_structure({
+			"Network" => "10.10.10.10/31 (Class A)",
+			"Netmask" => "255.255.255.254",
+			"Specified" => "Point-To-Point (10.10.10.10, 10.10.10.11)",
+		}, ["Network", "Netmask", "Specified"])
+	),
 );
 
 done_testing;

--- a/t/SubnetCalc.t
+++ b/t/SubnetCalc.t
@@ -6,14 +6,15 @@ use warnings;
 use Test::More;
 use DDG::Test::Goodie;
 
-zci answer_type => 'subnet_info';
+zci answer_type => 'subnet_calc';
 zci is_cached => 1;
 
 sub build_structure
 {
 	my ($data, $keys) = @_;
 	return {
-			id => "Subnet Calculator",
+			id => "subnet_calculator",
+			name => "Subnet Calculator",
 			description => "Calculates IPv4 Subnets to and from CIDR notation",
 			templates => {
 				group => 'list',

--- a/t/SubnetCalc.t
+++ b/t/SubnetCalc.t
@@ -11,22 +11,23 @@ zci is_cached => 1;
 
 sub build_structure
 {
-	my ($data, $keys) = @_;
-	return {
-			id => "subnet_calculator",
-			name => "Subnet Calculator",
-			templates => {
-				group => 'list',
-				options => {
-					content => 'record'
-				}
-			},
-			data => {
-				title => 'IPv4 Subnet',
-				record_data => $data,
-				record_keys => $keys,
-			}
-		}
+    my ($data, $keys) = @_;
+    return {
+        id => "subnet_calculator",
+        name => "Subnet Calculator",
+        templates => {
+            group => 'list',
+            options => {
+                content => 'record',
+                moreAt => 0
+            }
+        },
+        data => {
+            title => 'IPv4 Subnet',
+            record_data => $data,
+            record_keys => $keys,
+        }
+    };
 }
 
 ddg_goodie_test(
@@ -35,65 +36,65 @@ ddg_goodie_test(
         'DDG::Goodie::SubnetCalc'
     ],
     "10.0.0.0/24" => test_zci(
-		"Network: 10.0.0.0/24 (Class A)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 10.0.0.1-10.0.0.254 (254 hosts)\nBroadcast: 10.0.0.255",
-		structured_answer => build_structure({
-			"Network" => "10.0.0.0/24 (Class A)",
-			"Netmask" => "255.255.255.0",
-			"Specified" => "Network",
-			"Host Address Range" => "10.0.0.1-10.0.0.254 (254 hosts)",
-			"Broadcast" => "10.0.0.255",
-		}, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
-	),
+        "Network: 10.0.0.0/24 (Class A)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 10.0.0.1-10.0.0.254 (254 hosts)\nBroadcast: 10.0.0.255",
+            structured_answer => build_structure({
+                "Network" => "10.0.0.0/24 (Class A)",
+                "Netmask" => "255.255.255.0",
+                "Specified" => "Network",
+                "Host Address Range" => "10.0.0.1-10.0.0.254 (254 hosts)",
+                "Broadcast" => "10.0.0.255",
+            }, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
+    ),
 
     "192.168.0.0/24" => test_zci(
-		"Network: 192.168.0.0/24 (Class C)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 192.168.0.1-192.168.0.254 (254 hosts)\nBroadcast: 192.168.0.255",
-		structured_answer => build_structure({
-			"Network" => "192.168.0.0/24 (Class C)",
-			"Netmask" => "255.255.255.0",
-			"Specified" => "Network",
-			"Host Address Range" => "192.168.0.1-192.168.0.254 (254 hosts)",
-			"Broadcast" => "192.168.0.255",
-		}, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
-	),
+        "Network: 192.168.0.0/24 (Class C)\nNetmask: 255.255.255.0\nSpecified: Network\nHost Address Range: 192.168.0.1-192.168.0.254 (254 hosts)\nBroadcast: 192.168.0.255",
+            structured_answer => build_structure({
+                "Network" => "192.168.0.0/24 (Class C)",
+                "Netmask" => "255.255.255.0",
+                "Specified" => "Network",
+                "Host Address Range" => "192.168.0.1-192.168.0.254 (254 hosts)",
+                "Broadcast" => "192.168.0.255",
+            }, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
+    ),
 
     "8.8.8.8 255.255.224.0" => test_zci(
-		"Network: 8.8.0.0/19 (Class A)\nNetmask: 255.255.224.0\nSpecified: Host #2056\nHost Address Range: 8.8.0.1-8.8.31.254 (8190 hosts)\nBroadcast: 8.8.31.255",
-		structured_answer => build_structure({
-			"Network" => "8.8.0.0/19 (Class A)",
-			"Netmask" => "255.255.224.0",
-			"Specified" => "Host #2056",
-			"Host Address Range" => "8.8.0.1-8.8.31.254 (8190 hosts)",
-			"Broadcast" => "8.8.31.255",
-		}, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
-	),
+        "Network: 8.8.0.0/19 (Class A)\nNetmask: 255.255.224.0\nSpecified: Host #2056\nHost Address Range: 8.8.0.1-8.8.31.254 (8190 hosts)\nBroadcast: 8.8.31.255",
+            structured_answer => build_structure({
+                "Network" => "8.8.0.0/19 (Class A)",
+                "Netmask" => "255.255.224.0",
+                "Specified" => "Host #2056",
+                "Host Address Range" => "8.8.0.1-8.8.31.254 (8190 hosts)",
+                "Broadcast" => "8.8.31.255",
+            }, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
+    ),
 	
     '46.51.197.88/255.255.254.0' => test_zci(
-		"Network: 46.51.196.0/23 (Class A)\nNetmask: 255.255.254.0\nSpecified: Host #344\nHost Address Range: 46.51.196.1-46.51.197.254 (510 hosts)\nBroadcast: 46.51.197.255",
-		structured_answer => build_structure({
-			"Network" => "46.51.196.0/23 (Class A)",
-			"Netmask" => "255.255.254.0",
-			"Specified" => "Host #344",
-			"Host Address Range" => "46.51.196.1-46.51.197.254 (510 hosts)",
-			"Broadcast" => "46.51.197.255",
-		}, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
+        "Network: 46.51.196.0/23 (Class A)\nNetmask: 255.255.254.0\nSpecified: Host #344\nHost Address Range: 46.51.196.1-46.51.197.254 (510 hosts)\nBroadcast: 46.51.197.255",
+            structured_answer => build_structure({
+                "Network" => "46.51.196.0/23 (Class A)",
+                "Netmask" => "255.255.254.0",
+                "Specified" => "Host #344",
+                "Host Address Range" => "46.51.196.1-46.51.197.254 (510 hosts)",
+                "Broadcast" => "46.51.197.255",
+            }, ["Network", "Netmask", "Specified", "Host Address Range", "Broadcast"])
 	),
 
     '176.34.131.233/32' => test_zci(
-		"Network: 176.34.131.233/32 (Class B)\nNetmask: 255.255.255.255\nSpecified: Host Only",
-		structured_answer => build_structure({
-			"Network" => "176.34.131.233/32 (Class B)",
-			"Netmask" => "255.255.255.255",
-			"Specified" => "Host Only",
-		}, ["Network", "Netmask", "Specified"])
-	),
+        "Network: 176.34.131.233/32 (Class B)\nNetmask: 255.255.255.255\nSpecified: Host Only",
+            structured_answer => build_structure({
+            "Network" => "176.34.131.233/32 (Class B)",
+            "Netmask" => "255.255.255.255",
+            "Specified" => "Host Only",
+        }, ["Network", "Netmask", "Specified"])
+    ),
     
-	'10.10.10.10/31' => test_zci(
-		"Network: 10.10.10.10/31 (Class A)\nNetmask: 255.255.255.254\nSpecified: Point-To-Point (10.10.10.10, 10.10.10.11)",
-		structured_answer => build_structure({
-			"Network" => "10.10.10.10/31 (Class A)",
-			"Netmask" => "255.255.255.254",
-			"Specified" => "Point-To-Point (10.10.10.10, 10.10.10.11)",
-		}, ["Network", "Netmask", "Specified"])
+    '10.10.10.10/31' => test_zci(
+        "Network: 10.10.10.10/31 (Class A)\nNetmask: 255.255.255.254\nSpecified: Point-To-Point (10.10.10.10, 10.10.10.11)",
+            structured_answer => build_structure({
+                "Network" => "10.10.10.10/31 (Class A)",
+                "Netmask" => "255.255.255.254",
+                "Specified" => "Point-To-Point (10.10.10.10, 10.10.10.11)",
+        }, ["Network", "Netmask", "Specified"])
 	),
 );
 


### PR DESCRIPTION
This basically looks the same; however it uses the template:

![image](https://cloud.githubusercontent.com/assets/978048/8582341/27bcbbea-25be-11e5-8037-018a7a425ab3.png)


I found writing the tests for the structured answers really laborious; is there a short `.*` for the hash so that the structure only needs to be tested once?

