### PR TITLE
Cheat Sheet Dark Theme Fix

### DIFF
--- a/share/goodie/cheat_sheets/cheat_sheets.css
+++ b/share/goodie/cheat_sheets/cheat_sheets.css
@@ -6,7 +6,6 @@
     padding-bottom: 1em;
     font-size: 1.1111em;
     font-weight: bold;
-    color: #000;
 }
 
 .zci--cheat_sheets .cheatsheet__container {

--- a/share/goodie/cheat_sheets/detail.handlebars
+++ b/share/goodie/cheat_sheets/detail.handlebars
@@ -5,7 +5,7 @@
     {{#cheatsheets_ordered sections section_order}}
     <div class="cheatsheet__section {{#if showhide}} showhide is-hidden {{/if}}">
         <span>
-            <h6 class="cheatsheet__title">{{name}}</h6>
+            <h6 class="cheatsheet__title tx-clr--slate">{{name}}</h6>
         </span>
         <table>
             <tbody>


### PR DESCRIPTION
Directly declaring colors in custom CSS is usually discouraged because it doesn't work great in dark themes - this just brings the cheat sheet css up to speed.

to @bsstoner 
cc @abeyang 