### PR TITLE
HTMLEntitiesEncode: Structured answer

### DIFF
--- a/lib/DDG/Goodie/HTMLEntitiesEncode.pm
+++ b/lib/DDG/Goodie/HTMLEntitiesEncode.pm
@@ -266,7 +266,8 @@ sub make_structured_answer {
                 }
             },
             data => {
-                title => "HTML Entity Encode: $question",
+                title => "$question",
+                subtitle => "HTML Entity Encode",
                 record_data => \%output,
                 record_keys => \@output_keys,
             }

--- a/lib/DDG/Goodie/HTMLEntitiesEncode.pm
+++ b/lib/DDG/Goodie/HTMLEntitiesEncode.pm
@@ -239,8 +239,9 @@ sub make_text {
 };
 
 sub make_structured_answer {
-    my @input = @{$_[0]};
-
+    my ($answer, $question) = @_;
+    my @input = @$answer;
+    
     if (scalar(@input) == 1) {
         return {
             input       => [$input[0][0]],
@@ -265,6 +266,7 @@ sub make_structured_answer {
                 }
             },
             data => {
+                title => "HTML Entity Encode: $question",
                 record_data => \%output,
                 record_keys => \@output_keys,
             }
@@ -308,7 +310,7 @@ handle remainder => sub {
         }
         # Make final answer
         if (defined $value) {
-            return make_text($value), structured_answer => make_structured_answer($value);
+            return make_text($value), structured_answer => make_structured_answer($value, $_);
         }
     }
 
@@ -327,7 +329,7 @@ handle remainder => sub {
         $entity =~ s/;$//g;
         # Make final answer
         my $answer = [[$_, $entity]];
-        return make_text($answer), structured_answer => make_structured_answer($answer);
+        return make_text($answer), structured_answer => make_structured_answer($answer, $_);
     }
 
     return;

--- a/lib/DDG/Goodie/HTMLEntitiesEncode.pm
+++ b/lib/DDG/Goodie/HTMLEntitiesEncode.pm
@@ -6,6 +6,7 @@ use warnings;
 use DDG::Goodie;
 use Text::Trim;
 use HTML::Entities 'decode_entities';
+use utf8;
 
 triggers any =>             'html', 'entity', 'htmlencode','encodehtml','htmlescape','escapehtml', 'htmlentity';
 
@@ -241,7 +242,7 @@ sub make_structured_answer {
     my @input = @{$_[0]};
 
     if (scalar(@input) == 1) {
-        return structured_answer => {
+        return {
             input       => [$input[0][0]],
             operation   => "HTML Entity Encode",
             result      => html_enc("&$input[0][1];"),
@@ -264,7 +265,6 @@ sub make_structured_answer {
                 }
             },
             data => {
-                title => '',
                 record_data => \%output,
                 record_keys => \@output_keys,
             }

--- a/lib/DDG/Goodie/HTMLEntitiesEncode.pm
+++ b/lib/DDG/Goodie/HTMLEntitiesEncode.pm
@@ -6,6 +6,27 @@ use warnings;
 use DDG::Goodie;
 use Text::Trim;
 
+triggers any =>             'html', 'entity', 'htmlencode','encodehtml','htmlescape','escapehtml', 'htmlentity';
+
+primary_example_queries     'html em dash', 'html entity A-acute', 'html escape &';
+secondary_example_queries   'html code em-dash', 'html entity for E grave', '$ sign htmlentity', 'pound sign html encode', 'html character code for trademark symbol',
+                            'what is the html entity for greater than sign', 'how to encode an apostrophe in html';
+
+name                        'HTMLEntitiesEncode';
+description                 'Displays the HTML entity code for the query name';
+category                    'cheat_sheets';
+topics                      'programming', 'web_design';
+code_url                    'https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Goodie/HTMLEntitiesEncode.pm';
+zci answer_type =>          'html_entity';
+zci is_cached   =>          1;
+
+attribution web     =>      ["http://nishanths.github.io", "Nishanth Shanmugham"],
+            github  =>      ["https://github.com/nishanths", "Nishanth Shanmugham"],
+            twitter =>      ["https://twitter.com/nshanmugham", "Nishanth Shanmugham"],
+            twitter =>      ['crazedpsyc','crazedpsyc'],
+            cpan    =>      ['CRZEDPSYC','crazedpsyc'];
+
+
 # '&' and ';' not included in the hash value -- they are added in make_text() and make_html()
 my %codes = (
     # Punctuation
@@ -228,26 +249,6 @@ sub make_html {
     }
     return $html;
 };
-
-triggers any =>             'html', 'entity', 'htmlencode','encodehtml','htmlescape','escapehtml', 'htmlentity';
-
-primary_example_queries     'html em dash', 'html entity A-acute', 'html escape &';
-secondary_example_queries   'html code em-dash', 'html entity for E grave', '$ sign htmlentity', 'pound sign html encode', 'html character code for trademark symbol',
-                            'what is the html entity for greater than sign', 'how to encode an apostrophe in html';
-
-name                        'HTMLEntitiesEncode';
-description                 'Displays the HTML entity code for the query name';
-category                    'cheat_sheets';
-topics                      'programming', 'web_design';
-code_url                    'https://github.com/duckduckgo/zeroclickinfo-spice/blob/master/lib/DDG/Goodie/HTMLEntitiesEncode.pm';
-zci answer_type =>          'html_entity';
-zci is_cached   =>          1;
-
-attribution web     =>      ["http://nishanths.github.io", "Nishanth Shanmugham"],
-            github  =>      ["https://github.com/nishanths", "Nishanth Shanmugham"],
-            twitter =>      ["https://twitter.com/nshanmugham", "Nishanth Shanmugham"],
-            twitter =>      ['crazedpsyc','crazedpsyc'],
-            cpan    =>      ['CRZEDPSYC','crazedpsyc'];
 
 handle remainder => sub {
     # General query cleanup

--- a/lib/DDG/Goodie/HTMLEntitiesEncode.pm
+++ b/lib/DDG/Goodie/HTMLEntitiesEncode.pm
@@ -246,7 +246,7 @@ sub make_structured_answer {
         return {
             input       => [$input[0][0]],
             operation   => "HTML Entity Encode",
-            result      => html_enc("&$input[0][1];"),
+            result      => html_enc("&$input[0][1];")." (&$input[0][1];)",
         }
     } else {
         my (%output, @output_keys);

--- a/lib/DDG/Goodie/HTMLEntitiesEncode.pm
+++ b/lib/DDG/Goodie/HTMLEntitiesEncode.pm
@@ -210,11 +210,8 @@ my %accented_chars = (
 
 sub make_text {
     # Returns a text string of the form: "Encoded HTML Entity: <<entity>>"
-    my $text = "";
-    foreach my $i (0 .. scalar(@{$_[0]}) - 1) {
-        $text = $i ? ("$text" . "\n" . "Encoded HTML Entity: &$_[0][$i][1];") : ("$text" . "Encoded HTML Entity: &$_[0][$i][1];"); # No \n in the first line of the answer
-    }
-    return $text;
+    my @input = @{$_[0]};
+    return join ("\n", map {"Encoded HTML Entity: &$_->[1];"} @input);
 };
 
 sub make_html {

--- a/lib/DDG/Goodie/HTMLEntitiesEncode.pm
+++ b/lib/DDG/Goodie/HTMLEntitiesEncode.pm
@@ -238,16 +238,17 @@ sub make_text {
 
 sub make_html {
     # Returns a html formatted string with css class names (no inline styles)
-    my $html;
-    if (scalar(@{$_[0]}) == 1) { # single line answer
-        $html = qq(<div class="zci--htmlentitiesencode"><span class="text--secondary">Encoded HTML Entity (&$_[0][0][1];): </span><span class="text--primary">&<span>$_[0][0][1]</span>;</span></div>) ; # link in the same line for single line answers
-    } else {
-        $html = qq(<div class="zci--htmlentitiesencode">);
-        foreach my $i (0 .. scalar(@{$_[0]}) - 1) { # multiple line answer
-            $html = $html . qq(<div><span class="text--secondary">$_[0][$i][0] (&$_[0][$i][1];): </span><span class="text--primary">&<span>$_[0][$i][1]</span>;</span></div>);
+    my $html = qq(<div class="zci--htmlentitiesencode">);
+    my @input = @{$_[0]};
+    if (scalar(@input) == 1) { # single line answer
+        # link in the same line for single line answers
+        $html .= qq(<span class="text--secondary">Encoded HTML Entity (&$input[0][1];): </span><span class="text--primary">&<span>$input[0][1]</span>;</span>);
+    } else {       
+        foreach my $i (0 .. scalar(@input) - 1) { # multiple line answer
+            $html = $html . qq(<div><span class="text--secondary">$input[$i][0] (&$input[$i][1];): </span><span class="text--primary">&<span>$input[$i][1]</span>;</span></div>);
         }
-        $html = $html . "</div>";
     }
+    $html = $html . "</div>";
     return $html;
 };
 
@@ -287,9 +288,7 @@ handle remainder => sub {
         }
         # Make final answer
         if (defined $value) {
-            my $text = make_text($value);
-            my $html = make_html($value);
-            return $text, html => $html;
+            return make_text($value), html => make_html($value);
         }
     }
 
@@ -308,9 +307,7 @@ handle remainder => sub {
         $entity =~ s/;$//g;
         # Make final answer
         my $answer = [[$_, $entity]];
-        my $text = make_text($answer);
-        my $html = make_html($answer);
-        return $text, html => $html;
+        return make_text($answer), html => make_html($answer);
     }
 
     return;

--- a/lib/DDG/Goodie/HTMLEntitiesEncode.pm
+++ b/lib/DDG/Goodie/HTMLEntitiesEncode.pm
@@ -24,7 +24,8 @@ attribution web     =>      ["http://nishanths.github.io", "Nishanth Shanmugham"
             github  =>      ["https://github.com/nishanths", "Nishanth Shanmugham"],
             twitter =>      ["https://twitter.com/nshanmugham", "Nishanth Shanmugham"],
             twitter =>      ['crazedpsyc','crazedpsyc'],
-            cpan    =>      ['CRZEDPSYC','crazedpsyc'];
+            cpan    =>      ['CRZEDPSYC','crazedpsyc'],
+            github  =>      ['https://github.com/mintsoft', "Rob Emery"];
 
 
 # '&' and ';' not included in the hash value -- they are added in make_text() and make_html()

--- a/share/goodie/htmlentities_encode/htmlentities_encode.css
+++ b/share/goodie/htmlentities_encode/htmlentities_encode.css
@@ -1,6 +1,3 @@
-.zci--answer .zci--htmlentitiesencode {
-    padding-top: 0.25em;
-    padding-bottom: 0.25em;
-    font-weight: 300;
-    font-size: 1.5em;
+.zci--htmlentitiesencode .record .record__cell--key {
+    width: 12em;
 }

--- a/share/goodie/htmlentities_encode/htmlentities_encode.css
+++ b/share/goodie/htmlentities_encode/htmlentities_encode.css
@@ -1,3 +1,3 @@
 .zci--htmlentitiesencode .record .record__cell--key {
-    width: 12em;
+    width: 17em;
 }

--- a/t/HTMLEntitiesEncode.t
+++ b/t/HTMLEntitiesEncode.t
@@ -19,7 +19,7 @@ sub make_structured_answer {
 }
 
 sub make_record_answer {
-	my (%answers, @keys) = @_;
+	my ($data, $keys) = @_;
 	return {
             id => "htmlentitiesencode",
             name => "HTML Entities",
@@ -30,8 +30,8 @@ sub make_record_answer {
                 }
             },
             data => {
-                record_data => \%answers,
-                record_keys => \@keys,
+                record_data => $data,
+                record_keys => $keys,
             }
         };
 }
@@ -61,14 +61,14 @@ ddg_goodie_test(
     'html escape """' => test_zci("Encoded HTML Entity: &quot;", structured_answer => make_structured_answer(qr/quot/)), # "
     '$ sign htmlentity' => test_zci("Encoded HTML Entity: &#36;", structured_answer => make_structured_answer(qr/#36/)), # $
 
-#    # Return two matching entities for ambiguous query
-#    'pound symbol html encode ' => test_zci(
-#		"Encoded HTML Entity: &pound;\nEncoded HTML Entity: &#35;",
-#		structured_answer => make_record_answer({
-#			"British Pound Sterling (£)" => "&pound;",
-#			"Number sign (#)"			 => "&#35;"
-#		}, ["British Pound Sterling (£)", "Number sign (#)"])
-#	),
+    # Return two matching entities for ambiguous query
+    'pound symbol html encode ' => test_zci(
+		"Encoded HTML Entity: &pound;\nEncoded HTML Entity: &#35;",
+		structured_answer => make_record_answer({
+			"British Pound Sterling (£)" => "&pound;",
+			"Number sign (#)"			 => "&#35;"
+		}, ["British Pound Sterling (£)", "Number sign (#)"])
+	),
 
     # Ignore words and whitespace
     'html code of pilcrow sign' => test_zci("Encoded HTML Entity: &#182;", structured_answer => make_structured_answer(qr/#182/)), # of, sign
@@ -77,13 +77,13 @@ ddg_goodie_test(
 
     # Better hash hits substitutions
     # 'right angle brackets' should work even though the defined key contains the singular 'bracket'
-#	'right angle brackets htmlencode' => test_zci(
-#		"Encoded HTML Entity: &rsaquo;\nEncoded HTML Entity: &raquo;", 
-#		structured_answer => make_record_answer({
-#			"Single right pointing angle quote (›)" => "&rsaquo;",
-#			"Double right pointing angle quote (»)" => "&raquo;"
-#		}, ["Single right pointing angle quote (›)", "Double right pointing angle quote (»)"])
-#	),
+	'right angle brackets htmlencode' => test_zci(
+		"Encoded HTML Entity: &rsaquo;\nEncoded HTML Entity: &raquo;", 
+		structured_answer => make_record_answer({
+			"Single right pointing angle quote (›)" => "&rsaquo;",
+			"Double right pointing angle quote (»)" => "&raquo;"
+		}, ["Single right pointing angle quote (›)", "Double right pointing angle quote (»)"])
+	),
     # 'double quotes' should work even though the defined key contains the singular 'quote'
     'double quotes htmlescape' => test_zci("Encoded HTML Entity: &quot;", structured_answer => make_structured_answer(qr/quot/)),
 

--- a/t/HTMLEntitiesEncode.t
+++ b/t/HTMLEntitiesEncode.t
@@ -30,7 +30,8 @@ sub make_record_answer {
                 }
             },
             data => {
-                title => "HTML Entity Encode: $question",
+                title => "$question",
+                subtitle => "HTML Entity Encode",
                 record_data => $data,
                 record_keys => $keys,
             }

--- a/t/HTMLEntitiesEncode.t
+++ b/t/HTMLEntitiesEncode.t
@@ -10,17 +10,17 @@ zci answer_type => 'html_entity';
 zci is_cached   => 1;
 
 sub make_structured_answer {
-	my ($qr) = @_;
-	return {
+    my ($qr) = @_;
+    return {
             input       => '-ANY-',
             operation   => "HTML Entity Encode",
             result      => $qr,
-	};
+    };
 }
 
 sub make_record_answer {
-	my ($data, $keys) = @_;
-	return {
+    my ($data, $keys, $question) = @_;
+    return {
             id => "htmlentitiesencode",
             name => "HTML Entities",
             templates => {
@@ -30,6 +30,7 @@ sub make_record_answer {
                 }
             },
             data => {
+                title => "HTML Entity Encode: $question",
                 record_data => $data,
                 record_keys => $keys,
             }
@@ -63,12 +64,12 @@ ddg_goodie_test(
 
     # Return two matching entities for ambiguous query
     'pound symbol html encode ' => test_zci(
-		"Encoded HTML Entity: &pound;\nEncoded HTML Entity: &#35;",
-		structured_answer => make_record_answer({
-			"British Pound Sterling (£)" => "&pound;",
-			"Number sign (#)"			 => "&#35;"
-		}, ["British Pound Sterling (£)", "Number sign (#)"])
-	),
+        "Encoded HTML Entity: &pound;\nEncoded HTML Entity: &#35;",
+        structured_answer => make_record_answer({
+            "British Pound Sterling (£)" => "&pound;",
+            "Number sign (#)"             => "&#35;"
+        }, ["British Pound Sterling (£)", "Number sign (#)"], "pound")
+    ),
 
     # Ignore words and whitespace
     'html code of pilcrow sign' => test_zci("Encoded HTML Entity: &#182;", structured_answer => make_structured_answer(qr/#182/)), # of, sign
@@ -77,13 +78,13 @@ ddg_goodie_test(
 
     # Better hash hits substitutions
     # 'right angle brackets' should work even though the defined key contains the singular 'bracket'
-	'right angle brackets htmlencode' => test_zci(
-		"Encoded HTML Entity: &rsaquo;\nEncoded HTML Entity: &raquo;", 
-		structured_answer => make_record_answer({
-			"Single right pointing angle quote (›)" => "&rsaquo;",
-			"Double right pointing angle quote (»)" => "&raquo;"
-		}, ["Single right pointing angle quote (›)", "Double right pointing angle quote (»)"])
-	),
+    'right angle brackets htmlencode' => test_zci(
+        "Encoded HTML Entity: &rsaquo;\nEncoded HTML Entity: &raquo;", 
+        structured_answer => make_record_answer({
+            "Single right pointing angle quote (›)" => "&rsaquo;",
+            "Double right pointing angle quote (»)" => "&raquo;"
+        }, ["Single right pointing angle quote (›)", "Double right pointing angle quote (»)"], "right angle brackets")
+    ),
     # 'double quotes' should work even though the defined key contains the singular 'quote'
     'double quotes htmlescape' => test_zci("Encoded HTML Entity: &quot;", structured_answer => make_structured_answer(qr/quot/)),
 

--- a/t/HTMLEntitiesEncode.t
+++ b/t/HTMLEntitiesEncode.t
@@ -4,74 +4,113 @@ use strict;
 use warnings;
 use Test::More;
 use DDG::Test::Goodie;
+use utf8;
 
 zci answer_type => 'html_entity';
 zci is_cached   => 1;
+
+sub make_structured_answer {
+	my ($qr) = @_;
+	return {
+            input       => '-ANY-',
+            operation   => "HTML Entity Encode",
+            result      => $qr,
+	};
+}
+
+sub make_record_answer {
+	my (%answers, @keys) = @_;
+	return {
+            id => "htmlentitiesencode",
+            name => "HTML Entities",
+            templates => {
+                group => 'list',
+                options => {
+                    content => 'record',
+                }
+            },
+            data => {
+                record_data => \%answers,
+                record_keys => \@keys,
+            }
+        };
+}
 
 ddg_goodie_test(
     [qw(DDG::Goodie::HTMLEntitiesEncode)],
 
     # Simple tests
-    'html code em dash' => test_zci("Encoded HTML Entity: &mdash;", html => qr/mdash/),
-    'html em dash' => test_zci("Encoded HTML Entity: &mdash;", html => qr/mdash/),
-    'em-dash html' => test_zci("Encoded HTML Entity: &mdash;", html => qr/mdash/), # hyphens ignored
-    'html encode "em-dash"' => test_zci("Encoded HTML Entity: &mdash;", html => qr/mdash/), # quotes ignored
-    'ApoSTrophe escapehtml' => test_zci("Encoded HTML Entity: &#39;", html => qr/#39/), # mixed cases in query
+    'html code em dash' => test_zci("Encoded HTML Entity: &mdash;", structured_answer => make_structured_answer(qr/mdash/)),
+    'html em dash' => test_zci("Encoded HTML Entity: &mdash;", structured_answer => make_structured_answer(qr/mdash/)),
+    'em-dash html' => test_zci("Encoded HTML Entity: &mdash;", structured_answer => make_structured_answer(qr/mdash/)), # hyphens ignored
+    'html encode "em-dash"' => test_zci("Encoded HTML Entity: &mdash;", structured_answer => make_structured_answer(qr/mdash/)), # quotes ignored
+    'ApoSTrophe escapehtml' => test_zci("Encoded HTML Entity: &#39;", structured_answer => make_structured_answer(qr/#39/)), # mixed cases in query
 
     # Basic varieties in querying accented chars
-    'html entity A-acute' => test_zci("Encoded HTML Entity: &Aacute;",html => qr/Aacute/),
-    'html entity for E Grave' => test_zci("Encoded HTML Entity: &Egrave;", html => qr/Egrave/),
-    'html Ograve' => test_zci("Encoded HTML Entity: &Ograve;", html => qr/Ograve/),
+    'html entity A-acute' => test_zci("Encoded HTML Entity: &Aacute;",structured_answer => make_structured_answer(qr/Aacute/)),
+    'html entity for E Grave' => test_zci("Encoded HTML Entity: &Egrave;", structured_answer => make_structured_answer(qr/Egrave/)),
+    'html Ograve' => test_zci("Encoded HTML Entity: &Ograve;", structured_answer => make_structured_answer(qr/Ograve/)),
 
     # Single typed-in character queries
-    'html escape &' => test_zci("Encoded HTML Entity: &amp;", html => qr/amp/), # &
-    'html escape "' => test_zci("Encoded HTML Entity: &quot;", html => qr/quot/), # "
-    'how to html escape &?' => test_zci("Encoded HTML Entity: &amp;", html => qr/amp/), # ?
-    'how to html escape "&"?' => test_zci("Encoded HTML Entity: &amp;", html => qr/amp/), # &
-    'how to html escape ??' => test_zci("Encoded HTML Entity: &#63;", html => qr/#63/), # ?
-    'how do you html escape a "?"?' => test_zci("Encoded HTML Entity: &#63;", html => qr/#63/), # ?
-    'html escape """' => test_zci("Encoded HTML Entity: &quot;", html => qr/quot/), # "
-    '$ sign htmlentity' => test_zci("Encoded HTML Entity: &#36;", html => qr/#36/), # $
+    'html escape &' => test_zci("Encoded HTML Entity: &amp;", structured_answer => make_structured_answer(qr/amp/)), # &
+    'html escape "' => test_zci("Encoded HTML Entity: &quot;", structured_answer => make_structured_answer(qr/quot/)), # "
+    'how to html escape &?' => test_zci("Encoded HTML Entity: &amp;", structured_answer => make_structured_answer(qr/amp/)), # ?
+    'how to html escape "&"?' => test_zci("Encoded HTML Entity: &amp;", structured_answer => make_structured_answer(qr/amp/)), # &
+    'how to html escape ??' => test_zci("Encoded HTML Entity: &#63;", structured_answer => make_structured_answer(qr/#63/)), # ?
+    'how do you html escape a "?"?' => test_zci("Encoded HTML Entity: &#63;", structured_answer => make_structured_answer(qr/#63/)), # ?
+    'html escape """' => test_zci("Encoded HTML Entity: &quot;", structured_answer => make_structured_answer(qr/quot/)), # "
+    '$ sign htmlentity' => test_zci("Encoded HTML Entity: &#36;", structured_answer => make_structured_answer(qr/#36/)), # $
 
-    # Return two matching entities for ambiguous query
-    'pound symbol html encode ' => test_zci("Encoded HTML Entity: &pound;\nEncoded HTML Entity: &#35;", html => qr/pound.*#35|#35.*pound/),
+#    # Return two matching entities for ambiguous query
+#    'pound symbol html encode ' => test_zci(
+#		"Encoded HTML Entity: &pound;\nEncoded HTML Entity: &#35;",
+#		structured_answer => make_record_answer({
+#			"British Pound Sterling (£)" => "&pound;",
+#			"Number sign (#)"			 => "&#35;"
+#		}, ["British Pound Sterling (£)", "Number sign (#)"])
+#	),
 
     # Ignore words and whitespace
-    'html code of pilcrow sign' => test_zci("Encoded HTML Entity: &#182;", html => qr/#182/), # of, sign
-    'html escape greater than symbol' => test_zci("Encoded HTML Entity: &gt;", html => qr/gt/), # symbol
-    'space    html character code' => test_zci("Encoded HTML Entity: &nbsp;", html => qr/nbsp/), # Ignore extra whitespace
+    'html code of pilcrow sign' => test_zci("Encoded HTML Entity: &#182;", structured_answer => make_structured_answer(qr/#182/)), # of, sign
+    'html escape greater than symbol' => test_zci("Encoded HTML Entity: &gt;", structured_answer => make_structured_answer(qr/gt/)), # symbol
+    'space    html character code' => test_zci("Encoded HTML Entity: &nbsp;", structured_answer => make_structured_answer(qr/nbsp/)), # Ignore extra whitespace
 
     # Better hash hits substitutions
     # 'right angle brackets' should work even though the defined key contains the singular 'bracket'
-    'right angle brackets htmlencode' => test_zci("Encoded HTML Entity: &rsaquo;\nEncoded HTML Entity: &raquo;", html => qr/rsaquo.*raquo|raquo.*rsaquo/),
+#	'right angle brackets htmlencode' => test_zci(
+#		"Encoded HTML Entity: &rsaquo;\nEncoded HTML Entity: &raquo;", 
+#		structured_answer => make_record_answer({
+#			"Single right pointing angle quote (›)" => "&rsaquo;",
+#			"Double right pointing angle quote (»)" => "&raquo;"
+#		}, ["Single right pointing angle quote (›)", "Double right pointing angle quote (»)"])
+#	),
     # 'double quotes' should work even though the defined key contains the singular 'quote'
-    'double quotes htmlescape' => test_zci("Encoded HTML Entity: &quot;", html => qr/quot/),
+    'double quotes htmlescape' => test_zci("Encoded HTML Entity: &quot;", structured_answer => make_structured_answer(qr/quot/)),
 
-    # Should not work (would make sense to decode theese queries though!)
+    # Should not work
     'html encode &#43;' => undef,
     'html entity &amp;' => undef,
-    # Should also not work
-    'html encode is it magic' => undef, # most certainly, it is
+    'html encode is it magic' => undef, 
 
     # Natural querying
-    'What is the html character code for pi' => test_zci("Encoded HTML Entity: &#960;", html => qr/#960/),
-    'whatis html entity for en-dash' => test_zci("Encoded HTML Entity: &ndash;", html => qr/ndash/), # whatis spelling
-    'how do I escape the greater-than symbol html' => test_zci("Encoded HTML Entity: &gt;", html => qr/gt/),
+    'What is the html character code for pi' => test_zci("Encoded HTML Entity: &#960;", structured_answer => make_structured_answer(qr/#960/)),
+    'whatis html entity for en-dash' => test_zci("Encoded HTML Entity: &ndash;", structured_answer => make_structured_answer(qr/ndash/)), # whatis spelling
+    'how do I escape the greater-than symbol html' => test_zci("Encoded HTML Entity: &gt;", structured_answer => make_structured_answer(qr/gt/)),
 
     # the "a/A" belonging to "acute" matters, but the "a" immediately after "character" is removed
-    'How to get a a acute character in html code' => test_zci("Encoded HTML Entity: &aacute;", html => qr/aacute/),
-    'how to get a a-acute character in html code' => test_zci("Encoded HTML Entity: &aacute;", html => qr/aacute/),
-    'how to get a aacute character in html code' => test_zci("Encoded HTML Entity: &aacute;", html => qr/aacute/),
-    'how to get a A acute character in html code' => test_zci("Encoded HTML Entity: &Aacute;", html => qr/Aacute/),
-    'how to get a A-acute character in html code' => test_zci("Encoded HTML Entity: &Aacute;", html => qr/Aacute/),
-    'how to get a Aacute character in html code' => test_zci("Encoded HTML Entity: &Aacute;", html => qr/Aacute/),
+    'How to get a a acute character in html code' => test_zci("Encoded HTML Entity: &aacute;", structured_answer => make_structured_answer(qr/aacute/)),
+    'how to get a a-acute character in html code' => test_zci("Encoded HTML Entity: &aacute;", structured_answer => make_structured_answer(qr/aacute/)),
+    'how to get a aacute character in html code' => test_zci("Encoded HTML Entity: &aacute;", structured_answer => make_structured_answer(qr/aacute/)),
+    'how to get a A acute character in html code' => test_zci("Encoded HTML Entity: &Aacute;", structured_answer => make_structured_answer(qr/Aacute/)),
+    'how to get a A-acute character in html code' => test_zci("Encoded HTML Entity: &Aacute;", structured_answer => make_structured_answer(qr/Aacute/)),
+    'how to get a Aacute character in html code' => test_zci("Encoded HTML Entity: &Aacute;", structured_answer => make_structured_answer(qr/Aacute/)),
 
     # Question marks ignored
-    'the encoded html entity of apostrophe is?' => test_zci("Encoded HTML Entity: &#39;", html => qr/#39/),
-    'how to encode an apostrophe in html ? ' => test_zci("Encoded HTML Entity: &#39;", html => qr/#39/), # spaces around the end
+    'the encoded html entity of apostrophe is?' => test_zci("Encoded HTML Entity: &#39;", structured_answer => make_structured_answer(qr/#39/)),
+    'how to encode an apostrophe in html ? ' => test_zci("Encoded HTML Entity: &#39;", structured_answer => make_structured_answer(qr/#39/)), # spaces around the end
 
     # Question mark matters
-    'how to encode "?" in html' => test_zci("Encoded HTML Entity: &#63;", html => qr/#63/),
+    'how to encode "?" in html' => test_zci("Encoded HTML Entity: &#63;", structured_answer => make_structured_answer(qr/#63/)),
 );
 
 done_testing;


### PR DESCRIPTION
Notes: This is a weird IA to work on, it has single row output and guessed multi-line output, so I've used a basic structured_answer in the "one line" output case and the record template in the multi-line output.

Edge case queries to test:
* right angle brackets htmlencode
* how to encode an apostrophe in html ?
* htmlencode pound

New output (I really doubt many people actually see this record template):

![image](https://cloud.githubusercontent.com/assets/978048/8767642/bfb8be9a-2e5a-11e5-8a13-f91d3b54fa62.png)
![image](https://cloud.githubusercontent.com/assets/978048/8767649/f1460012-2e5a-11e5-8a17-e52812cfb66a.png)

Single lookup answer (much more likely for people to see I think!)
![image](https://cloud.githubusercontent.com/assets/978048/8767644/cf32ffe8-2e5a-11e5-9723-81aa43b9b092.png)
