### PR TITLE
Fixing Tests in Travis for EmailValidator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ language: perl
 perl:
   - 5.16
 script:
-  - dzil smoke --release --author 2> /dev/null
+  - dzil smoke --release --author

--- a/lib/DDG/Goodie/EmailValidator.pm
+++ b/lib/DDG/Goodie/EmailValidator.pm
@@ -3,6 +3,7 @@ package DDG::Goodie::EmailValidator;
 
 use strict;
 use DDG::Goodie;
+use Net::Domain::TLD;
 use Email::Valid;
 
 primary_example_queries 'validate foo@example.com';


### PR DESCRIPTION
@moollaza @zachthompson this seems to fix the tests for EmailValidator; the stderr redirection was hiding the issue; however there's now a lot of noise in the output due to:
```
Use of uninitialized value in subroutine entry at /home/travis/perl5/perlbrew/perls/5.16/lib/site_perl/5.16.3/File/ShareDir.pm line 329.
```
It looks like autodeps wasn't pulling in `Net::Domain::TLD`; added it into EmailValidator.pm and voila.

I'm not that familiar with dzil, so I guess this isn't solving some root problem somewhere, however at least it shows up the problem!

Secondly, how can we resolve the ShareDir issue; it looks like problem is within the module itself.