### PR TITLE
Prime factors altered to use templates

### DIFF
--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -30,7 +30,7 @@ name 'PrimeFactors';
 topics 'math';
 category 'calculations';
 attribution github => [ 'austinheimark', 'Austin Heimark' ],
-                    ['https://github.com/Sloff', 'Sloff'];
+            github => ['https://github.com/Sloff', 'Sloff'];
 
 sub convert_to_superscripts (_) {
     my $string = $_[0];

--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -123,9 +123,10 @@ handle remainder => sub {
         @result = format_answer("$formatted is a prime number");
     } else {
         my ($text, $answer) = format_prime(@factors);
-        my $intro = "Prime factorization of $formatted";
+        my $subtitle = "$formatted - Prime Factors";
+        my $plaintext = "The prime factorization of $formatted is $text";
 
-        @result = format_answer($intro." is ".$text, $answer, $intro);
+        @result = format_answer($plaintext, $answer, $subtitle);
     }
     
     return @result;

--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -29,7 +29,8 @@ description 'Returns the prime factors of the entered number';
 name 'PrimeFactors';
 topics 'math';
 category 'calculations';
-attribution github => [ 'austinheimark', 'Austin Heimark' ];
+attribution github => [ 'austinheimark', 'Austin Heimark' ],
+                    ['https://github.com/Sloff', 'Sloff'];
 
 # This adds exponents to the prime numbers.
 # It outputs both text and HTML:
@@ -39,7 +40,7 @@ sub format_exp {
     my $factor = shift;
 
     if($factor->[1] > 1) {
-	return "$factor->[0]^$factor->[1]", "$factor->[0]<sup>$factor->[1]</sup>";
+        return "$factor->[0]^$factor->[1]", "$factor->[0]<sup>$factor->[1]</sup>";
     }
     return $factor->[0], $factor->[0];
 }
@@ -52,10 +53,10 @@ sub format_prime {
     my @html_result = ();
 
     foreach my $factor (@factors) {
-	my ($text, $html) = format_exp($factor);
+        my ($text, $html) = format_exp($factor);
 
-	push(@text_result, $text);
-	push(@html_result, $html);
+        push(@text_result, $text);
+        push(@html_result, $html);
     }
 
     return join(" × ", @text_result), join(" × ", @html_result);
@@ -81,12 +82,12 @@ handle remainder => sub {
 
     # Provide only one second for computing the factors.
     eval {
-	alarm(1);
-	@factors = factor_exp($_);
+        alarm(1);
+        @factors = factor_exp($_);
     };
     # Exit if we didn't find anything.
     if(@factors == 0) {
-	return;
+        return;
     }
 
     my $formatted = commify($_);
@@ -94,12 +95,12 @@ handle remainder => sub {
     # If it has only one factor then it is a prime. Except if it's 0 or 1.
     my $result;
     if(is_prime($_)) {
-	return "$formatted is a prime number.", html => "$formatted is a prime number.";
+        return "$formatted is a prime number.", html => "$formatted is a prime number.";
     } else {
-	my ($text, $html) = format_prime(@factors);
-	my $intro = "The prime factorization of $formatted is";
+        my ($text, $html) = format_prime(@factors);
+        my $intro = "The prime factorization of $formatted is";
 
-	return "$intro $text", html => "$intro $html";
+        return "$intro $text", html => "$intro $html";
     }
 };
 

--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -40,7 +40,7 @@ sub convert_to_superscripts (_) {
 }
 
 # This adds exponents to the prime numbers.
-# It outputs both text and HTML:
+# It outputs both plaintext and the number that will be displayed:
 # - 2^2
 # - 2²
 sub format_exp {
@@ -53,20 +53,20 @@ sub format_exp {
 }
 
 # This goes through all the prime factors and formats them in an "n × m" format.
-# It outputs both text and HTML.
+# It outputs both plaintext and the text that will be used in the answer.
 sub format_prime {
     my @factors = @_;
     my @text_result = ();
-    my @html_result = ();
+    my @answer_result = ();
 
     foreach my $factor (@factors) {
-        my ($text, $html) = format_exp($factor);
+        my ($text, $exp) = format_exp($factor);
 
         push(@text_result, $text);
-        push(@html_result, $html);
+        push(@answer_result, $exp);
     }
 
-    return join(" × ", @text_result), join(" × ", @html_result);
+    return join(" × ", @text_result), join(" × ", @answer_result);
 }
 
 # This adds commas to the number.
@@ -122,10 +122,10 @@ handle remainder => sub {
     if(is_prime($_)) {
         @result = format_answer("$formatted is a prime number");
     } else {
-        my ($text, $html) = format_prime(@factors);
-        my $intro = "The prime factorization of $formatted";
+        my ($text, $answer) = format_prime(@factors);
+        my $intro = "Prime factorization of $formatted";
 
-        @result = format_answer($intro." is ".$text, $html, $intro);
+        @result = format_answer($intro." is ".$text, $answer, $intro);
     }
     
     return @result;

--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -32,15 +32,22 @@ category 'calculations';
 attribution github => [ 'austinheimark', 'Austin Heimark' ],
                     ['https://github.com/Sloff', 'Sloff'];
 
+sub convert_to_superscripts (_) {
+    my $string = $_[0];
+    $string =~ tr[+−=()0123456789]
+                [⁺⁻⁼⁽⁾⁰¹²³⁴⁵⁶⁷⁸⁹ⵯ];
+    return $string;
+}
+
 # This adds exponents to the prime numbers.
 # It outputs both text and HTML:
 # - 2^2
-# - 2<sup>2</sup>
+# - 2²
 sub format_exp {
     my $factor = shift;
 
     if($factor->[1] > 1) {
-        return "$factor->[0]^$factor->[1]", "$factor->[0]<sup>$factor->[1]</sup>";
+        return "$factor->[0]^$factor->[1]", "$factor->[0]".convert_to_superscripts($factor->[1]);
     }
     return $factor->[0], $factor->[0];
 }
@@ -72,6 +79,24 @@ sub commify {
     return $_;
 }
 
+# Structured answer that will be returned
+sub format_answer {
+    my ($plaintext, $title, $subtitle) = @_;
+    
+    return $plaintext,
+    structured_answer => {
+        id => 'prime_factors',
+        name => 'Answer',
+        data => {
+            title => $title || $plaintext,
+            subtitle => $subtitle
+        },
+        templates => {
+            group => 'text'
+        }
+    };
+}
+
 handle remainder => sub {
     # Exit if it's not a digit.
     # TODO: We should accept different number formats.
@@ -93,15 +118,17 @@ handle remainder => sub {
     my $formatted = commify($_);
 
     # If it has only one factor then it is a prime. Except if it's 0 or 1.
-    my $result;
+    my @result;
     if(is_prime($_)) {
-        return "$formatted is a prime number.", html => "$formatted is a prime number.";
+        @result = format_answer("$formatted is a prime number");
     } else {
         my ($text, $html) = format_prime(@factors);
-        my $intro = "The prime factorization of $formatted is";
+        my $intro = "The prime factorization of $formatted";
 
-        return "$intro $text", html => "$intro $html";
+        @result = format_answer($intro." is ".$text, $html, $intro);
     }
+    
+    return @result;
 };
 
 1;

--- a/t/PrimeFactors.t
+++ b/t/PrimeFactors.t
@@ -30,18 +30,18 @@ ddg_goodie_test(
 	[qw(
 		DDG::Goodie::PrimeFactors
 	)],
-    '72 prime factors' => test_zci('The prime factorization of 72 is 2^3 × 3^2',
-                                    build_answer('The prime factorization of 72', '2³ × 3²')),
-    'prime factors of 111' => test_zci('The prime factorization of 111 is 3 × 37',
-                                    build_answer('The prime factorization of 111', '3 × 37')),
-    'prime factors of 30' => test_zci('The prime factorization of 30 is 2 × 3 × 5',
-                                    build_answer('The prime factorization of 30', '2 × 3 × 5')),
-    'prime factorization of 45' => test_zci('The prime factorization of 45 is 3^2 × 5',
-                                    build_answer('The prime factorization of 45', '3² × 5')),
-    'factorize 128' => test_zci('The prime factorization of 128 is 2^7',
-                                    build_answer('The prime factorization of 128', '2⁷')),
-    '42 prime factorize' => test_zci('The prime factorization of 42 is 2 × 3 × 7',
-                                    build_answer('The prime factorization of 42', '2 × 3 × 7')),
+    '72 prime factors' => test_zci('Prime factorization of 72 is 2^3 × 3^2',
+                                    build_answer('Prime factorization of 72', '2³ × 3²')),
+    'prime factors of 111' => test_zci('Prime factorization of 111 is 3 × 37',
+                                    build_answer('Prime factorization of 111', '3 × 37')),
+    'prime factors of 30' => test_zci('Prime factorization of 30 is 2 × 3 × 5',
+                                    build_answer('Prime factorization of 30', '2 × 3 × 5')),
+    'prime factorization of 45' => test_zci('Prime factorization of 45 is 3^2 × 5',
+                                    build_answer('Prime factorization of 45', '3² × 5')),
+    'factorize 128' => test_zci('Prime factorization of 128 is 2^7',
+                                    build_answer('Prime factorization of 128', '2⁷')),
+    '42 prime factorize' => test_zci('Prime factorization of 42 is 2 × 3 × 7',
+                                    build_answer('Prime factorization of 42', '2 × 3 × 7')),
     'optimus prime 45' => undef
 );
 

--- a/t/PrimeFactors.t
+++ b/t/PrimeFactors.t
@@ -42,7 +42,7 @@ ddg_goodie_test(
                                     build_answer('The prime factorization of 128', '2⁷')),
     '42 prime factorize' => test_zci('The prime factorization of 42 is 2 × 3 × 7',
                                     build_answer('The prime factorization of 42', '2 × 3 × 7')),
-    'optimus prime 45' => undef,
+    'optimus prime 45' => undef
 );
 
 done_testing;

--- a/t/PrimeFactors.t
+++ b/t/PrimeFactors.t
@@ -10,22 +10,38 @@ use DDG::Test::Goodie;
 zci answer_type => "prime_factors";
 zci is_cached => 1;
 
+sub build_answer {
+    my ($subtitle, $title) = @_;
+    
+    return structured_answer => {
+        id => 'prime_factors',
+        name => 'Answer',
+        data => {
+            title => $title,
+            subtitle => $subtitle
+        },
+        templates => {
+            group => 'text'
+        }
+    }
+}
+
 ddg_goodie_test(
 	[qw(
 		DDG::Goodie::PrimeFactors
 	)],
     '72 prime factors' => test_zci('The prime factorization of 72 is 2^3 × 3^2',
-				   html => 'The prime factorization of 72 is 2<sup>3</sup> × 3<sup>2</sup>'),
+                                    build_answer('The prime factorization of 72', '2³ × 3²')),
     'prime factors of 111' => test_zci('The prime factorization of 111 is 3 × 37',
-				       html => 'The prime factorization of 111 is 3 × 37'),
+                                    build_answer('The prime factorization of 111', '3 × 37')),
     'prime factors of 30' => test_zci('The prime factorization of 30 is 2 × 3 × 5',
-				      html => 'The prime factorization of 30 is 2 × 3 × 5'),
+                                    build_answer('The prime factorization of 30', '2 × 3 × 5')),
     'prime factorization of 45' => test_zci('The prime factorization of 45 is 3^2 × 5',
-					    html => 'The prime factorization of 45 is 3<sup>2</sup> × 5'),
+                                    build_answer('The prime factorization of 45', '3² × 5')),
     'factorize 128' => test_zci('The prime factorization of 128 is 2^7',
-					    html => 'The prime factorization of 128 is 2<sup>7</sup>'),
+                                    build_answer('The prime factorization of 128', '2⁷')),
     '42 prime factorize' => test_zci('The prime factorization of 42 is 2 × 3 × 7',
-					    html => 'The prime factorization of 42 is 2 × 3 × 7'),
+                                    build_answer('The prime factorization of 42', '2 × 3 × 7')),
     'optimus prime 45' => undef,
 );
 

--- a/t/PrimeFactors.t
+++ b/t/PrimeFactors.t
@@ -30,18 +30,18 @@ ddg_goodie_test(
 	[qw(
 		DDG::Goodie::PrimeFactors
 	)],
-    '72 prime factors' => test_zci('Prime factorization of 72 is 2^3 × 3^2',
-                                    build_answer('Prime factorization of 72', '2³ × 3²')),
-    'prime factors of 111' => test_zci('Prime factorization of 111 is 3 × 37',
-                                    build_answer('Prime factorization of 111', '3 × 37')),
-    'prime factors of 30' => test_zci('Prime factorization of 30 is 2 × 3 × 5',
-                                    build_answer('Prime factorization of 30', '2 × 3 × 5')),
-    'prime factorization of 45' => test_zci('Prime factorization of 45 is 3^2 × 5',
-                                    build_answer('Prime factorization of 45', '3² × 5')),
-    'factorize 128' => test_zci('Prime factorization of 128 is 2^7',
-                                    build_answer('Prime factorization of 128', '2⁷')),
-    '42 prime factorize' => test_zci('Prime factorization of 42 is 2 × 3 × 7',
-                                    build_answer('Prime factorization of 42', '2 × 3 × 7')),
+    '72 prime factors' => test_zci('The prime factorization of 72 is 2^3 × 3^2',
+                                    build_answer('72 - Prime Factors', '2³ × 3²')),
+    'prime factors of 111' => test_zci('The prime factorization of 111 is 3 × 37',
+                                    build_answer('111 - Prime Factors', '3 × 37')),
+    'prime factors of 30' => test_zci('The prime factorization of 30 is 2 × 3 × 5',
+                                    build_answer('30 - Prime Factors', '2 × 3 × 5')),
+    'prime factorization of 45' => test_zci('The prime factorization of 45 is 3^2 × 5',
+                                    build_answer('45 - Prime Factors', '3² × 5')),
+    'factorize 128' => test_zci('The prime factorization of 128 is 2^7',
+                                    build_answer('128 - Prime Factors', '2⁷')),
+    '42 prime factorize' => test_zci('The prime factorization of 42 is 2 × 3 × 7',
+                                    build_answer('42 - Prime Factors', '2 × 3 × 7')),
     'optimus prime 45' => undef
 );
 


### PR DESCRIPTION
Fixes part of #1163 

Before:
![before1](https://cloud.githubusercontent.com/assets/7330170/8794492/86e2504c-2f84-11e5-8d93-a0d67d841160.PNG)
![before2](https://cloud.githubusercontent.com/assets/7330170/8794493/8716f608-2f84-11e5-96f8-3c007c82b02c.PNG)
![before3](https://cloud.githubusercontent.com/assets/7330170/8794495/87e64c5a-2f84-11e5-9db8-6c6ada04c642.PNG)

After:
![after1](https://cloud.githubusercontent.com/assets/7330170/8794501/922c18de-2f84-11e5-9ea1-5e2ce08a9905.PNG)
![after2](https://cloud.githubusercontent.com/assets/7330170/8794503/925789b0-2f84-11e5-8f32-2df05a659fb6.PNG)
![after3](https://cloud.githubusercontent.com/assets/7330170/8794508/954508b4-2f84-11e5-85c2-889832770275.PNG)

Bug:
Is cached is ```Math::BigInt``` instead of ```0```, not sure why or if it matters
![problem](https://cloud.githubusercontent.com/assets/7330170/8794525/b8887946-2f84-11e5-95cc-b7d5ee7df5cd.PNG)
