### PR TITLE
make 'flip coin' trigger coin flipping ia

### DIFF
--- a/lib/DDG/Goodie/Coin.pm
+++ b/lib/DDG/Goodie/Coin.pm
@@ -20,7 +20,7 @@ attribution github => [ 'http://github.com/mattlehning', 'mattlehning' ];
 
 handle query_lc => sub {
     my $flips;
-    if ($_ =~ /^(heads or tails[ ]?[\?]?)|((flip|toss) a coin)$/) {
+    if ($_ =~ /^(heads or tails[ ]?[\?]?)|((flip|toss) (a )?coin)$/) {
         $flips = 1;
     } elsif ($_ =~ /^(?:flip|toss) (\d{0,2}) coins?$/) {
         $flips = $1;

--- a/t/Coin.t
+++ b/t/Coin.t
@@ -18,6 +18,14 @@ ddg_goodie_test(
             result    => qr/^(heads|tails)$/
         }
     ),
+    'flip coin' => test_zci(
+        qr/(heads|tails) \(random\)/,
+        structured_answer => {
+            input     => [1],
+            operation => 'Flip coin',
+            result    => qr/^(heads|tails)$/
+        }
+    ),
     'flip 1 coin' => test_zci(
         qr/(heads|tails) \(random\)/,
         structured_answer => {


### PR DESCRIPTION
Make "a " optional, so "flip coin" triggers the IA as well.

This goes from:
![bug](https://cloud.githubusercontent.com/assets/104916/8960412/ce42875e-35dd-11e5-852a-ab6b43a4bdd0.png)

To:
 
![fixed](https://cloud.githubusercontent.com/assets/104916/8960415/d1f7a67c-35dd-11e5-9d26-a5008f9a2010.png)

This should fix #1343 