### PR TITLE
Uptime altered to use templates

### DIFF
--- a/lib/DDG/Goodie/Uptime.pm
+++ b/lib/DDG/Goodie/Uptime.pm
@@ -67,26 +67,28 @@ sub format_text {
 # Format response as structured_answer
 sub format_answer {
     my ($uptime_percentage, $downtime_year, $downtime_month, $downtime_day) = @_;
+    
+    my ($title, $subtitle, @record_data, @record_keys);
 
     if ($downtime_year eq $LESS_THAN_ONE_SECOND_MSG) {
-        return structured_answer => {
-            id => "uptime",
-            name => "Answer",
-            data => {
-                title => "No downtime or less than a second during a year",
-                subtitle => "Implied downtimes for $uptime_percentage uptime"
-            },
-            templates => {
-                group => "text",
-                moreAt => 0
-            }
-        }
+        $title = "No downtime or less than a second during a year";
+        $subtitle = "Implied downtimes for $uptime_percentage uptime";
+        @record_data = undef;
+        @record_keys = undef;
+    } else {
+        $title = "Implied downtimes for $uptime_percentage uptime";
+        @record_data = {
+            daily => $downtime_day,
+            monthly => $downtime_month,
+            yearly => $downtime_year
+        };
+        @record_keys = ["daily", "monthly", "yearly"];
+        
     }
     
     return structured_answer => {
         id => "uptime",
         name => "Answer",
-        description => "Implied downtimes for $uptime_percentage uptime",
         templates => {
             group => "list",
             options => {
@@ -94,13 +96,10 @@ sub format_answer {
             }
         },
         data => {
-            title => "Implied downtimes for $uptime_percentage uptime",
-            record_data => {
-                daily => $downtime_day,
-                monthly => $downtime_month,
-                yearly => $downtime_year
-            },
-            record_keys => ["daily", "monthly", "yearly"]
+            title => $title,
+            subtitle => $subtitle,
+            record_data => @record_data,
+            record_keys => @record_keys
         }
     }
 }

--- a/lib/DDG/Goodie/Uptime.pm
+++ b/lib/DDG/Goodie/Uptime.pm
@@ -129,7 +129,7 @@ handle remainder => sub {
     my $plaintext = format_text($clean_query, $year, $month, $day);
     my @structured_answer = format_answer($clean_query, $year, $month, $day);
     
-	return $plaintext, @structured_answer;
+    return $plaintext, @structured_answer;
 };
 
 1;

--- a/t/Uptime.t
+++ b/t/Uptime.t
@@ -8,47 +8,128 @@ use DDG::Test::Goodie;
 zci answer_type => "uptime";
 zci is_cached   => 1;
 
+sub build_structure {
+    my ($percentage, $data) = @_;
+    
+    return {
+        id => "uptime",
+        name => "Answer",
+        description => "Implied downtimes for $percentage uptime",
+        templates => {
+            group => "list",
+            options => {
+                content => "record"
+            }
+        },
+        data => {
+            title => "Implied downtimes for $percentage uptime",
+            record_data => $data,
+            record_keys => ["daily", "monthly", "yearly"]
+        }
+    }
+}
+
+sub build_text_structure {
+    my ($percentage) = @_;
+    
+    return {
+        id => "uptime",
+        name => "Answer",
+        templates => {
+            group => "text",
+            moreAt => 0
+        },
+        data => {
+            subtitle => "Implied downtimes for $percentage uptime",
+            title => "No downtime or less than a second during a year"
+        }
+    }
+}
+
 ddg_goodie_test(
     [qw( DDG::Goodie::Uptime )],
-
-    # A complete text+html positive test
-    'uptime 99%' => test_zci(qr/^Implied downtimes for 99% uptime.*/, html=>qr/.*/),
-    'uptime 99%' => test_zci(qr/.*Daily: 14 minutes and 24 seconds.*/, html=>qr/.*/),
-    'uptime 99%' => test_zci(qr/.*Monthly: 7 hours and 18 minutes.*/, html=>qr/.*/),
-    'uptime 99%' => test_zci(qr/.*Annually: 3 days and 16 hours$/, html=>qr/.*/),
-    'uptime 99%' => test_zci(qr/.*/, html=>qr/.*99% uptime.*/),
-    'uptime 99%' => test_zci(qr/.*/, html=>qr/.*Implied downtimes for 99% uptime.*/),
-    'uptime 99%' => test_zci(qr/.*/, html=>qr/.*Daily: 14 minutes and 24 seconds.*/),
-    'uptime 99%' => test_zci(qr/.*/, html=>qr/.*Monthly: 7 hours and 18 minutes.*/),
-    'uptime 99%' => test_zci(qr/.*/, html=>qr/.*Annually: 3 days and 16 hours.*/),
+    
+    'uptime 99%' => test_zci("Implied downtimes for 99% uptime\n".
+                            "Daily: 14 minutes and 24 seconds\n".
+                            "Monthly: 7 hours and 18 minutes\n".
+                            "Annually: 3 days and 16 hours",
+                            structured_answer => build_structure("99%",{
+                                "daily" => "14 minutes and 24 seconds",
+                                "monthly" => "7 hours and 18 minutes",
+                                "yearly" => "3 days and 16 hours"
+                            })),
 
     # Alternate trigger
-    'uptime of 99%' => test_zci(qr/^Implied downtimes for 99% uptime.*/, html=>qr/.*/),
+    'uptime of 99%' => test_zci("Implied downtimes for 99% uptime\n".
+                            "Daily: 14 minutes and 24 seconds\n".
+                            "Monthly: 7 hours and 18 minutes\n".
+                            "Annually: 3 days and 16 hours",
+                            structured_answer => build_structure("99%",{
+                                "daily" => "14 minutes and 24 seconds",
+                                "monthly" => "7 hours and 18 minutes",
+                                "yearly" => "3 days and 16 hours"
+                            })),
     
     # Startend trigger
-    '99% uptime' => test_zci(qr/^Implied downtimes for 99% uptime.*/, html=>qr/.*/),
+    '99% uptime' => test_zci("Implied downtimes for 99% uptime\n".
+                            "Daily: 14 minutes and 24 seconds\n".
+                            "Monthly: 7 hours and 18 minutes\n".
+                            "Annually: 3 days and 16 hours",
+                            structured_answer => build_structure("99%",{
+                                "daily" => "14 minutes and 24 seconds",
+                                "monthly" => "7 hours and 18 minutes",
+                                "yearly" => "3 days and 16 hours"
+                            })),
 
     # Decimal separator
-    'uptime 99,99%' => test_zci(qr/.*/, html=>qr/.*99,99% uptime.*/),
-    'uptime 99.99%' => test_zci(qr/.*/, html=>qr/.*99.99% uptime.*/),
+    'uptime 99,99%' => test_zci("Implied downtimes for 99,99% uptime\n".
+                            "Daily: 8 seconds\n".
+                            "Monthly: 4 minutes and 22 seconds\n".
+                            "Annually: 52 minutes and 35 seconds",
+                            structured_answer => build_structure("99,99%",{
+                                "daily" => "8 seconds",
+                                "monthly" => "4 minutes and 22 seconds",
+                                "yearly" => "52 minutes and 35 seconds"
+                            })),
+    'uptime 99.99%' => test_zci("Implied downtimes for 99.99% uptime\n".
+                            "Daily: 8 seconds\n".
+                            "Monthly: 4 minutes and 22 seconds\n".
+                            "Annually: 52 minutes and 35 seconds",
+                            structured_answer => build_structure("99.99%",{
+                                "daily" => "8 seconds",
+                                "monthly" => "4 minutes and 22 seconds",
+                                "yearly" => "52 minutes and 35 seconds"
+                            })),
     
     # Grouping allowed on input
-    'uptime 99.999 999 999%' => test_zci(qr/.*/, html=>qr/.*99.999999999% uptime.*/),
+    'uptime 99.999 999 999%' => test_zci("Implied downtimes for 99.999999999% uptime\n".
+                            "No downtime or less than a second during a year",
+                            structured_answer => build_text_structure("99.999999999%")),
 
     # Less than 100% uptime but close to no downtime
-    'uptime 99.999999999%' => test_zci(qr/.*/, html=>qr/.*No downtime or less than a second during a year.*/),
+    'uptime 99.999999999%' => test_zci("Implied downtimes for 99.999999999% uptime\n".
+                            "No downtime or less than a second during a year",
+                            structured_answer => build_text_structure("99.999999999%")),
 
     # Some parts (but not all) are below 1 second
-    'uptime 99.9999%' => test_zci(qr/.*/, html=>qr/.*Annually: 31 seconds.*/),
-    'uptime 99.9999%' => test_zci(qr/.*/, html=>qr/.*Monthly: 2 seconds.*/),
-    'uptime 99.9999%' => test_zci(qr/.*/, html=>qr/.*Daily: less than one second.*/),
-    'uptime 99.99999%' => test_zci(qr/.*/, html=>qr/.*Annually: 3 seconds.*/),
-    'uptime 99.99999%' => test_zci(qr/.*/, html=>qr/.*Monthly: less than one second.*/),
-    'uptime 99.99999%' => test_zci(qr/.*/, html=>qr/.*Daily: less than one second.*/),
-
-    # Lower limit
-    'uptime 0%' => test_zci(qr/.*/, html=>qr/.*0% uptime.*/),
-    'uptime 000%' => test_zci(qr/.*/, html=>qr/.*000% uptime.*/),
+    'uptime 99.9999%' => test_zci("Implied downtimes for 99.9999% uptime\n".
+                            "Daily: less than one second\n".
+                            "Monthly: 2 seconds\n".
+                            "Annually: 31 seconds",
+                            structured_answer => build_structure("99.9999%",{
+                                "daily" => "less than one second",
+                                "monthly" => "2 seconds",
+                                "yearly" => "31 seconds"
+                            })),
+    'uptime 99.99999%' => test_zci("Implied downtimes for 99.99999% uptime\n".
+                            "Daily: less than one second\n".
+                            "Monthly: less than one second\n".
+                            "Annually: 3 seconds",
+                            structured_answer => build_structure("99.99999%",{
+                                "daily" => "less than one second",
+                                "monthly" => "less than one second",
+                                "yearly" => "3 seconds"
+                            })),
 
     # Outside range
     'uptime 101%' => undef,

--- a/t/Uptime.t
+++ b/t/Uptime.t
@@ -9,12 +9,11 @@ zci answer_type => "uptime";
 zci is_cached   => 1;
 
 sub build_structure {
-    my ($percentage, $data) = @_;
+    my ($title, $subtitle, $percentage, $data, $keys) = @_;
     
     return {
         id => "uptime",
         name => "Answer",
-        description => "Implied downtimes for $percentage uptime",
         templates => {
             group => "list",
             options => {
@@ -22,28 +21,34 @@ sub build_structure {
             }
         },
         data => {
-            title => "Implied downtimes for $percentage uptime",
+            title => $title,
+            subtitle => $subtitle,
             record_data => $data,
-            record_keys => ["daily", "monthly", "yearly"]
+            record_keys => $keys
         }
     }
 }
 
+sub build_list_structure {
+    my ($percentage, $data) = @_;
+    return build_structure(
+        "Implied downtimes for $percentage uptime",
+        undef,
+        $percentage,
+        $data,
+        ["daily", "monthly", "yearly"]
+    );
+}
+
 sub build_text_structure {
     my ($percentage) = @_;
-    
-    return {
-        id => "uptime",
-        name => "Answer",
-        templates => {
-            group => "text",
-            moreAt => 0
-        },
-        data => {
-            subtitle => "Implied downtimes for $percentage uptime",
-            title => "No downtime or less than a second during a year"
-        }
-    }
+    return build_structure(
+        "No downtime or less than a second during a year",
+        "Implied downtimes for $percentage uptime",
+        $percentage,
+        undef,
+        undef
+    );
 }
 
 ddg_goodie_test(
@@ -53,7 +58,7 @@ ddg_goodie_test(
                             "Daily: 14 minutes and 24 seconds\n".
                             "Monthly: 7 hours and 18 minutes\n".
                             "Annually: 3 days and 16 hours",
-                            structured_answer => build_structure("99%",{
+                            structured_answer => build_list_structure("99%",{
                                 "daily" => "14 minutes and 24 seconds",
                                 "monthly" => "7 hours and 18 minutes",
                                 "yearly" => "3 days and 16 hours"
@@ -64,7 +69,7 @@ ddg_goodie_test(
                             "Daily: 14 minutes and 24 seconds\n".
                             "Monthly: 7 hours and 18 minutes\n".
                             "Annually: 3 days and 16 hours",
-                            structured_answer => build_structure("99%",{
+                            structured_answer => build_list_structure("99%",{
                                 "daily" => "14 minutes and 24 seconds",
                                 "monthly" => "7 hours and 18 minutes",
                                 "yearly" => "3 days and 16 hours"
@@ -75,7 +80,7 @@ ddg_goodie_test(
                             "Daily: 14 minutes and 24 seconds\n".
                             "Monthly: 7 hours and 18 minutes\n".
                             "Annually: 3 days and 16 hours",
-                            structured_answer => build_structure("99%",{
+                            structured_answer => build_list_structure("99%",{
                                 "daily" => "14 minutes and 24 seconds",
                                 "monthly" => "7 hours and 18 minutes",
                                 "yearly" => "3 days and 16 hours"
@@ -86,7 +91,7 @@ ddg_goodie_test(
                             "Daily: 8 seconds\n".
                             "Monthly: 4 minutes and 22 seconds\n".
                             "Annually: 52 minutes and 35 seconds",
-                            structured_answer => build_structure("99,99%",{
+                            structured_answer => build_list_structure("99,99%",{
                                 "daily" => "8 seconds",
                                 "monthly" => "4 minutes and 22 seconds",
                                 "yearly" => "52 minutes and 35 seconds"
@@ -95,7 +100,7 @@ ddg_goodie_test(
                             "Daily: 8 seconds\n".
                             "Monthly: 4 minutes and 22 seconds\n".
                             "Annually: 52 minutes and 35 seconds",
-                            structured_answer => build_structure("99.99%",{
+                            structured_answer => build_list_structure("99.99%",{
                                 "daily" => "8 seconds",
                                 "monthly" => "4 minutes and 22 seconds",
                                 "yearly" => "52 minutes and 35 seconds"
@@ -116,7 +121,7 @@ ddg_goodie_test(
                             "Daily: less than one second\n".
                             "Monthly: 2 seconds\n".
                             "Annually: 31 seconds",
-                            structured_answer => build_structure("99.9999%",{
+                            structured_answer => build_list_structure("99.9999%",{
                                 "daily" => "less than one second",
                                 "monthly" => "2 seconds",
                                 "yearly" => "31 seconds"
@@ -125,7 +130,7 @@ ddg_goodie_test(
                             "Daily: less than one second\n".
                             "Monthly: less than one second\n".
                             "Annually: 3 seconds",
-                            structured_answer => build_structure("99.99999%",{
+                            structured_answer => build_list_structure("99.99999%",{
                                 "daily" => "less than one second",
                                 "monthly" => "less than one second",
                                 "yearly" => "3 seconds"

--- a/t/Uptime.t
+++ b/t/Uptime.t
@@ -135,6 +135,26 @@ ddg_goodie_test(
                                 "monthly" => "less than one second",
                                 "yearly" => "3 seconds"
                             })),
+                            
+    # Lower limit
+    'uptime 0%' => test_zci("Implied downtimes for 0% uptime\n".
+                            "Daily: 1 day\n".
+                            "Monthly: 30 days and 10 hours\n".
+                            "Annually: 1 year and 6 hours",
+                            structured_answer => build_list_structure("0%",{
+                                "daily" => "1 day",
+                                "monthly" => "30 days and 10 hours",
+                                "yearly" => "1 year and 6 hours"
+                            })),
+    'uptime 000%' => test_zci("Implied downtimes for 000% uptime\n".
+                            "Daily: 1 day\n".
+                            "Monthly: 30 days and 10 hours\n".
+                            "Annually: 1 year and 6 hours",
+                            structured_answer => build_list_structure("000%",{
+                                "daily" => "1 day",
+                                "monthly" => "30 days and 10 hours",
+                                "yearly" => "1 year and 6 hours"
+                            })),
 
     # Outside range
     'uptime 101%' => undef,


### PR DESCRIPTION
This updates the uptime module to use the new template system as part of #1163 

**Before**
![before](https://cloud.githubusercontent.com/assets/7330170/8719078/3ed8221a-2ba9-11e5-8bc1-ecac4c0d0cef.PNG)
![before2](https://cloud.githubusercontent.com/assets/7330170/8719077/3ed59e82-2ba9-11e5-9534-5ad898539958.PNG)

**After**
![after](https://cloud.githubusercontent.com/assets/7330170/8719088/47dc3ef0-2ba9-11e5-9471-18b7318c0cd1.PNG)
![after2](https://cloud.githubusercontent.com/assets/7330170/8719090/48368b62-2ba9-11e5-8edf-254bb37fae2e.PNG)