### PR TITLE
TimezoneConverter: switch HTML to template

### DIFF
--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -151,8 +151,7 @@ handle query => sub {
 
     $input->{time}  = $hours + $minutes / 60 + $seconds / 3600 + $pm;
     $output->{time} = $input->{time} + $modifier;
-    for ( $input, $output ) {
-        my $io = $_;
+    for my $io ( $input, $output ) {
         my $time = $io->{time};
         $io->{days} = '';
         if ( $time < 0 ) {

--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -133,61 +133,62 @@ handle query => sub {
     my $american        = $+{'american'};
     my $pm              = ($+{'pm'} && $hours != 12) ? 12 : (!$+{'pm'} && $hours == 12) ? -12 : 0;
 
+    my $input = {};
+    my $output = {};
     # parse_timezone returns undef if the timezone cannot be parsed
-    my ($input_timezone, $gmt_input_timezone) = parse_timezone($+{'from_tz'});
-    return unless defined $gmt_input_timezone;
-    my ($output_timezone, $gmt_output_timezone) = parse_timezone($+{'to_tz'});
-    return unless defined($gmt_output_timezone);
+    ($input->{timezone}, $input->{gmt_timezone}) = parse_timezone($+{'from_tz'});
+    return unless defined $input->{gmt_timezone};
+    ($output->{timezone}, $output->{gmt_timezone}) = parse_timezone($+{'to_tz'});
+    return unless defined $output->{gmt_timezone};
 
-    my $modifier = $gmt_output_timezone - $gmt_input_timezone;
+    my $modifier = $output->{gmt_timezone} - $input->{gmt_timezone};
 
-    for ( $gmt_input_timezone, $gmt_output_timezone ) {
+    for ( $input->{gmt_timezone}, $output->{gmt_timezone} ) {
         $_ = to_time $_;
         s/\A\b/+/;
         s/:00\z//;
     }
 
-    my $input_time  = $hours + $minutes / 60 + $seconds / 3600 + $pm;
-    my $output_time = $input_time + $modifier;
-    for ( $input_time, $output_time ) {
-        my $days = "";
-        if ( $_ < 0 ) {
-            my $s = $_ <= -24 ? 's' : "";
-            $days = sprintf ', %i day%s prior', $_ / -24 + 1, $s;
+    $input->{time}  = $hours + $minutes / 60 + $seconds / 3600 + $pm;
+    $output->{time} = $input->{time} + $modifier;
+    for ( $input, $output ) {
+        my $io = $_;
+        my $time = $io->{time};
+        $io->{days} = '';
+        if ( $time < 0 ) {
+            my $s = $time <= -24 ? 's' : "";
+            $io->{days} = sprintf ' (%i day%s prior)', $time / -24 + 1, $s;
 
             # fmod() doesn't do what I want, Perl's % operator doesn't
             # support floating point numbers. Instead, I will use
             # lamest hack ever to do things correctly.
-            $_ += int( $_ / -24 + 1 ) * 24;
+            $time += int( $time / -24 + 1 ) * 24;
         }
-        elsif ( $_ >= 24 ) {
-            my $s = $_ >= 48 ? 's' : "";
-            $days = sprintf ', %i day%s after', $_ / 24, $s;
+        elsif ( $time >= 24 ) {
+            my $s = $time >= 48 ? 's' : "";
+            $io->{days} = sprintf ' (%i day%s after)', $time / 24, $s;
         }
-        $_ = fmod $_, 24;
-        $_ = to_time($_, $american) . $days;
+        $time = fmod $time, 24;
+        $io->{time} = to_time($time, $american);
+
+        $io->{format} = '%s (UTC%s)';
+        $io->{timezones}  = [ $io->{timezone},  $io->{gmt_timezone} ];
+
+        $io->{timezone} =~ /(\A\w+)/;
+        if ( $timezones{ $1 } !~ /[1-9]/ ) {
+            $io->{format} = '%s';
+            pop @{$io->{timezones}};
+        }
     }
 
-    my ( $input_format, $output_format ) = ('%s, UTC%s') x 2;
-    my @input_timezones  = ( $input_timezone,  $gmt_input_timezone );
-    my @output_timezones = ( $output_timezone, $gmt_output_timezone );
+    my $input_string = sprintf "%s $input->{format} to $output->{format}",
+            ucfirst $input->{time}, @{$input->{timezones}}, @{$output->{timezones}};
 
-    # I'm using @timezones because I need list context.
-    if ( @timezones{ $input_timezone =~ /(\A\w+)/ } !~ /[1-9]/ ) {
-        $input_format = '%s';
-        pop @input_timezones;
-    }
-    if ( @timezones{ $output_timezone =~ /(\A\w+)/ } !~ /[1-9]/ ) {
-        $output_format = '%s';
-        pop @output_timezones;
-    }
-
-    my $output_string = sprintf "%s ($input_format) is %s ($output_format).",
-            ucfirst $input_time, @input_timezones,
-            $output_time, @output_timezones;
+    my $output_string = sprintf "%s %s%s",
+            ucfirst $output->{time}, $output->{timezone}, $output->{days};
 
     return $output_string, structured_answer => {
-        input     => [html_enc($query)],
+        input     => [html_enc($input_string)],
         operation => 'Convert Timezone',
         result    => html_enc($output_string),
     };

--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -185,11 +185,12 @@ handle query => sub {
     my $output_string = sprintf "%s ($input_format) is %s ($output_format).",
             ucfirst $input_time, @input_timezones,
             $output_time, @output_timezones;
-    my $output_html = sprintf "<div class='zci--timezone-converter text--secondary'><span class='text--primary'>%s</span> ($input_format) is <span class='text--primary'>%s</span> ($output_format).</div>",
-            ucfirst $input_time, @input_timezones,
-            $output_time, @output_timezones;
 
-    return $output_string, html => $output_html;
+    return $output_string, structured_answer => {
+        input     => [html_enc($query)],
+        operation => 'Convert Timezone',
+        result    => html_enc($output_string),
+    };
 };
 
 1;

--- a/t/TimezoneConverter.t
+++ b/t/TimezoneConverter.t
@@ -12,164 +12,164 @@ zci is_cached   => 1;
 ddg_goodie_test(
     ['DDG::Goodie::TimezoneConverter'],
     '3:14 in GMT' =>
-        test_zci('3:14 (UTC) is 3:14 (GMT).',
+        test_zci('3:14 GMT',
         structured_answer => {
-            input => ['3:14 in GMT'],
+            input => ['3:14 UTC to GMT'],
             operation => 'Convert Timezone',
-            result => '3:14 (UTC) is 3:14 (GMT).',
+            result => '3:14 GMT',
         },
     ),
     '8:10 AM AZOST into CAT' =>
-        test_zci('8:10 AM (AZOST, UTC-1) is 11:10 AM (CAT, UTC+2).',
+        test_zci('11:10 AM CAT',
         structured_answer => {
-            input => ['8:10 AM AZOST into CAT'],
+            input => ['8:10 AM AZOST (UTC-1) to CAT (UTC+2)'],
             operation => 'Convert Timezone',
-            result => '8:10 AM (AZOST, UTC-1) is 11:10 AM (CAT, UTC+2).',
+            result => '11:10 AM CAT',
         },
     ),
     '1pm EDT into UTC+2' =>
-        test_zci('1:00 PM (EDT, UTC-4) is 7:00 PM (UTC+2).',
+        test_zci('7:00 PM UTC+2',
         structured_answer => {
-            input => ['1pm EDT into UTC+2'],
+            input => ['1:00 PM EDT (UTC-4) to UTC+2'],
             operation => 'Convert Timezone',
-            result => '1:00 PM (EDT, UTC-4) is 7:00 PM (UTC+2).',
+            result => '7:00 PM UTC+2',
         },
     ),
     '0pm into GMT' =>
-        test_zci('Noon (UTC) is noon (GMT).',
+        test_zci('Noon GMT',
         structured_answer => {
-            input => ['0pm into GMT'],
+            input => ['Noon UTC to GMT'],
             operation => 'Convert Timezone',
-            result => 'Noon (UTC) is noon (GMT).',
+            result => 'Noon GMT',
         },
     ),
     '0am into UTC' =>
-        test_zci('Midnight (UTC) is midnight (UTC).',
+        test_zci('Midnight UTC',
         structured_answer => {
-            input => ['0am into UTC'],
+            input => ['Midnight UTC to UTC'],
             operation => 'Convert Timezone',
-            result => 'Midnight (UTC) is midnight (UTC).',
+            result => 'Midnight UTC',
         },
     ),
     '1 into UTC -2 ' =>
-        test_zci('1:00 (UTC) is 23:00, 1 day prior (UTC-2).',
+        test_zci('23:00 UTC-2 (1 day prior)',
         structured_answer => {
-            input => ['1 into UTC -2'],
+            input => ['1:00 UTC to UTC-2'],
             operation => 'Convert Timezone',
-            result => '1:00 (UTC) is 23:00, 1 day prior (UTC-2).',
+            result => '23:00 UTC-2 (1 day prior)',
         },
     ),
     ' 1 into UTC-1' =>
-        test_zci('1:00 (UTC) is 0:00 (UTC-1).',
+        test_zci('0:00 UTC-1',
         structured_answer => {
-            input => ['1 into UTC-1'],
+            input => ['1:00 UTC to UTC-1'],
             operation => 'Convert Timezone',
-            result => '1:00 (UTC) is 0:00 (UTC-1).',
+            result => '0:00 UTC-1',
         },
     ),
     '21 FNT into EET' =>
-        test_zci('21:00 (FNT, UTC-2) is 1:00, 1 day after (EET, UTC+2).',
+        test_zci('1:00 EET (1 day after)',
         structured_answer => {
-            input => ['21 FNT into EET'],
+            input => ['21:00 FNT (UTC-2) to EET (UTC+2)'],
             operation => 'Convert Timezone',
-            result => '21:00 (FNT, UTC-2) is 1:00, 1 day after (EET, UTC+2).',
+            result => '1:00 EET (1 day after)',
         },
     ),
     '23:00:00  InTo  UTC+1' =>
-        test_zci('23:00 (UTC) is 0:00, 1 day after (UTC+1).',
+        test_zci('0:00 UTC+1 (1 day after)',
         structured_answer => {
-            input => ['23:00:00 InTo UTC+1'],
+            input => ['23:00 UTC to UTC+1'],
             operation => 'Convert Timezone',
-            result => '23:00 (UTC) is 0:00, 1 day after (UTC+1).',
+            result => '0:00 UTC+1 (1 day after)',
         },
     ),
     '23:00:01  Into    UTC+1' =>
-        test_zci('23:00:01 (UTC) is 0:00:01, 1 day after (UTC+1).',
+        test_zci('0:00:01 UTC+1 (1 day after)',
         structured_answer => {
-            input => ['23:00:01 Into UTC+1'],
+            input => ['23:00:01 UTC to UTC+1'],
             operation => 'Convert Timezone',
-            result => '23:00:01 (UTC) is 0:00:01, 1 day after (UTC+1).',
+            result => '0:00:01 UTC+1 (1 day after)',
         },
     ),
     '13:15:00 UTC-0:30 into UTC+0:30' =>
-        test_zci('13:15 (UTC-0:30) is 13:15 (UTC+0:30).',
+        test_zci('13:15 UTC+0:30',
         structured_answer => {
-            input => ['13:15:00 UTC-0:30 into UTC+0:30'],
+            input => ['13:15 UTC-0:30 to UTC+0:30'],
             operation => 'Convert Timezone',
-            result => '13:15 (UTC-0:30) is 13:15 (UTC+0:30).',
+            result => '13:15 UTC+0:30',
         },
     ),
     # ok, this is unlikely to happen without trying to do that
     '19:42:42 BIT into GMT+100' =>
-        test_zci('19:42:42 (BIT, UTC-12) is 11:42:42, 5 days after (GMT+100).',
+        test_zci('11:42:42 GMT+100 (5 days after)',
         structured_answer => {
-            input => ['19:42:42 BIT into GMT+100'],
+            input => ['19:42:42 BIT (UTC-12) to GMT+100'],
             operation => 'Convert Timezone',
-            result => '19:42:42 (BIT, UTC-12) is 11:42:42, 5 days after (GMT+100).',
+            result => '11:42:42 GMT+100 (5 days after)',
         },
     ),
     '19:42:42 CHADT into GMT-100' =>
-        test_zci('19:42:42 (CHADT, UTC+13:45) is 1:57:42, 4 days prior (GMT-100).',
+        test_zci('1:57:42 GMT-100 (4 days prior)',
         structured_answer => {
-            input => ['19:42:42 CHADT into GMT-100'],
+            input => ['19:42:42 CHADT (UTC+13:45) to GMT-100'],
             operation => 'Convert Timezone',
-            result => '19:42:42 (CHADT, UTC+13:45) is 1:57:42, 4 days prior (GMT-100).',
+            result => '1:57:42 GMT-100 (4 days prior)',
         },
     ),
     '10:00AM MST to PST' =>
-        test_zci('10:00 AM (MST, UTC-7) is 9:00 AM (PST, UTC-8).',
+        test_zci('9:00 AM PST',
         structured_answer => {
-            input => ['10:00AM MST to PST'],
+            input => ['10:00 AM MST (UTC-7) to PST (UTC-8)'],
             operation => 'Convert Timezone',
-            result => '10:00 AM (MST, UTC-7) is 9:00 AM (PST, UTC-8).',
+            result => '9:00 AM PST',
         },
     ),
     '19:00 UTC to EST' =>
-        test_zci('19:00 (UTC) is 14:00 (EST, UTC-5).',
+        test_zci('14:00 EST',
         structured_answer => {
-            input => ['19:00 UTC to EST'],
+            input => ['19:00 UTC to EST (UTC-5)'],
             operation => 'Convert Timezone',
-            result => '19:00 (UTC) is 14:00 (EST, UTC-5).',
+            result => '14:00 EST',
         },
     ),
     '1am UTC to PST' =>
-        test_zci('1:00 AM (UTC) is 5:00 PM, 1 day prior (PST, UTC-8).',
+        test_zci('5:00 PM PST (1 day prior)',
         structured_answer => {
-            input => ['1am UTC to PST'],
+            input => ['1:00 AM UTC to PST (UTC-8)'],
             operation => 'Convert Timezone',
-            result => '1:00 AM (UTC) is 5:00 PM, 1 day prior (PST, UTC-8).',
+            result => '5:00 PM PST (1 day prior)',
         },
     ),
     '12:40pm PST into JST' =>
-        test_zci('12:40 PM (PST, UTC-8) is 5:40 AM, 1 day after (JST, UTC+9).',
+        test_zci('5:40 AM JST (1 day after)',
         structured_answer => {
-            input => ['12:40pm PST into JST'],
+            input => ['12:40 PM PST (UTC-8) to JST (UTC+9)'],
             operation => 'Convert Timezone',
-            result => '12:40 PM (PST, UTC-8) is 5:40 AM, 1 day after (JST, UTC+9).',
+            result => '5:40 AM JST (1 day after)',
         },
     ),
     '12:40 pm from PST to JST' =>
-        test_zci('12:40 PM (PST, UTC-8) is 5:40 AM, 1 day after (JST, UTC+9).',
+        test_zci('5:40 AM JST (1 day after)',
         structured_answer => {
-            input => ['12:40 pm from PST to JST'],
+            input => ['12:40 PM PST (UTC-8) to JST (UTC+9)'],
             operation => 'Convert Timezone',
-            result => '12:40 PM (PST, UTC-8) is 5:40 AM, 1 day after (JST, UTC+9).',
+            result => '5:40 AM JST (1 day after)',
         },
     ),
     '11:22am est in utc' =>
-        test_zci('11:22 AM (EST, UTC-5) is 4:22 PM (UTC).',
+        test_zci('4:22 PM UTC',
         structured_answer => {
-            input => ['11:22am est in utc'],
+            input => ['11:22 AM EST (UTC-5) to UTC'],
             operation => 'Convert Timezone',
-            result => '11:22 AM (EST, UTC-5) is 4:22 PM (UTC).',
+            result => '4:22 PM UTC',
         },
     ),
       '1600 UTC in BST' =>
-        test_zci('16:00 (UTC) is 17:00 (BST, UTC+1).',
+        test_zci('17:00 BST',
         structured_answer => {
-            input => ['1600 UTC in BST'],
+            input => ['16:00 UTC to BST (UTC+1)'],
             operation => 'Convert Timezone',
-            result => '16:00 (UTC) is 17:00 (BST, UTC+1).',
+            result => '17:00 BST',
         },
     ),  
     
@@ -178,145 +178,145 @@ ddg_goodie_test(
 );
 
 # Summertime
-my $test_location_tz = qr/\(EDT, UTC-4\)/;
+my $test_location_tz = q/EDT (UTC-4)/;
 set_fixed_time("2014-10-14T00:00:00");
 ddg_goodie_test(
     ['DDG::Goodie::TimezoneConverter'],
     # Location-specific tests (variable with DST)
     '13:00 GMT in my time' =>
-        test_zci(qr/13:00 \(GMT\) is 9:00 $test_location_tz/,
+        test_zci(q/9:00 EDT/,
         structured_answer => {
-            input => ['13:00 GMT in my time'],
+            input => [qq/13:00 GMT to $test_location_tz/],
             operation => 'Convert Timezone',
-            result => qr/13:00 \(GMT\) is 9:00 $test_location_tz/,
+            result => q/9:00 EDT/,
         },
     ),
     '11:22am cest in my timezone' =>
-        test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
+        test_zci(qr/5:22 AM EDT/,
         structured_answer => {
-            input => ['11:22am cest in my timezone'],
+            input => [qq/11:22 AM CEST (UTC+2) to $test_location_tz/],
             operation => 'Convert Timezone',
-            result => qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
+            result => qr/5:22 AM EDT/,
         },
     ),
     '11:22am cest in localtime' =>
-        test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
+        test_zci(qr/5:22 AM EDT/,
         structured_answer => {
-            input => ['11:22am cest in localtime'],
+            input => [qq/11:22 AM CEST (UTC+2) to $test_location_tz/],
             operation => 'Convert Timezone',
-            result => qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
+            result => qr/5:22 AM EDT/,
         },
     ),
     '11:22am cest in my local timezone' =>
-        test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
+        test_zci(qr/5:22 AM EDT/,
         structured_answer => {
-            input => ['11:22am cest in my local timezone'],
+            input => [qq/11:22 AM CEST (UTC+2) to $test_location_tz/],
             operation => 'Convert Timezone',
-            result => qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
+            result => qr/5:22 AM EDT/,
         },
     ),
     '12pm my time in CEST' =>
-        test_zci(qr/Noon $test_location_tz is 6:00 PM \(CEST, UTC\+2\)./,
+        test_zci(q/6:00 PM CEST/,
         structured_answer => {
-            input => ['12pm my time in CEST'],
+            input => [qq/Noon $test_location_tz to CEST (UTC+2)/],
             operation => 'Convert Timezone',
-            result => qr/Noon $test_location_tz is 6:00 PM \(CEST, UTC\+2\)./,
+            result => q/6:00 PM CEST/,
         },
     ),
     '12pm local timezone in CEST' =>
-        test_zci(qr/Noon $test_location_tz is 6:00 PM \(CEST, UTC\+2\)./,
+        test_zci(q/6:00 PM CEST/,
         structured_answer => {
-            input => ['12pm local timezone in CEST'],
+            input => [qq/Noon $test_location_tz to CEST (UTC+2)/],
             operation => 'Convert Timezone',
-            result => qr/Noon $test_location_tz is 6:00 PM \(CEST, UTC\+2\)./,
+            result => q/6:00 PM CEST/,
         },
     ),
     '12am my timezone in UTC' =>
-        test_zci(qr/Midnight $test_location_tz is 4:00 AM \(UTC\)./,
+        test_zci(q/4:00 AM UTC/,
         structured_answer => {
-            input => ['12am my timezone in UTC'],
+            input => [qq/Midnight $test_location_tz to UTC/],
             operation => 'Convert Timezone',
-            result => qr/Midnight $test_location_tz is 4:00 AM \(UTC\)./,
+            result => q/4:00 AM UTC/,
         },
     ),
     '12am local time in UTC' =>
-        test_zci(qr/Midnight $test_location_tz is 4:00 AM \(UTC\)./,
+        test_zci(q/4:00 AM UTC/,
         structured_answer => {
-            input => ['12am local time in UTC'],
+            input => [qq/Midnight $test_location_tz to UTC/],
             operation => 'Convert Timezone',
-            result => qr/Midnight $test_location_tz is 4:00 AM \(UTC\)./,
+            result => q/4:00 AM UTC/,
         },
     ),
 );
 restore_time();
 
 set_fixed_time("2014-11-02T11:00:00");
-$test_location_tz = qr/\(EST, UTC-5\)/;
+$test_location_tz = 'EST (UTC-5)';
 ddg_goodie_test(
     ['DDG::Goodie::TimezoneConverter'],
     # Location-specific tests (variable with DST)
     '13:00 GMT in my time' =>
-        test_zci(qr/13:00 \(GMT\) is 8:00 $test_location_tz/,
+        test_zci(qq/8:00 EST/,
         structured_answer => {
-            input => ['13:00 GMT in my time'],
+            input => [qq/13:00 GMT to $test_location_tz/],
             operation => 'Convert Timezone',
-            result => qr/13:00 \(GMT\) is 8:00 $test_location_tz/,
+            result => q/8:00 EST/,
         },
     ),
     '11:22am cest in my timezone' =>
-        test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
+        test_zci(qr/4:22 AM EST/,
         structured_answer => {
-            input => ['11:22am cest in my timezone'],
+            input => [qq/11:22 AM CEST (UTC+2) to $test_location_tz/],
             operation => 'Convert Timezone',
-            result => qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
+            result => qr/4:22 AM EST/,
         },
     ),
     '11:22am cest in localtime' =>
-        test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
+        test_zci(qr/4:22 AM EST/,
         structured_answer => {
-            input => ['11:22am cest in localtime'],
+            input => [qq/11:22 AM CEST (UTC+2) to $test_location_tz/],
             operation => 'Convert Timezone',
-            result => qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
+            result => qr/4:22 AM EST/,
         },
     ),
     '11:22am cest in my local timezone' =>
-        test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
+        test_zci(q/4:22 AM EST/,
         structured_answer => {
-            input => ['11:22am cest in my local timezone'],
+            input => [qq/11:22 AM CEST (UTC+2) to $test_location_tz/],
             operation => 'Convert Timezone',
-            result => qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
+            result => q/4:22 AM EST/,
         },
     ),
     '12pm my time in CEST' =>
-        test_zci(qr/Noon $test_location_tz is 7:00 PM \(CEST, UTC\+2\)./,
+        test_zci(q/7:00 PM CEST/,
         structured_answer => {
-            input => ['12pm my time in CEST'],
+            input => [qq/Noon $test_location_tz to CEST (UTC+2)/],
             operation => 'Convert Timezone',
-            result => qr/Noon $test_location_tz is 7:00 PM \(CEST, UTC\+2\)./,
+            result => q/7:00 PM CEST/,
         },
     ),
     '12pm local timezone in CEST' =>
-        test_zci(qr/Noon $test_location_tz is 7:00 PM \(CEST, UTC\+2\)./,
+        test_zci(q/7:00 PM CEST/,
         structured_answer => {
-            input => ['12pm local timezone in CEST'],
+            input => [qq/Noon $test_location_tz to CEST (UTC+2)/],
             operation => 'Convert Timezone',
-            result => qr/Noon $test_location_tz is 7:00 PM \(CEST, UTC\+2\)./,
+            result => q/7:00 PM CEST/,
         },
     ),
     '12am my timezone in UTC' =>
-        test_zci(qr/Midnight $test_location_tz is 5:00 AM \(UTC\)./,
+        test_zci(qr/5:00 AM UTC/,
         structured_answer => {
-            input => ['12am my timezone in UTC'],
+            input => [qq/Midnight $test_location_tz to UTC/],
             operation => 'Convert Timezone',
-            result => qr/Midnight $test_location_tz is 5:00 AM \(UTC\)./,
+            result => q/5:00 AM UTC/,
         },
     ),
     '12am local time in UTC' =>
-        test_zci(qr/Midnight $test_location_tz is 5:00 AM \(UTC\)./,
+        test_zci(qr/5:00 AM UTC/,
         structured_answer => {
-            input => ['12am local time in UTC'],
+            input => [qq/Midnight $test_location_tz to UTC/],
             operation => 'Convert Timezone',
-            result => qr/Midnight $test_location_tz is 5:00 AM \(UTC\)./,
+            result => q/5:00 AM UTC/,
         },
     ),
 );

--- a/t/TimezoneConverter.t
+++ b/t/TimezoneConverter.t
@@ -13,84 +13,164 @@ ddg_goodie_test(
     ['DDG::Goodie::TimezoneConverter'],
     '3:14 in GMT' =>
         test_zci('3:14 (UTC) is 3:14 (GMT).',
-            html => qr/.*3:14.*\(UTC\) is.*3:14.*\(GMT\)./
-        ),
+        structured_answer => {
+            input => ['3:14 in GMT'],
+            operation => 'Convert Timezone',
+            result => '3:14 (UTC) is 3:14 (GMT).',
+        },
+    ),
     '8:10 AM AZOST into CAT' =>
         test_zci('8:10 AM (AZOST, UTC-1) is 11:10 AM (CAT, UTC+2).',
-        html => '-ANY-'
-        ),
+        structured_answer => {
+            input => ['8:10 AM AZOST into CAT'],
+            operation => 'Convert Timezone',
+            result => '8:10 AM (AZOST, UTC-1) is 11:10 AM (CAT, UTC+2).',
+        },
+    ),
     '1pm EDT into UTC+2' =>
         test_zci('1:00 PM (EDT, UTC-4) is 7:00 PM (UTC+2).',
-        html => '-ANY-'
-        ),
+        structured_answer => {
+            input => ['1pm EDT into UTC+2'],
+            operation => 'Convert Timezone',
+            result => '1:00 PM (EDT, UTC-4) is 7:00 PM (UTC+2).',
+        },
+    ),
     '0pm into GMT' =>
         test_zci('Noon (UTC) is noon (GMT).',
-        html => '-ANY-'
-        ),
+        structured_answer => {
+            input => ['0pm into GMT'],
+            operation => 'Convert Timezone',
+            result => 'Noon (UTC) is noon (GMT).',
+        },
+    ),
     '0am into UTC' =>
         test_zci('Midnight (UTC) is midnight (UTC).',
-        html => '-ANY-'
-        ),
+        structured_answer => {
+            input => ['0am into UTC'],
+            operation => 'Convert Timezone',
+            result => 'Midnight (UTC) is midnight (UTC).',
+        },
+    ),
     '1 into UTC -2 ' =>
         test_zci('1:00 (UTC) is 23:00, 1 day prior (UTC-2).',
-        html => '-ANY-'
-        ),
+        structured_answer => {
+            input => ['1 into UTC -2'],
+            operation => 'Convert Timezone',
+            result => '1:00 (UTC) is 23:00, 1 day prior (UTC-2).',
+        },
+    ),
     ' 1 into UTC-1' =>
         test_zci('1:00 (UTC) is 0:00 (UTC-1).',
-        html => '-ANY-'
-        ),
+        structured_answer => {
+            input => ['1 into UTC-1'],
+            operation => 'Convert Timezone',
+            result => '1:00 (UTC) is 0:00 (UTC-1).',
+        },
+    ),
     '21 FNT into EET' =>
         test_zci('21:00 (FNT, UTC-2) is 1:00, 1 day after (EET, UTC+2).',
-        html => '-ANY-'
+        structured_answer => {
+            input => ['21 FNT into EET'],
+            operation => 'Convert Timezone',
+            result => '21:00 (FNT, UTC-2) is 1:00, 1 day after (EET, UTC+2).',
+        },
     ),
     '23:00:00  InTo  UTC+1' =>
         test_zci('23:00 (UTC) is 0:00, 1 day after (UTC+1).',
-        html => '-ANY-'
+        structured_answer => {
+            input => ['23:00:00 InTo UTC+1'],
+            operation => 'Convert Timezone',
+            result => '23:00 (UTC) is 0:00, 1 day after (UTC+1).',
+        },
     ),
     '23:00:01  Into    UTC+1' =>
         test_zci('23:00:01 (UTC) is 0:00:01, 1 day after (UTC+1).',
-        html => '-ANY-'
+        structured_answer => {
+            input => ['23:00:01 Into UTC+1'],
+            operation => 'Convert Timezone',
+            result => '23:00:01 (UTC) is 0:00:01, 1 day after (UTC+1).',
+        },
     ),
     '13:15:00 UTC-0:30 into UTC+0:30' =>
         test_zci('13:15 (UTC-0:30) is 13:15 (UTC+0:30).',
-        html => '-ANY-'
+        structured_answer => {
+            input => ['13:15:00 UTC-0:30 into UTC+0:30'],
+            operation => 'Convert Timezone',
+            result => '13:15 (UTC-0:30) is 13:15 (UTC+0:30).',
+        },
     ),
     # ok, this is unlikely to happen without trying to do that
     '19:42:42 BIT into GMT+100' =>
         test_zci('19:42:42 (BIT, UTC-12) is 11:42:42, 5 days after (GMT+100).',
-        html => '-ANY-'
+        structured_answer => {
+            input => ['19:42:42 BIT into GMT+100'],
+            operation => 'Convert Timezone',
+            result => '19:42:42 (BIT, UTC-12) is 11:42:42, 5 days after (GMT+100).',
+        },
     ),
     '19:42:42 CHADT into GMT-100' =>
         test_zci('19:42:42 (CHADT, UTC+13:45) is 1:57:42, 4 days prior (GMT-100).',
-        html => '-ANY-'
+        structured_answer => {
+            input => ['19:42:42 CHADT into GMT-100'],
+            operation => 'Convert Timezone',
+            result => '19:42:42 (CHADT, UTC+13:45) is 1:57:42, 4 days prior (GMT-100).',
+        },
     ),
     '10:00AM MST to PST' =>
         test_zci('10:00 AM (MST, UTC-7) is 9:00 AM (PST, UTC-8).',
-        html => '-ANY-'
+        structured_answer => {
+            input => ['10:00AM MST to PST'],
+            operation => 'Convert Timezone',
+            result => '10:00 AM (MST, UTC-7) is 9:00 AM (PST, UTC-8).',
+        },
     ),
     '19:00 UTC to EST' =>
         test_zci('19:00 (UTC) is 14:00 (EST, UTC-5).',
-        html => '-ANY-'
+        structured_answer => {
+            input => ['19:00 UTC to EST'],
+            operation => 'Convert Timezone',
+            result => '19:00 (UTC) is 14:00 (EST, UTC-5).',
+        },
     ),
     '1am UTC to PST' =>
         test_zci('1:00 AM (UTC) is 5:00 PM, 1 day prior (PST, UTC-8).',
-        html => '-ANY-'
+        structured_answer => {
+            input => ['1am UTC to PST'],
+            operation => 'Convert Timezone',
+            result => '1:00 AM (UTC) is 5:00 PM, 1 day prior (PST, UTC-8).',
+        },
     ),
     '12:40pm PST into JST' =>
         test_zci('12:40 PM (PST, UTC-8) is 5:40 AM, 1 day after (JST, UTC+9).',
-        html => '-ANY-'
+        structured_answer => {
+            input => ['12:40pm PST into JST'],
+            operation => 'Convert Timezone',
+            result => '12:40 PM (PST, UTC-8) is 5:40 AM, 1 day after (JST, UTC+9).',
+        },
     ),
     '12:40 pm from PST to JST' =>
         test_zci('12:40 PM (PST, UTC-8) is 5:40 AM, 1 day after (JST, UTC+9).',
-        html => qr/.*12:40 PM.*\(PST, UTC-8\) is.*5:40 AM, 1 day after.*\(JST, UTC\+9\)./
+        structured_answer => {
+            input => ['12:40 pm from PST to JST'],
+            operation => 'Convert Timezone',
+            result => '12:40 PM (PST, UTC-8) is 5:40 AM, 1 day after (JST, UTC+9).',
+        },
     ),
     '11:22am est in utc' =>
         test_zci('11:22 AM (EST, UTC-5) is 4:22 PM (UTC).',
-        html => qr/.*11:22 AM.*\(EST, UTC-5\) is.*4:22 PM.*\(UTC\)./
+        structured_answer => {
+            input => ['11:22am est in utc'],
+            operation => 'Convert Timezone',
+            result => '11:22 AM (EST, UTC-5) is 4:22 PM (UTC).',
+        },
     ),
       '1600 UTC in BST' =>
         test_zci('16:00 (UTC) is 17:00 (BST, UTC+1).',
-        html => '-ANY-'
+        structured_answer => {
+            input => ['1600 UTC in BST'],
+            operation => 'Convert Timezone',
+            result => '16:00 (UTC) is 17:00 (BST, UTC+1).',
+        },
     ),  
     
     # Intentional non-answers
@@ -105,35 +185,67 @@ ddg_goodie_test(
     # Location-specific tests (variable with DST)
     '13:00 GMT in my time' =>
         test_zci(qr/13:00 \(GMT\) is 9:00 $test_location_tz/,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['13:00 GMT in my time'],
+            operation => 'Convert Timezone',
+            result => qr/13:00 \(GMT\) is 9:00 $test_location_tz/,
+        },
     ),
     '11:22am cest in my timezone' =>
         test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['11:22am cest in my timezone'],
+            operation => 'Convert Timezone',
+            result => qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
+        },
     ),
     '11:22am cest in localtime' =>
         test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['11:22am cest in localtime'],
+            operation => 'Convert Timezone',
+            result => qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
+        },
     ),
     '11:22am cest in my local timezone' =>
         test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['11:22am cest in my local timezone'],
+            operation => 'Convert Timezone',
+            result => qr/11:22 AM \(CEST, UTC\+2\) is 5:22 AM $test_location_tz/,
+        },
     ),
     '12pm my time in CEST' =>
         test_zci(qr/Noon $test_location_tz is 6:00 PM \(CEST, UTC\+2\)./,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['12pm my time in CEST'],
+            operation => 'Convert Timezone',
+            result => qr/Noon $test_location_tz is 6:00 PM \(CEST, UTC\+2\)./,
+        },
     ),
     '12pm local timezone in CEST' =>
         test_zci(qr/Noon $test_location_tz is 6:00 PM \(CEST, UTC\+2\)./,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['12pm local timezone in CEST'],
+            operation => 'Convert Timezone',
+            result => qr/Noon $test_location_tz is 6:00 PM \(CEST, UTC\+2\)./,
+        },
     ),
     '12am my timezone in UTC' =>
         test_zci(qr/Midnight $test_location_tz is 4:00 AM \(UTC\)./,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['12am my timezone in UTC'],
+            operation => 'Convert Timezone',
+            result => qr/Midnight $test_location_tz is 4:00 AM \(UTC\)./,
+        },
     ),
     '12am local time in UTC' =>
         test_zci(qr/Midnight $test_location_tz is 4:00 AM \(UTC\)./,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['12am local time in UTC'],
+            operation => 'Convert Timezone',
+            result => qr/Midnight $test_location_tz is 4:00 AM \(UTC\)./,
+        },
     ),
 );
 restore_time();
@@ -145,35 +257,67 @@ ddg_goodie_test(
     # Location-specific tests (variable with DST)
     '13:00 GMT in my time' =>
         test_zci(qr/13:00 \(GMT\) is 8:00 $test_location_tz/,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['13:00 GMT in my time'],
+            operation => 'Convert Timezone',
+            result => qr/13:00 \(GMT\) is 8:00 $test_location_tz/,
+        },
     ),
     '11:22am cest in my timezone' =>
         test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['11:22am cest in my timezone'],
+            operation => 'Convert Timezone',
+            result => qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
+        },
     ),
     '11:22am cest in localtime' =>
         test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['11:22am cest in localtime'],
+            operation => 'Convert Timezone',
+            result => qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
+        },
     ),
     '11:22am cest in my local timezone' =>
         test_zci(qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['11:22am cest in my local timezone'],
+            operation => 'Convert Timezone',
+            result => qr/11:22 AM \(CEST, UTC\+2\) is 4:22 AM $test_location_tz/,
+        },
     ),
     '12pm my time in CEST' =>
         test_zci(qr/Noon $test_location_tz is 7:00 PM \(CEST, UTC\+2\)./,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['12pm my time in CEST'],
+            operation => 'Convert Timezone',
+            result => qr/Noon $test_location_tz is 7:00 PM \(CEST, UTC\+2\)./,
+        },
     ),
     '12pm local timezone in CEST' =>
         test_zci(qr/Noon $test_location_tz is 7:00 PM \(CEST, UTC\+2\)./,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['12pm local timezone in CEST'],
+            operation => 'Convert Timezone',
+            result => qr/Noon $test_location_tz is 7:00 PM \(CEST, UTC\+2\)./,
+        },
     ),
     '12am my timezone in UTC' =>
         test_zci(qr/Midnight $test_location_tz is 5:00 AM \(UTC\)./,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['12am my timezone in UTC'],
+            operation => 'Convert Timezone',
+            result => qr/Midnight $test_location_tz is 5:00 AM \(UTC\)./,
+        },
     ),
     '12am local time in UTC' =>
         test_zci(qr/Midnight $test_location_tz is 5:00 AM \(UTC\)./,
-        html => '-ANY-'
+        structured_answer => {
+            input => ['12am local time in UTC'],
+            operation => 'Convert Timezone',
+            result => qr/Midnight $test_location_tz is 5:00 AM \(UTC\)./,
+        },
     ),
 );
 


### PR DESCRIPTION
Part of https://github.com/duckduckgo/zeroclickinfo-goodies/issues/1163

It drops the styles, but I didn't see a way to keep that without getting more custom than seemed worth it.

Before: 
![screenshot 2015-07-19 21 11 43](https://cloud.githubusercontent.com/assets/244130/8768815/e2148bea-2e5a-11e5-8dfb-91ae9f2a3c5d.png)


After:
![screenshot 2015-07-19 21 06 20](https://cloud.githubusercontent.com/assets/244130/8768808/a5344ca6-2e5a-11e5-9f47-e236c0dc1113.png)
