### PR TITLE
Fixes #415 by converting to structured answer

### DIFF
--- a/lib/DDG/Goodie/LeapYear.pm
+++ b/lib/DDG/Goodie/LeapYear.pm
@@ -77,27 +77,26 @@ sub format_year {
 handle remainder => sub {
     
     my $year = (localtime)[5] + 1900;
+    my ($plaintext, $title, $subtitle);
     
     if ($_ =~ /(last|previous) ([0-9][0-9]?)$/i) {
         my @years = search_leaps($2, -1, 0, $year);
         @years = map(format_year, @years);
         my $pretty_years = join(', ', @years);
-        return "The last $2 leap years were $pretty_years",
-            structured_answer => {
-                input       => [],
-                operation   => "The last $2 leap years",
-                result      => $pretty_years,
-            };
+        
+        $plaintext = "The last $2 leap years were $pretty_years";
+        $title = $pretty_years;
+        $subtitle = "The last $2 leap years";
+        
     } elsif ($_ =~ /(next|future) ([0-9][0-9]?)$/i) {
         my @years = search_leaps($2, 1, 0, $year);
         @years = map(format_year, @years);
         my $pretty_years = join(', ', @years);
-        return "The $1 $2 leap years will be $pretty_years",
-            structured_answer => {
-                input       => [],
-                operation   => "The $1 $2 leap years",
-                result      => $pretty_years,
-            };
+        
+        $plaintext = "The $1 $2 leap years will be $pretty_years";
+        $title = $pretty_years;
+        $subtitle = "The $1 $2 leap years";
+        
     } elsif ($_ =~ /^(after|before) ([0-9]+) ?(ad|bce|bc|ce)?$/) {
         my $cyear = $2;
         my $direction = $1;
@@ -112,39 +111,35 @@ handle remainder => sub {
         @years = map(format_year, @years);
         my $pretty_years = join(', ', @years);
         my $pretty_year = format_year($cyear);
-        return "The 5 leap years $direction $pretty_year are $pretty_years",
-            structured_answer => {
-                input       => [],
-                operation   => "The 5 leap years $direction $pretty_year",
-                result      => $pretty_years,
-            };
+        
+        $plaintext = "The 5 leap years $direction $pretty_year are $pretty_years";
+        $title = $pretty_years;
+        $subtitle = "The 5 leap years $direction $pretty_year";
+        
     } elsif ($_ =~ /(next|future|upcoming)$/i) {
         my ($nyear) = search_leaps(1, 1, 0, $year);
         $nyear = format_year($nyear);
-        return "$nyear will be the $1 leap year",
-            structured_answer => {
-                input       => [],
-                operation   => "The $1 leap year",
-                result      => $nyear,
-            };
+        
+        $plaintext = "$nyear will be the $1 leap year";
+        $title = $nyear;
+        $subtitle = "The $1 leap year";
+        
     } elsif ($_ =~ /(latest|last|previous)$/i) {
         my ($pyear) = search_leaps(1, -1, 0, $year);
         $pyear = format_year($pyear);
-        return "$pyear was the $1 leap year",
-            structured_answer => {
-                input       => [],
-                operation   => "The $1 leap year",
-                result      => $pyear,
-            };
+        
+        $plaintext = "$pyear was the $1 leap year";
+        $title = $pyear;
+        $subtitle = "The $1 leap year";
+        
     } elsif ($_ =~ /(most recent)$/i) {
         my ($ryear) = search_leaps(1, -1, 1, $year);
         $ryear = format_year($ryear);
-        return "$ryear is the $1 leap year",
-            structured_answer => {
-                input       => [],
-                operation   => "The $1 leap year",
-                result      => $ryear,
-            };
+        
+        $plaintext = "$ryear is the $1 leap year";
+        $title = $ryear;
+        $subtitle = "The $1 leap year";
+        
     } elsif($_ =~ /^(was|is|will) ([0-9]+) ?(ad|bce|bc|ce)?( be)? a$/i) {
         my $cyear = $2;
         if(defined($3) && $3 =~ /^(bce|bc)$/i) {
@@ -153,39 +148,40 @@ handle remainder => sub {
         my $fyear = format_year($cyear);
         my $tense = find_tense($cyear, $year);
         if(isleap($cyear)) {
-            return "$fyear $is_tense{$tense} a leap year",
-                structured_answer => {
-                    input       => [$fyear],
-                    operation   => "Leap year",
-                    result      => "$fyear $is_tense{$tense} a leap year",
-                };
+            
+            $plaintext = "Yes! $fyear $is_tense{$tense} a leap year";
+            
         } else {
-            return "$fyear $is_not_tense{$tense} a leap year",
-                structured_answer => {
-                    input       => [$fyear],
-                    operation   => "Leap year",
-                    result      => "$fyear $is_not_tense{$tense} a leap year",
-                };
+        
+            $plaintext = "No. $fyear $is_not_tense{$tense} a leap year"
+            
         }
     } elsif($_ =~ /^is it( now | currently)? a|are we in a$/i) {
         my $fyear = format_year($year);
         if(isleap($year)) {
-            return "$fyear is a leap year",
-                structured_answer => {
-                    input       => [$fyear],
-                    operation   => "Leap year",
-                    result      => "$fyear is a leap year",
-                };
+            
+            $plaintext = "Yes! $fyear is a leap year";
+            
         } else {
-            return "$fyear is not a leap year",
-                structured_answer => {
-                    input       => [$fyear],
-                    operation   => "Leap year",
-                    result      => "$fyear is not a leap year",
-                };
+            
+            $plaintext = "No. $fyear is not a leap year",
+            
         }
     }
-    return;
+    
+    return $plaintext,
+    structured_answer => {
+        id => "leap_year",
+        name => "Answer",
+        data => {
+            title => $title || $plaintext,
+            subtitle => $subtitle
+        },
+        templates => {
+            group => "text",
+            moreAt => 0
+        }
+    }
 };
 
 1;

--- a/lib/DDG/Goodie/LeapYear.pm
+++ b/lib/DDG/Goodie/LeapYear.pm
@@ -15,7 +15,8 @@ code_url 'https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DD
 category 'dates';
 topics 'everyday';
 attribution github => [ 'https://github.com/tophattedcoder', 'Tom Bebbington'],
-            twitter => ['@tophattedcoder', 'Tom Bebbington'];
+            twitter => ['@tophattedcoder', 'Tom Bebbington'],
+            github => ['https://github.com/Sloff', 'Sloff'];
 
 zci is_cached => 1;
 triggers startend => 'leap years', 'leap year';
@@ -40,7 +41,7 @@ sub search_leaps {
     if($include_curr == 0) {
         $cyear += $direction;
     }
-    while($#years + 1 <= $num) {
+    while($#years + 1 < $num) {
         while(!isleap($cyear)) {
             $cyear += $direction;
         }
@@ -81,12 +82,22 @@ handle remainder => sub {
         my @years = search_leaps($2, -1, 0, $year);
         @years = map(format_year, @years);
         my $pretty_years = join(', ', @years);
-        return "The last $2 leap years were $pretty_years";
+        return "The last $2 leap years were $pretty_years",
+            structured_answer => {
+                input       => [],
+                operation   => "The last $2 leap years",
+                result      => $pretty_years,
+            };
     } elsif ($_ =~ /(next|future) ([0-9][0-9]?)$/i) {
         my @years = search_leaps($2, 1, 0, $year);
         @years = map(format_year, @years);
         my $pretty_years = join(', ', @years);
-        return "The $1 $2 leap years will be $pretty_years";
+        return "The $1 $2 leap years will be $pretty_years",
+            structured_answer => {
+                input       => [],
+                operation   => "The $1 $2 leap years",
+                result      => $pretty_years,
+            };
     } elsif ($_ =~ /^(after|before) ([0-9]+) ?(ad|bce|bc|ce)?$/) {
         my $cyear = $2;
         my $direction = $1;
@@ -101,19 +112,39 @@ handle remainder => sub {
         @years = map(format_year, @years);
         my $pretty_years = join(', ', @years);
         my $pretty_year = format_year($cyear);
-        return "The 5 leap years $direction $pretty_year are $pretty_years";
+        return "The 5 leap years $direction $pretty_year are $pretty_years",
+            structured_answer => {
+                input       => [],
+                operation   => "The 5 leap years $direction $pretty_year",
+                result      => $pretty_years,
+            };
     } elsif ($_ =~ /(next|future|upcoming)$/i) {
         my ($nyear) = search_leaps(1, 1, 0, $year);
         $nyear = format_year($nyear);
-        return "$nyear will be the $1 leap year";
+        return "$nyear will be the $1 leap year",
+            structured_answer => {
+                input       => [],
+                operation   => "The $1 leap year",
+                result      => $nyear,
+            };
     } elsif ($_ =~ /(latest|last|previous)$/i) {
         my ($pyear) = search_leaps(1, -1, 0, $year);
         $pyear = format_year($pyear);
-        return "$pyear was the $1 leap year";
+        return "$pyear was the $1 leap year",
+            structured_answer => {
+                input       => [],
+                operation   => "The $1 leap year",
+                result      => $pyear,
+            };
     } elsif ($_ =~ /(most recent)$/i) {
         my ($ryear) = search_leaps(1, -1, 1, $year);
         $ryear = format_year($ryear);
-        return "$ryear is the $1 leap year";
+        return "$ryear is the $1 leap year",
+            structured_answer => {
+                input       => [],
+                operation   => "The $1 leap year",
+                result      => $ryear,
+            };
     } elsif($_ =~ /^(was|is|will) ([0-9]+) ?(ad|bce|bc|ce)?( be)? a$/i) {
         my $cyear = $2;
         if(defined($3) && $3 =~ /^(bce|bc)$/i) {
@@ -122,16 +153,36 @@ handle remainder => sub {
         my $fyear = format_year($cyear);
         my $tense = find_tense($cyear, $year);
         if(isleap($cyear)) {
-            return "$fyear $is_tense{$tense} a leap year";
+            return "$fyear $is_tense{$tense} a leap year",
+                structured_answer => {
+                    input       => [$fyear],
+                    operation   => "Leap year",
+                    result      => "$fyear $is_tense{$tense} a leap year",
+                };
         } else {
-            return "$fyear $is_not_tense{$tense} a leap year";
+            return "$fyear $is_not_tense{$tense} a leap year",
+                structured_answer => {
+                    input       => [$fyear],
+                    operation   => "Leap year",
+                    result      => "$fyear $is_not_tense{$tense} a leap year",
+                };
         }
     } elsif($_ =~ /^is it( now | currently)? a|are we in a$/i) {
         my $fyear = format_year($year);
         if(isleap($year)) {
-            return "$fyear is a leap year";
+            return "$fyear is a leap year",
+                structured_answer => {
+                    input       => [$fyear],
+                    operation   => "Leap year",
+                    result      => "$fyear is a leap year",
+                };
         } else {
-            return "$fyear is not a leap year";
+            return "$fyear is not a leap year",
+                structured_answer => {
+                    input       => [$fyear],
+                    operation   => "Leap year",
+                    result      => "$fyear is not a leap year",
+                };
         }
     }
     return;

--- a/t/LeapYear.t
+++ b/t/LeapYear.t
@@ -14,13 +14,36 @@ ddg_goodie_test(
     [qw(
         DDG::Goodie::LeapYear
     )],
-    'was 2012 a leap year' => test_zci('2012 CE was a leap year'),
-    'will 3012 be a leap year' => test_zci('3012 CE will be a leap year'),
-    'was 1 bce a leap year' => test_zci('1 BCE was not a leap year'),
-    'leap years after 2005' => test_zci('The 5 leap years after 2005 CE are 2008 CE, 2012 CE, 2016 CE, 2020 CE, 2024 CE, 2028 CE'),
-    'leap years before 2 bc' => test_zci('The 5 leap years before 2 BCE are 4 BCE, 8 BCE, 12 BCE, 16 BCE, 20 BCE, 24 BCE'),
-    'when were the last 50 leap years' => test_zci('The last 50 leap years were 2012 CE, 2008 CE, 2004 CE, 2000 CE, 1996 CE, 1992 CE, 1988 CE, 1984 CE, 1980 CE, 1976 CE, 1972 CE, 1968 CE, 1964 CE, 1960 CE, 1956 CE, 1952 CE, 1948 CE, 1944 CE, 1940 CE, 1936 CE, 1932 CE, 1928 CE, 1924 CE, 1920 CE, 1916 CE, 1912 CE, 1908 CE, 1904 CE, 1896 CE, 1892 CE, 1888 CE, 1884 CE, 1880 CE, 1876 CE, 1872 CE, 1868 CE, 1864 CE, 1860 CE, 1856 CE, 1852 CE, 1848 CE, 1844 CE, 1840 CE, 1836 CE, 1832 CE, 1828 CE, 1824 CE, 1820 CE, 1816 CE, 1812 CE, 1808 CE'),
-    'is it a leap year?' => test_zci(qr'[0-9]{4} CE is (not )?a leap year'),
+    'was 2012 a leap year' => test_zci('2012 CE was a leap year',
+                structured_answer => {
+                    input       => ["2012 CE"],
+                    operation   => "Leap year",
+                    result      => "2012 CE was a leap year",
+                }),
+    'will 3012 be a leap year' => test_zci('3012 CE will be a leap year',
+                structured_answer => {
+                    input       => ["3012 CE"],
+                    operation   => "Leap year",
+                    result      => "3012 CE will be a leap year",
+                }),
+    'was 1 bce a leap year' => test_zci('1 BCE was not a leap year',
+                structured_answer => {
+                    input       => ["1 BCE"],
+                    operation   => "Leap year",
+                    result      => "1 BCE was not a leap year",
+                }),
+    'leap years after 2005' => test_zci('The 5 leap years after 2005 CE are 2008 CE, 2012 CE, 2016 CE, 2020 CE, 2024 CE',
+                structured_answer => {
+                    input       => [],
+                    operation   => "The 5 leap years after 2005 CE",
+                    result      => "2008 CE, 2012 CE, 2016 CE, 2020 CE, 2024 CE",
+                }),
+    'leap years before 2 bc' => test_zci('The 5 leap years before 2 BCE are 4 BCE, 8 BCE, 12 BCE, 16 BCE, 20 BCE',
+                structured_answer => {
+                    input       => [],
+                    operation   => "The 5 leap years before 2 BCE",
+                    result      => "4 BCE, 8 BCE, 12 BCE, 16 BCE, 20 BCE",
+                }),
 );
 
 set_fixed_time("2014-12-01T00:00:00");
@@ -28,7 +51,18 @@ ddg_goodie_test(
     [qw(
         DDG::Goodie::LeapYear
     )],
-    'is it a leap year?' => test_zci('2014 CE is not a leap year')
+    'is it a leap year?' => test_zci('2014 CE is not a leap year',
+                structured_answer => {
+                    input       => ['2014 CE'],
+                    operation   => "Leap year",
+                    result      => "2014 CE is not a leap year",
+                }),
+    'when were the last 50 leap years' => test_zci('The last 50 leap years were 2012 CE, 2008 CE, 2004 CE, 2000 CE, 1996 CE, 1992 CE, 1988 CE, 1984 CE, 1980 CE, 1976 CE, 1972 CE, 1968 CE, 1964 CE, 1960 CE, 1956 CE, 1952 CE, 1948 CE, 1944 CE, 1940 CE, 1936 CE, 1932 CE, 1928 CE, 1924 CE, 1920 CE, 1916 CE, 1912 CE, 1908 CE, 1904 CE, 1896 CE, 1892 CE, 1888 CE, 1884 CE, 1880 CE, 1876 CE, 1872 CE, 1868 CE, 1864 CE, 1860 CE, 1856 CE, 1852 CE, 1848 CE, 1844 CE, 1840 CE, 1836 CE, 1832 CE, 1828 CE, 1824 CE, 1820 CE, 1816 CE, 1812 CE',
+                structured_answer => {
+                    input       => [],
+                    operation   => "The last 50 leap years",
+                    result      => "2012 CE, 2008 CE, 2004 CE, 2000 CE, 1996 CE, 1992 CE, 1988 CE, 1984 CE, 1980 CE, 1976 CE, 1972 CE, 1968 CE, 1964 CE, 1960 CE, 1956 CE, 1952 CE, 1948 CE, 1944 CE, 1940 CE, 1936 CE, 1932 CE, 1928 CE, 1924 CE, 1920 CE, 1916 CE, 1912 CE, 1908 CE, 1904 CE, 1896 CE, 1892 CE, 1888 CE, 1884 CE, 1880 CE, 1876 CE, 1872 CE, 1868 CE, 1864 CE, 1860 CE, 1856 CE, 1852 CE, 1848 CE, 1844 CE, 1840 CE, 1836 CE, 1832 CE, 1828 CE, 1824 CE, 1820 CE, 1816 CE, 1812 CE",
+                }),
 );
 restore_time();
 set_fixed_time("2015-12-01T00:00:00");
@@ -36,7 +70,12 @@ ddg_goodie_test(
     [qw(
         DDG::Goodie::LeapYear
     )],
-    'is it a leap year?' => test_zci('2015 CE is not a leap year')
+    'is it a leap year?' => test_zci('2015 CE is not a leap year',
+                structured_answer => {
+                    input       => ['2015 CE'],
+                    operation   => "Leap year",
+                    result      => "2015 CE is not a leap year",
+                })
 );
 restore_time();
 set_fixed_time("2012-12-01T00:00:00");
@@ -44,7 +83,12 @@ ddg_goodie_test(
     [qw(
         DDG::Goodie::LeapYear
     )],
-    'is it a leap year?' => test_zci('2012 CE is a leap year')
+    'is it a leap year?' => test_zci('2012 CE is a leap year',
+                structured_answer => {
+                    input       => ['2012 CE'],
+                    operation   => "Leap year",
+                    result      => "2012 CE is a leap year",
+                })
 );
 restore_time();
 

--- a/t/LeapYear.t
+++ b/t/LeapYear.t
@@ -14,36 +14,71 @@ ddg_goodie_test(
     [qw(
         DDG::Goodie::LeapYear
     )],
-    'was 2012 a leap year' => test_zci('2012 CE was a leap year',
-                structured_answer => {
-                    input       => ["2012 CE"],
-                    operation   => "Leap year",
-                    result      => "2012 CE was a leap year",
-                }),
-    'will 3012 be a leap year' => test_zci('3012 CE will be a leap year',
-                structured_answer => {
-                    input       => ["3012 CE"],
-                    operation   => "Leap year",
-                    result      => "3012 CE will be a leap year",
-                }),
-    'was 1 bce a leap year' => test_zci('1 BCE was not a leap year',
-                structured_answer => {
-                    input       => ["1 BCE"],
-                    operation   => "Leap year",
-                    result      => "1 BCE was not a leap year",
-                }),
+    'was 2012 a leap year' => test_zci('Yes! 2012 CE was a leap year',
+    structured_answer => {
+        id => "leap_year",
+        name => "Answer",
+        data => {
+            subtitle => undef,
+            title => "Yes! 2012 CE was a leap year"
+        },
+        templates => {
+            group => "text",
+            moreAt => 0
+        }
+    }),
+    'will 3012 be a leap year' => test_zci('Yes! 3012 CE will be a leap year',
+    structured_answer => {
+        id => "leap_year",
+        name => "Answer",
+        data => {
+            subtitle => undef,
+            title => "Yes! 3012 CE will be a leap year"
+        },
+        templates => {
+            group => "text",
+            moreAt => 0
+        }
+    }),
+    'was 1 bce a leap year' => test_zci('No. 1 BCE was not a leap year',
+    structured_answer => {
+        id => "leap_year",
+        name => "Answer",
+        data => {
+            subtitle => undef,
+            title => "No. 1 BCE was not a leap year"
+        },
+        templates => {
+            group => "text",
+            moreAt => 0
+        }
+    }),
     'leap years after 2005' => test_zci('The 5 leap years after 2005 CE are 2008 CE, 2012 CE, 2016 CE, 2020 CE, 2024 CE',
-                structured_answer => {
-                    input       => [],
-                    operation   => "The 5 leap years after 2005 CE",
-                    result      => "2008 CE, 2012 CE, 2016 CE, 2020 CE, 2024 CE",
-                }),
+    structured_answer => {
+        id => "leap_year",
+        name => "Answer",
+        data => {
+            subtitle => "The 5 leap years after 2005 CE",
+            title => "2008 CE, 2012 CE, 2016 CE, 2020 CE, 2024 CE"
+        },
+        templates => {
+            group => "text",
+            moreAt => 0
+        }
+    }),
     'leap years before 2 bc' => test_zci('The 5 leap years before 2 BCE are 4 BCE, 8 BCE, 12 BCE, 16 BCE, 20 BCE',
-                structured_answer => {
-                    input       => [],
-                    operation   => "The 5 leap years before 2 BCE",
-                    result      => "4 BCE, 8 BCE, 12 BCE, 16 BCE, 20 BCE",
-                }),
+    structured_answer => {
+        id => "leap_year",
+        name => "Answer",
+        data => {
+            subtitle => "The 5 leap years before 2 BCE",
+            title => "4 BCE, 8 BCE, 12 BCE, 16 BCE, 20 BCE"
+        },
+        templates => {
+            group => "text",
+            moreAt => 0
+        }
+    })
 );
 
 set_fixed_time("2014-12-01T00:00:00");
@@ -51,18 +86,32 @@ ddg_goodie_test(
     [qw(
         DDG::Goodie::LeapYear
     )],
-    'is it a leap year?' => test_zci('2014 CE is not a leap year',
-                structured_answer => {
-                    input       => ['2014 CE'],
-                    operation   => "Leap year",
-                    result      => "2014 CE is not a leap year",
-                }),
+    'is it a leap year?' => test_zci('No. 2014 CE is not a leap year',
+    structured_answer => {
+        id => "leap_year",
+        name => "Answer",
+        data => {
+            subtitle => undef,
+            title => "No. 2014 CE is not a leap year"
+        },
+        templates => {
+            group => "text",
+            moreAt => 0
+        }
+    }),
     'when were the last 50 leap years' => test_zci('The last 50 leap years were 2012 CE, 2008 CE, 2004 CE, 2000 CE, 1996 CE, 1992 CE, 1988 CE, 1984 CE, 1980 CE, 1976 CE, 1972 CE, 1968 CE, 1964 CE, 1960 CE, 1956 CE, 1952 CE, 1948 CE, 1944 CE, 1940 CE, 1936 CE, 1932 CE, 1928 CE, 1924 CE, 1920 CE, 1916 CE, 1912 CE, 1908 CE, 1904 CE, 1896 CE, 1892 CE, 1888 CE, 1884 CE, 1880 CE, 1876 CE, 1872 CE, 1868 CE, 1864 CE, 1860 CE, 1856 CE, 1852 CE, 1848 CE, 1844 CE, 1840 CE, 1836 CE, 1832 CE, 1828 CE, 1824 CE, 1820 CE, 1816 CE, 1812 CE',
-                structured_answer => {
-                    input       => [],
-                    operation   => "The last 50 leap years",
-                    result      => "2012 CE, 2008 CE, 2004 CE, 2000 CE, 1996 CE, 1992 CE, 1988 CE, 1984 CE, 1980 CE, 1976 CE, 1972 CE, 1968 CE, 1964 CE, 1960 CE, 1956 CE, 1952 CE, 1948 CE, 1944 CE, 1940 CE, 1936 CE, 1932 CE, 1928 CE, 1924 CE, 1920 CE, 1916 CE, 1912 CE, 1908 CE, 1904 CE, 1896 CE, 1892 CE, 1888 CE, 1884 CE, 1880 CE, 1876 CE, 1872 CE, 1868 CE, 1864 CE, 1860 CE, 1856 CE, 1852 CE, 1848 CE, 1844 CE, 1840 CE, 1836 CE, 1832 CE, 1828 CE, 1824 CE, 1820 CE, 1816 CE, 1812 CE",
-                }),
+    structured_answer => {
+        id => "leap_year",
+        name => "Answer",
+        data => {
+            subtitle => "The last 50 leap years",
+            title => "2012 CE, 2008 CE, 2004 CE, 2000 CE, 1996 CE, 1992 CE, 1988 CE, 1984 CE, 1980 CE, 1976 CE, 1972 CE, 1968 CE, 1964 CE, 1960 CE, 1956 CE, 1952 CE, 1948 CE, 1944 CE, 1940 CE, 1936 CE, 1932 CE, 1928 CE, 1924 CE, 1920 CE, 1916 CE, 1912 CE, 1908 CE, 1904 CE, 1896 CE, 1892 CE, 1888 CE, 1884 CE, 1880 CE, 1876 CE, 1872 CE, 1868 CE, 1864 CE, 1860 CE, 1856 CE, 1852 CE, 1848 CE, 1844 CE, 1840 CE, 1836 CE, 1832 CE, 1828 CE, 1824 CE, 1820 CE, 1816 CE, 1812 CE",
+        },
+        templates => {
+            group => "text",
+            moreAt => 0
+        }
+    })
 );
 restore_time();
 set_fixed_time("2015-12-01T00:00:00");
@@ -70,12 +119,19 @@ ddg_goodie_test(
     [qw(
         DDG::Goodie::LeapYear
     )],
-    'is it a leap year?' => test_zci('2015 CE is not a leap year',
-                structured_answer => {
-                    input       => ['2015 CE'],
-                    operation   => "Leap year",
-                    result      => "2015 CE is not a leap year",
-                })
+    'is it a leap year?' => test_zci('No. 2015 CE is not a leap year',
+    structured_answer => {
+        id => "leap_year",
+        name => "Answer",
+        data => {
+            title => 'No. 2015 CE is not a leap year',
+            subtitle => undef
+        },
+        templates => {
+            group => "text",
+            moreAt => 0
+        }
+    })
 );
 restore_time();
 set_fixed_time("2012-12-01T00:00:00");
@@ -83,12 +139,19 @@ ddg_goodie_test(
     [qw(
         DDG::Goodie::LeapYear
     )],
-    'is it a leap year?' => test_zci('2012 CE is a leap year',
-                structured_answer => {
-                    input       => ['2012 CE'],
-                    operation   => "Leap year",
-                    result      => "2012 CE is a leap year",
-                })
+    'is it a leap year?' => test_zci('Yes! 2012 CE is a leap year',
+    structured_answer => {
+        id => "leap_year",
+        name => "Answer",
+        data => {
+            title => 'Yes! 2012 CE is a leap year',
+            subtitle => undef
+        },
+        templates => {
+            group => "text",
+            moreAt => 0
+        }
+    })
 );
 restore_time();
 


### PR DESCRIPTION
**Intro**
This is my first attempt at contributing to an IA by converting the returns to structured answers, I hope everything is ok

Fixes #415 

**What does your Instant Answer do?**
Shows whether a certain year is a leap year or not, among other leap year related functions

**What problem does your Instant Answer solve (Why is it better than organic links)?**
Immediately shows if it is a leap year

**What are some example queries that trigger this Instant Answer?**
"is it a leap year"
"was 2010 a leap year"
"next 50 leap years"

**Which existing Instant Answers will this one supercede/overlap with?**
It adds structured answers to the existing leap year module

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![1](https://cloud.githubusercontent.com/assets/7330170/8657155/38c581d8-299c-11e5-8e43-b14132aa10f4.PNG)
![2](https://cloud.githubusercontent.com/assets/7330170/8657156/38cb57fc-299c-11e5-8873-72a92d5b3dd7.PNG)
![3](https://cloud.githubusercontent.com/assets/7330170/8657157/38d2a99e-299c-11e5-8185-2c6b6b7a5984.PNG)

## Checklist
Please place an 'X' where appropriate.

```
- [X] Added metadata and attribution information (https://duck.co/duckduckhack/metadata)
- [X] Wrote test file and added to t/ directory (https://duck.co/duckduckhack/goodie_tests)
- [X] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
- [X] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
- [] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Windows 8
        - [] Google Chrome
        - [X] Firefox
        - [] Opera
        - [] IE 10

    - Windows 7
        - [] Google Chrome
        - [] Firefox
        - [] Opera
        - [] IE 8
        - [] IE 9
        - [] IE 10

    - Windows XP
        - [] IE 7
        - [] IE 8

    - Mac OSX
        - [] Google Chrome
        - [] Firefox
        - [] Opera
        - [] Safari

    - iOS (iPhone)
        - [] Safari Mobile
        - [] Google Chrome
        - [] Opera

    - iOS (iPad)
        - [] Safari Mobile
        - [] Google Chrome
        - [] Opera

    - Android
        - [] Firefox
        - [] Native Browser
        - [] Google Chrome
        - [] Opera

```

-----
IA Page: https://duck.co/ia/view/leap_year