### PR TITLE
Emacs Keys wrapped and commas added for Consecutive Keys

### DIFF
--- a/share/goodie/cheat_sheets/emacs.json
+++ b/share/goodie/cheat_sheets/emacs.json
@@ -29,13 +29,13 @@
 	}],
         "Quick Answers": [{
 	    "val": "find file",
-	    "key": "[C-x] [C-f]"
+	    "key": "[C-x], [C-f]"
 	}, {
 	    "val": "save file",
-	    "key": "[C-x] [C-s]"
+	    "key": "[C-x], [C-s]"
 	}, {
 	    "val": "exit Emacs",
-	    "key": "[C-x] [C-c]"
+	    "key": "[C-x], [C-c]"
 	}],
         "Cursor Motion": [{
             "val": "Move forward by a character",
@@ -103,13 +103,13 @@
             "key": "C-k"
         }, {
             "val": "Delete a line (backward)",
-            "key": "[C-SPC] [C-a] [C-w]"
+            "key": "[C-SPC], [C-a], [C-w]"
         }, {
             "val": "Delete a sentence (forward)",
             "key": "M-k"
         }, {
             "val": "Delete a sentence (backward)",
-            "key": "[C-x] [DEL]"
+            "key": "[C-x], [DEL]"
         }, {
             "val": "Delete an expression (forward)",
             "key": "C-M-k"
@@ -128,22 +128,22 @@
             "key": "C-M-v"
         }, {
             "val": "Make current window only window",
-            "key": "[C-x] [1]"
+            "key": "[C-x], [1]"
         }, {
             "val": "Split window vertically",
-            "key": "[C-x] [2]"
+            "key": "[C-x], [2]"
         }, {
             "val": "Split window horizontally",
-            "key": "[C-x] [3]"
+            "key": "[C-x], [3]"
         }, {
             "val": "Grow window vertically",
-            "key": "[C-x] [^]"
+            "key": "[C-x], [^]"
         }, {
             "val": "Switch to next window",
-            "key": "[C-x] [o]"
+            "key": "[C-x], [o]"
         }, {
             "val": "Close current window",
-            "key": "[C-x] [0]"
+            "key": "[C-x], [0]"
         }],
         "Cutting and Pasting": [{
             "val": "Set mark",
@@ -163,32 +163,32 @@
         }],
         "Files and Buffers": [{
             "val": "Find file (or create if not existing)",
-            "key": "[C-x] [C-f]"
+            "key": "[C-x], [C-f]"
         }, {
             "val": "Save file",
-            "key": "[C-x] [C-s]"
+            "key": "[C-x], [C-s]"
         }, {
             "val": "Write file",
-            "key": "[C-x] [C-w]"
+            "key": "[C-x], [C-w]"
         }, {
             "val": "Save modified buffers",
-            "key": "[C-x] [s]"
+            "key": "[C-x], [s]"
         }, {
             "val": "Select buffer",
-            "key": "[C-x] [b]"
+            "key": "[C-x], [b]"
         }, {
             "val": "List buffers",
-            "key": "[C-x] [C-b]"
+            "key": "[C-x], [C-b]"
         }, {
             "val": "Kill buffer",
-            "key": "[C-x] [k]"
+            "key": "[C-x], [k]"
         }],
         "Command-Related Stuff": [{
             "val": "Leave current location",
-            "key": "[ESC] [ESC] [ESC]"
+            "key": "[ESC], [ESC], [ESC]"
         }, {
             "val": "Prefix numeric argument # to next command",
-            "key": "[C-u] [#]"
+            "key": "[C-u], [#]"
         }, {
             "val": "Stop running command, or cancel partially entered command",
             "key": "C-g"
@@ -207,36 +207,39 @@
             "key": "C-M-r"
         }, {
             "val": "String replace from here to end of buffer",
-            "key": "[M-x replace-string RET]"
+            "key": "[M-x], [<replace-string>], [RET]"
         }, {
             "val": "String replace from here to end of buffer, querying for each occurrence",
-            "key": "[M-x query-replace RET]"
+            "key": "[M-x], [<query-replace>], [RET]"
         }, {
             "val": "Prompts for a grep command, shows hits in a buffer",
-            "key": "[M-x grep RET]"
+            "key": "[M-x], [<grep>], [RET]"
         }, {
             "val": "Visit next grep hit",
-            "key": "[C-x] [`]"
+            "key": "[C-x], [`]"
         }],
         "Help": [{
             "val": "Show command documentation",
-            "key": "[C-h] [k]"
+            "key": "[C-h], [k]"
         }, {
             "val": "\"Command apropos\"",
-            "key": "[C-h] [a]"
+            "key": "[C-h], [a]"
         }, {
             "val": "Show command name on message line",
-            "key": "[C-h] [c]"
+            "key": "[C-h], [c]"
         }, {
             "val": "Describe function",
-            "key": "[C-h] [f]"
+            "key": "[C-h], [f]"
         }, {
             "val": "Info browser",
-            "key": "[C-h] [i]"
+            "key": "[C-h], [i]"
         }],
         "Misc": [{
             "val": "Undo/redo",
-            "key": "[C-_] or [C-x] [u]"
+            "key": "C-_"
+        }, {
+            "val": "Undo/redo (alternative)",
+            "key": "[C-x], [u]"
         }, {
             "val": "Quoted insert",
             "key": "C-q"
@@ -245,7 +248,7 @@
             "key": "C-z"
         }, {
             "val": "Exit emacs",
-            "key": "[C-x] [C-c]"
+            "key": "[C-x], [C-c]"
         }]
     }
 }


### PR DESCRIPTION
Replaces #1291 and fixes #1281 

**Before**
![before](https://cloud.githubusercontent.com/assets/7330170/8716544/aa2fdbf0-2b92-11e5-849b-ae8e057dce6c.PNG)

**After**
![after](https://cloud.githubusercontent.com/assets/7330170/8716549/b2c93acc-2b92-11e5-8698-c59a980cdcce.PNG)
