### PR TITLE
Alias added to cheat sheets

### DIFF
--- a/lib/DDG/Goodie/CheatSheets.pm
+++ b/lib/DDG/Goodie/CheatSheets.pm
@@ -21,10 +21,43 @@ triggers startend => (
     'key bindings', 'keys', 'default keys'
 );
 
+# Accepts the json cheatsheet file name and an array of everything
+# that should be aliased with the json file
+sub build_aliases {
+    my ($json, @aliases) = @_;
+    my @result = ();
+    
+    foreach (@aliases) {
+        push (@result, $_);
+        push (@result, $json);
+    }
+    
+    return @result;
+}
+
+# The hash of all aliases
+my %alias = (
+    build_aliases('microsoft-windows.json', (
+        'windows', 'windows xp', 'windows vista', 'windows 7', 'windows 8',
+        'microsoft windows xp', 'microsoft windows vista', 'microsoft windows 7', 'microsoft windows 8'
+    )),
+    build_aliases('sublime-text.json', (
+        'sublime', 'sublime text 2', 'sublime 2'
+    ))
+);
+
 handle remainder => sub {
     # If needed we could jump through a few more hoops to check
     # terms against file names.
-    my $json_path = share(join('-', split /\s+/o, lc($_) . '.json'));
+    
+    my $json_path;
+    
+    if ($alias{lc($_)}) {
+        $json_path = share($alias{lc($_)});
+    } else {
+        $json_path = share(join('-', split /\s+/o, lc($_) . '.json'));
+    }
+
     open my $fh, $json_path or return;
     my $json = do { local $/;  <$fh> };
     my $data = decode_json($json);


### PR DESCRIPTION
This alters CheatSheet.pm to allow aliases to be assigned to cheat sheets, for example "microsoft windows cheat sheet" and "windows cheat sheet" will show the same cheat sheet:

![1](https://cloud.githubusercontent.com/assets/7330170/8851501/1e8c04e8-3150-11e5-9a54-f4b02050bf79.PNG)
![2](https://cloud.githubusercontent.com/assets/7330170/8851502/1eb29c52-3150-11e5-870e-c2bf1c925a82.PNG)
