### PR TITLE
Added cheatsheets for ghci

### DIFF
--- a/share/goodie/cheat_sheets/ghci.json
+++ b/share/goodie/cheat_sheets/ghci.json
@@ -1,0 +1,1 @@
+haskell-repl.json

--- a/share/goodie/cheat_sheets/haskell-repl.json
+++ b/share/goodie/cheat_sheets/haskell-repl.json
@@ -1,0 +1,102 @@
+{
+    "id": "ghci_repl_cheat_sheet",
+    "name": "GHCi Cheatsheet",
+    "description": "A cheatsheet for ghci.",
+    "metadata": {
+        "sourceName": "Haskell Website",
+        "sourceUrl": "https://www.haskell.org"
+    },
+    "section_order": [
+        "Commands available from the prompt",
+        "Commands for debugging",
+        "Commands for changing settings",
+        "Options for ':set' and ':unset'",
+        "Commands for displaying information"
+    ],
+    "sections": {
+        "Commands available from the prompt": [
+            { "key" : "<statement>"                         , "val" : "evaluate/run <statement>"},
+            { "key" : ":"                                   , "val" : "repeat last command"},
+            { "key" : ":{\n ..lines.. \n:}\n"               , "val" : "multiline command"},
+            { "key" : ":add \\[*\\]<module> ..."            , "val" : "add module(s) to the current target set"},
+            { "key" : ":browse\\[!\\] \\[\\[*\\]<mod>\\]"   , "val" : "display the names defined by module <mod> (!: more details; *: all top-level names)"},
+            { "key" : ":cd <dir>"                           , "val" : "change directory to <dir>"},
+            { "key" : ":cmd <expr>"                         , "val" : "run the commands returned by <expr>::IO String"},
+            { "key" : ":complete <dom> \\[<rng>\\] <s>"     , "val" : "list completions for partial input string"},
+            { "key" : ":ctags\\[!\\] \\[<file>\\]"          , "val" : "create tags file for Vi (default: \"tags\") (!: use regex instead of line number)"},
+            {"key" : ":def <cmd> <expr>"                    , "val" : "define command :<cmd> (later defined command has precedence, ::<cmd> is always a builtin command)"},
+            { "key" : ":edit <file>"                        , "val" : "edit file"},
+            { "key" : ":edit"                               , "val" : "edit last module"},
+            { "key" : ":etags \\[<file>\\]"                 , "val" : "create tags file for Emacs (default: \"TAGS\")"},
+            { "key" : ":help                                , :?", "val" : "display this list of commands"},
+            { "key" : ":info\\[!\\] \\[<name> ...\\]"       , "val" : "display information about the given names (!: do not filter instances)"},
+            { "key" : ":issafe \\[<mod>\\]"                 , "val" : "display safe haskell information of module <mod>" },
+            { "key" : ":kind\\[!\\] <type>"                 , "val" : "show the kind of <type> (!: also print the normalised type)"},
+            { "key" : ":load \\[*\\]<module> ..."           , "val" : "load module(s) and their dependents"},
+            { "key" : ":main \\[<arguments> ...\\]"         , "val" : "run the main function with the given arguments"},
+            { "key" : ":module \\[+/-\\] \\[*\\]<mod> ... " , "val" : "set the context for expression evaluation"},
+            { "key" : ":quit"                               , "val" : "exit GHCi"},
+            { "key" : ":reload"                             , "val" : "reload the current module set"},
+            { "key" : ":run function \\[<arguments> ...\\]" , "val" : "run the function with the given arguments"},
+            { "key" : ":script <filename>"                  , "val" : "run the script <filename>" },
+            { "key" : ":type <expr>"                        , "val" : "show the type of <expr>"},
+            { "key" : ":undef <cmd>"                        , "val" : "undefine user-defined command :<cmd>"},
+            { "key" : ":!<command>"                         , "val" : "run the shell command <command>"}
+           ],
+        "Commands for debugging" : [
+             { "key" : ":abandon"                           , "val" : "at a breakpoint, abandon current computation"},
+             { "key" : ":back"                              , "val" : "go back in the history (after :trace)"},
+             { "key" : ":break \\[<mod>\\] <l> \\[<col>\\]" , "val" : "set a breakpoint at the specified location"},
+             { "key" : ":break <name>"                      , "val" : "set a breakpoint on the specified function"},
+             { "key" : ":continue"                          , "val" : "resume after a breakpoint"},
+             { "key" : ":delete <number>"                   , "val" : "delete the specified breakpoint"},
+             { "key" : ":delete *"                          , "val" : "delete all breakpoints"},
+             { "key" : ":force <expr>"                      , "val" : "print <expr>, forcing unevaluated parts"},
+             { "key" : ":forward"                           , "val" : "go forward in the history (after :back)"},
+             { "key" : ":history \\[<n>\\]"                 , "val" : "after :trace, show the execution history"},
+             { "key" : ":list"                              , "val" : "show the source code around current breakpoint"},
+             { "key" : ":list <identifier>"                 , "val" : "show the source code for <identifier>"},
+             { "key" : ":list \\[<module>\\] <line>"        , "val" : "show the source code around line number <line>"},
+             { "key" : ":print \\[<name> ...\\]"            , "val" : "prints a value without forcing its computation"},
+             { "key" : ":sprint \\[<name> ...\\]"           , "val" : "simplifed version of :print"},
+             { "key" : ":step"                              , "val" : "single-step after stopping at a breakpoint"},
+             { "key" : ":step <expr>"                       , "val" : "single-step into <expr>"},
+             { "key" : ":steplocal"                         , "val" : "single-step within the current top-level binding"},
+             { "key" : ":stepmodule"                        , "val" : "single-step restricted to the current module"},
+             { "key" : ":trace"                             , "val" : "trace after stopping at a breakpoint"},
+             { "key" : ":trace <expr>"                      , "val" : "evaluate <expr> with tracing on (see :history)"}
+        ],
+        "Commands for changing settings": [
+            { "key" : ":set <option> ..."         , "val" :  "set options"},
+            { "key" : ":seti <option> ..."        , "val" :  "set options for interactive evaluation only"},
+            { "key" : ":set args <arg> ..."       , "val" :  "set the arguments returned by System.getArgs"},
+            { "key" : ":set prog <progname>"      , "val" :  "set the value returned by System.getProgName"},
+            { "key" : ":set prompt <prompt>"      , "val" :  "set the prompt used in GHCi"},
+            { "key" : ":set prompt2 <prompt>"     , "val" :  "set the continuation prompt used in GHCi"},
+            { "key" : ":set editor <cmd>"         , "val" :  "set the command used for :edit"},
+            { "key" : ":set stop \\[<n>\\] <cmd>" , "val" :  "set the command to run when a breakpoint is hit"},
+            { "key" : ":unset <option> ..."       , "val" :  "unset options"}
+        ],
+        "Options for ':set' and ':unset'":[
+            { "key" : "+m" , "val" : "allow multiline commands"},
+            { "key" : "+r" , "val" : "revert top-level expressions after each evaluation"},
+            { "key" : "+s" , "val" : "print timing/memory stats after each evaluation"},
+            { "key" : "+t" , "val" : "print type after evaluation"},
+            { "key" : "-<flags>" , "val" : "most GHC command line flags can also be set here (eg. -v2, -XFlexibleInstances, etc.) for GHCi-specific flags, see User's Guide, Flag reference, Interactive-mode options"}
+
+        ],
+        "Commands for displaying information":[
+            { "key" : ":show bindings"  , "val" : "show the current bindings made at the prompt"},
+            { "key" : ":show breaks"    , "val" : "show the active breakpoints"},
+            { "key" : ":show context"   , "val" : "show the breakpoint context"},
+            { "key" : ":show imports"   , "val" : "show the current imports"},
+            { "key" : ":show linker"    , "val" : "show current linker state"},
+            { "key" : ":show modules"   , "val" : "show the currently loaded modules"},
+            { "key" : ":show packages"  , "val" : "show the currently active package flags"},
+            { "key" : ":show paths"     , "val" : "show the currently active search paths"},
+            { "key" : ":show language"  , "val" : "show the currently active language flags"},
+            { "key" : ":show <setting>" , "val" : "show value of <setting>, which is one of \\[args, prog, prompt, editor, stop\\]"},
+            { "key" : ":showi language" , "val" : "show language flags for interactive evaluation"}
+        ]
+    }
+}

--- a/share/goodie/cheat_sheets/haskell-repl.json
+++ b/share/goodie/cheat_sheets/haskell-repl.json
@@ -1,11 +1,12 @@
 {
-    "description": "A cheatsheet for ghci.",
     "id": "ghci_repl_cheat_sheet",
+    "name": "GHCi Cheatsheet",
+    "description": "A cheatsheet for ghci.",
     "metadata": {
         "sourceName": "Haskell Website",
         "sourceUrl": "https://www.haskell.org"
     },
-    "name": "GHCi Cheatsheet",
+
     "section_order": [
         "Commands available from the prompt",
         "Commands for debugging",

--- a/share/goodie/cheat_sheets/haskell-repl.json
+++ b/share/goodie/cheat_sheets/haskell-repl.json
@@ -1,11 +1,11 @@
 {
-    "id": "ghci_repl_cheat_sheet",
-    "name": "GHCi Cheatsheet",
     "description": "A cheatsheet for ghci.",
+    "id": "ghci_repl_cheat_sheet",
     "metadata": {
         "sourceName": "Haskell Website",
         "sourceUrl": "https://www.haskell.org"
     },
+    "name": "GHCi Cheatsheet",
     "section_order": [
         "Commands available from the prompt",
         "Commands for debugging",
@@ -15,88 +15,306 @@
     ],
     "sections": {
         "Commands available from the prompt": [
-            { "key" : "<statement>"                         , "val" : "evaluate/run <statement>"},
-            { "key" : ":"                                   , "val" : "repeat last command"},
-            { "key" : ":{\n ..lines.. \n:}\n"               , "val" : "multiline command"},
-            { "key" : ":add \\[*\\]<module> ..."            , "val" : "add module(s) to the current target set"},
-            { "key" : ":browse\\[!\\] \\[\\[*\\]<mod>\\]"   , "val" : "display the names defined by module <mod> (!: more details; *: all top-level names)"},
-            { "key" : ":cd <dir>"                           , "val" : "change directory to <dir>"},
-            { "key" : ":cmd <expr>"                         , "val" : "run the commands returned by <expr>::IO String"},
-            { "key" : ":complete <dom> \\[<rng>\\] <s>"     , "val" : "list completions for partial input string"},
-            { "key" : ":ctags\\[!\\] \\[<file>\\]"          , "val" : "create tags file for Vi (default: \"tags\") (!: use regex instead of line number)"},
-            {"key" : ":def <cmd> <expr>"                    , "val" : "define command :<cmd> (later defined command has precedence, ::<cmd> is always a builtin command)"},
-            { "key" : ":edit <file>"                        , "val" : "edit file"},
-            { "key" : ":edit"                               , "val" : "edit last module"},
-            { "key" : ":etags \\[<file>\\]"                 , "val" : "create tags file for Emacs (default: \"TAGS\")"},
-            { "key" : ":help                                , :?", "val" : "display this list of commands"},
-            { "key" : ":info\\[!\\] \\[<name> ...\\]"       , "val" : "display information about the given names (!: do not filter instances)"},
-            { "key" : ":issafe \\[<mod>\\]"                 , "val" : "display safe haskell information of module <mod>" },
-            { "key" : ":kind\\[!\\] <type>"                 , "val" : "show the kind of <type> (!: also print the normalised type)"},
-            { "key" : ":load \\[*\\]<module> ..."           , "val" : "load module(s) and their dependents"},
-            { "key" : ":main \\[<arguments> ...\\]"         , "val" : "run the main function with the given arguments"},
-            { "key" : ":module \\[+/-\\] \\[*\\]<mod> ... " , "val" : "set the context for expression evaluation"},
-            { "key" : ":quit"                               , "val" : "exit GHCi"},
-            { "key" : ":reload"                             , "val" : "reload the current module set"},
-            { "key" : ":run function \\[<arguments> ...\\]" , "val" : "run the function with the given arguments"},
-            { "key" : ":script <filename>"                  , "val" : "run the script <filename>" },
-            { "key" : ":type <expr>"                        , "val" : "show the type of <expr>"},
-            { "key" : ":undef <cmd>"                        , "val" : "undefine user-defined command :<cmd>"},
-            { "key" : ":!<command>"                         , "val" : "run the shell command <command>"}
-           ],
-        "Commands for debugging" : [
-             { "key" : ":abandon"                           , "val" : "at a breakpoint, abandon current computation"},
-             { "key" : ":back"                              , "val" : "go back in the history (after :trace)"},
-             { "key" : ":break \\[<mod>\\] <l> \\[<col>\\]" , "val" : "set a breakpoint at the specified location"},
-             { "key" : ":break <name>"                      , "val" : "set a breakpoint on the specified function"},
-             { "key" : ":continue"                          , "val" : "resume after a breakpoint"},
-             { "key" : ":delete <number>"                   , "val" : "delete the specified breakpoint"},
-             { "key" : ":delete *"                          , "val" : "delete all breakpoints"},
-             { "key" : ":force <expr>"                      , "val" : "print <expr>, forcing unevaluated parts"},
-             { "key" : ":forward"                           , "val" : "go forward in the history (after :back)"},
-             { "key" : ":history \\[<n>\\]"                 , "val" : "after :trace, show the execution history"},
-             { "key" : ":list"                              , "val" : "show the source code around current breakpoint"},
-             { "key" : ":list <identifier>"                 , "val" : "show the source code for <identifier>"},
-             { "key" : ":list \\[<module>\\] <line>"        , "val" : "show the source code around line number <line>"},
-             { "key" : ":print \\[<name> ...\\]"            , "val" : "prints a value without forcing its computation"},
-             { "key" : ":sprint \\[<name> ...\\]"           , "val" : "simplifed version of :print"},
-             { "key" : ":step"                              , "val" : "single-step after stopping at a breakpoint"},
-             { "key" : ":step <expr>"                       , "val" : "single-step into <expr>"},
-             { "key" : ":steplocal"                         , "val" : "single-step within the current top-level binding"},
-             { "key" : ":stepmodule"                        , "val" : "single-step restricted to the current module"},
-             { "key" : ":trace"                             , "val" : "trace after stopping at a breakpoint"},
-             { "key" : ":trace <expr>"                      , "val" : "evaluate <expr> with tracing on (see :history)"}
+            {
+                "key": "<statement>",
+                "val": "evaluate/run <statement>"
+            },
+            {
+                "key": ":",
+                "val": "repeat last command"
+            },
+            {
+                "key": ":\\{\\n ..lines.. \\n:\\}\\n",
+                "val": "multiline command"
+            },
+            {
+                "key": ":add \\[*\\]<module> ...",
+                "val": "add module(s) to the current target set"
+            },
+            {
+                "key": ":browse\\[!\\] \\[\\[*\\]<mod>\\]",
+                "val": "display the names defined by module <mod> (!: more details; *: all top-level names)"
+            },
+            {
+                "key": ":cd <dir>",
+                "val": "change directory to <dir>"
+            },
+            {
+                "key": ":cmd <expr>",
+                "val": "run the commands returned by <expr>::IO String"
+            },
+            {
+                "key": ":complete <dom> \\[<rng>\\] <s>",
+                "val": "list completions for partial input string"
+            },
+            {
+                "key": ":ctags\\[!\\] \\[<file>\\]",
+                "val": "create tags file for Vi (default: \"tags\") (!: use regex instead of line number)"
+            },
+            {
+                "key": ":def <cmd> <expr>",
+                "val": "define command :<cmd> (later defined command has precedence, ::<cmd> is always a builtin command)"
+            },
+            {
+                "key": ":edit <file>",
+                "val": "edit file"
+            },
+            {
+                "key": ":edit",
+                "val": "edit last module"
+            },
+            {
+                "key": ":etags \\[<file>\\]",
+                "val": "create tags file for Emacs (default: \"TAGS\")"
+            },
+            {
+                "key": ":help                                , :?",
+                "val": "display this list of commands"
+            },
+            {
+                "key": ":info\\[!\\] \\[<name> ...\\]",
+                "val": "display information about the given names (!: do not filter instances)"
+            },
+            {
+                "key": ":issafe \\[<mod>\\]",
+                "val": "display safe haskell information of module <mod>"
+            },
+            {
+                "key": ":kind\\[!\\] <type>",
+                "val": "show the kind of <type> (!: also print the normalised type)"
+            },
+            {
+                "key": ":load \\[*\\]<module> ...",
+                "val": "load module(s) and their dependents"
+            },
+            {
+                "key": ":main \\[<arguments> ...\\]",
+                "val": "run the main function with the given arguments"
+            },
+            {
+                "key": ":module \\[+/-\\] \\[*\\]<mod> ... ",
+                "val": "set the context for expression evaluation"
+            },
+            {
+                "key": ":quit",
+                "val": "exit GHCi"
+            },
+            {
+                "key": ":reload",
+                "val": "reload the current module set"
+            },
+            {
+                "key": ":run function \\[<arguments> ...\\]",
+                "val": "run the function with the given arguments"
+            },
+            {
+                "key": ":script <filename>",
+                "val": "run the script <filename>"
+            },
+            {
+                "key": ":type <expr>",
+                "val": "show the type of <expr>"
+            },
+            {
+                "key": ":undef <cmd>",
+                "val": "undefine user-defined command :<cmd>"
+            },
+            {
+                "key": ":!<command>",
+                "val": "run the shell command <command>"
+            }
         ],
         "Commands for changing settings": [
-            { "key" : ":set <option> ..."         , "val" :  "set options"},
-            { "key" : ":seti <option> ..."        , "val" :  "set options for interactive evaluation only"},
-            { "key" : ":set args <arg> ..."       , "val" :  "set the arguments returned by System.getArgs"},
-            { "key" : ":set prog <progname>"      , "val" :  "set the value returned by System.getProgName"},
-            { "key" : ":set prompt <prompt>"      , "val" :  "set the prompt used in GHCi"},
-            { "key" : ":set prompt2 <prompt>"     , "val" :  "set the continuation prompt used in GHCi"},
-            { "key" : ":set editor <cmd>"         , "val" :  "set the command used for :edit"},
-            { "key" : ":set stop \\[<n>\\] <cmd>" , "val" :  "set the command to run when a breakpoint is hit"},
-            { "key" : ":unset <option> ..."       , "val" :  "unset options"}
+            {
+                "key": ":set <option> ...",
+                "val": "set options"
+            },
+            {
+                "key": ":seti <option> ...",
+                "val": "set options for interactive evaluation only"
+            },
+            {
+                "key": ":set args <arg> ...",
+                "val": "set the arguments returned by System.getArgs"
+            },
+            {
+                "key": ":set prog <progname>",
+                "val": "set the value returned by System.getProgName"
+            },
+            {
+                "key": ":set prompt <prompt>",
+                "val": "set the prompt used in GHCi"
+            },
+            {
+                "key": ":set prompt2 <prompt>",
+                "val": "set the continuation prompt used in GHCi"
+            },
+            {
+                "key": ":set editor <cmd>",
+                "val": "set the command used for :edit"
+            },
+            {
+                "key": ":set stop \\[<n>\\] <cmd>",
+                "val": "set the command to run when a breakpoint is hit"
+            },
+            {
+                "key": ":unset <option> ...",
+                "val": "unset options"
+            }
         ],
-        "Options for ':set' and ':unset'":[
-            { "key" : "+m" , "val" : "allow multiline commands"},
-            { "key" : "+r" , "val" : "revert top-level expressions after each evaluation"},
-            { "key" : "+s" , "val" : "print timing/memory stats after each evaluation"},
-            { "key" : "+t" , "val" : "print type after evaluation"},
-            { "key" : "-<flags>" , "val" : "most GHC command line flags can also be set here (eg. -v2, -XFlexibleInstances, etc.) for GHCi-specific flags, see User's Guide, Flag reference, Interactive-mode options"}
-
+        "Commands for debugging": [
+            {
+                "key": ":abandon",
+                "val": "at a breakpoint, abandon current computation"
+            },
+            {
+                "key": ":back",
+                "val": "go back in the history (after :trace)"
+            },
+            {
+                "key": ":break \\[<mod>\\] <l> \\[<col>\\]",
+                "val": "set a breakpoint at the specified location"
+            },
+            {
+                "key": ":break <name>",
+                "val": "set a breakpoint on the specified function"
+            },
+            {
+                "key": ":continue",
+                "val": "resume after a breakpoint"
+            },
+            {
+                "key": ":delete <number>",
+                "val": "delete the specified breakpoint"
+            },
+            {
+                "key": ":delete *",
+                "val": "delete all breakpoints"
+            },
+            {
+                "key": ":force <expr>",
+                "val": "print <expr>, forcing unevaluated parts"
+            },
+            {
+                "key": ":forward",
+                "val": "go forward in the history (after :back)"
+            },
+            {
+                "key": ":history \\[<n>\\]",
+                "val": "after :trace, show the execution history"
+            },
+            {
+                "key": ":list",
+                "val": "show the source code around current breakpoint"
+            },
+            {
+                "key": ":list <identifier>",
+                "val": "show the source code for <identifier>"
+            },
+            {
+                "key": ":list \\[<module>\\] <line>",
+                "val": "show the source code around line number <line>"
+            },
+            {
+                "key": ":print \\[<name> ...\\]",
+                "val": "prints a value without forcing its computation"
+            },
+            {
+                "key": ":sprint \\[<name> ...\\]",
+                "val": "simplifed version of :print"
+            },
+            {
+                "key": ":step",
+                "val": "single-step after stopping at a breakpoint"
+            },
+            {
+                "key": ":step <expr>",
+                "val": "single-step into <expr>"
+            },
+            {
+                "key": ":steplocal",
+                "val": "single-step within the current top-level binding"
+            },
+            {
+                "key": ":stepmodule",
+                "val": "single-step restricted to the current module"
+            },
+            {
+                "key": ":trace",
+                "val": "trace after stopping at a breakpoint"
+            },
+            {
+                "key": ":trace <expr>",
+                "val": "evaluate <expr> with tracing on (see :history)"
+            }
         ],
-        "Commands for displaying information":[
-            { "key" : ":show bindings"  , "val" : "show the current bindings made at the prompt"},
-            { "key" : ":show breaks"    , "val" : "show the active breakpoints"},
-            { "key" : ":show context"   , "val" : "show the breakpoint context"},
-            { "key" : ":show imports"   , "val" : "show the current imports"},
-            { "key" : ":show linker"    , "val" : "show current linker state"},
-            { "key" : ":show modules"   , "val" : "show the currently loaded modules"},
-            { "key" : ":show packages"  , "val" : "show the currently active package flags"},
-            { "key" : ":show paths"     , "val" : "show the currently active search paths"},
-            { "key" : ":show language"  , "val" : "show the currently active language flags"},
-            { "key" : ":show <setting>" , "val" : "show value of <setting>, which is one of \\[args, prog, prompt, editor, stop\\]"},
-            { "key" : ":showi language" , "val" : "show language flags for interactive evaluation"}
+        "Commands for displaying information": [
+            {
+                "key": ":show bindings",
+                "val": "show the current bindings made at the prompt"
+            },
+            {
+                "key": ":show breaks",
+                "val": "show the active breakpoints"
+            },
+            {
+                "key": ":show context",
+                "val": "show the breakpoint context"
+            },
+            {
+                "key": ":show imports",
+                "val": "show the current imports"
+            },
+            {
+                "key": ":show linker",
+                "val": "show current linker state"
+            },
+            {
+                "key": ":show modules",
+                "val": "show the currently loaded modules"
+            },
+            {
+                "key": ":show packages",
+                "val": "show the currently active package flags"
+            },
+            {
+                "key": ":show paths",
+                "val": "show the currently active search paths"
+            },
+            {
+                "key": ":show language",
+                "val": "show the currently active language flags"
+            },
+            {
+                "key": ":show <setting>",
+                "val": "show value of <setting>, which is one of \\[args, prog, prompt, editor, stop\\]"
+            },
+            {
+                "key": ":showi language",
+                "val": "show language flags for interactive evaluation"
+            }
+        ],
+        "Options for ':set' and ':unset'": [
+            {
+                "key": "+m",
+                "val": "allow multiline commands"
+            },
+            {
+                "key": "+r",
+                "val": "revert top-level expressions after each evaluation"
+            },
+            {
+                "key": "+s",
+                "val": "print timing/memory stats after each evaluation"
+            },
+            {
+                "key": "+t",
+                "val": "print type after evaluation"
+            },
+            {
+                "key": "-<flags>",
+                "val": "most GHC command line flags can also be set here (eg. -v2, -XFlexibleInstances, etc.) for GHCi-specific flags, see User's Guide, Flag reference, Interactive-mode options"
+            }
         ]
     }
 }


### PR DESCRIPTION
# Cheat sheets for GHCi

**What does your Instant Answer do?**

A cheatsheet for the GHCi prompt. Although the information is available from a command inside the prompt this cheatsheet provides an alternate view.

**What is the data source for your Instant Answer? (Provide a link if possible)**

The data source is the help documentation for ghci, accessible from the program itself.

More information about haskell is [available online](https://wiki.haskell.org/GHC/GHCi)

**Why did you choose this data source?**

These are the official sources of information.

**Are there any other alternative (better) data sources?**

No.

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**

For developers, researchers, and enthusiasts of Haskell.



**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**

Not that I am aware of.

**Are you having any problems? Do you need our help with anything?**

No.

**Where did you hear about DuckDuckHack? (For first time contributors)**

From colleagues, you social media links, and the web.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![screen shot 2015-08-01 at 23 32 51](https://cloud.githubusercontent.com/assets/331273/9023833/2c7ee9a0-38a6-11e5-829a-2b5a32defdae.png)

-----
IA Page: https://duck.co/ia/view/ghci_repl_cheat_sheet