### PR TITLE
CheatSheets: removed plus sign between consecutive keys as per most recent syntax rules

### DIFF
--- a/share/goodie/cheat_sheets/blender.json
+++ b/share/goodie/cheat_sheets/blender.json
@@ -37,7 +37,7 @@
             "key": "Mouse wheel"
         }, {
             "val": "Add object",
-            "key": "[Shift] + [a]"
+            "key": "[Shift] [a]"
         }, {
             "val": "Delete",
             "key": "x"
@@ -52,13 +52,13 @@
             "key": "n"
         }, {
             "val": "Save file",
-            "key": "[Ctrl] + [s]"
+            "key": "[Ctrl] [s]"
         }, {
             "val": "Render image",
             "key": "F12"
         }, {
             "val": "Render animation",
-            "key": "[Ctrl] + [F12]"
+            "key": "[Ctrl] [F12]"
         }, {
             "val": "Stop render",
             "key": "Esc"
@@ -70,50 +70,50 @@
             "key": "F11"
         }, {
             "val": "Undo",
-            "key": "[Ctrl] + [z]"
+            "key": "[Ctrl] [z]"
         }, {
             "val": "Redo",
-            "key": "[Ctrl] + [Shift] + [z]"
+            "key": "[Ctrl] [Shift] [z]"
         }],
         "General": [{
             "val": "Duplicate",
-            "key": "[Shift] + [d]"
+            "key": "[Shift] [d]"
         }, {
             "val": "Move to layer",
             "key": "m"
         }, {
             "val": "Mirror",
-            "key": "[Ctrl] + [m]"
+            "key": "[Ctrl] [m]"
         }, {
             "val": "Hide",
             "key": "h"
         }, {
             "val": "Unhide",
-            "key": "[Alt] + [h]"
+            "key": "[Alt] [h]"
         }, {
             "val": "Move origin point",
-            "key": "[Ctrl] + [Shift] + [Alt] + [c]"
+            "key": "[Ctrl] [Shift] [Alt] [c]"
         }, {
             "val": "Parent to",
-            "key": "[Ctrl] + [p]"
+            "key": "[Ctrl] [p]"
         }, {
             "val": "Clear parent",
-            "key": "[Alt] + [p]"
+            "key": "[Alt] [p]"
         }, {
             "val": "Track to",
-            "key": "[Ctrl] + [t]"
+            "key": "[Ctrl] [t]"
         }, {
             "val": "Clear track",
-            "key": "[Alt] + [t]"
+            "key": "[Alt] [t]"
         }, {
             "val": "Reset 3D cursor",
-            "key": "[Shift] + [c]"
+            "key": "[Shift] [c]"
         }, {
             "val": "Turn widget on/off",
-            "key": "[Ctrl] + [Spacebar]"
+            "key": "[Ctrl] [Spacebar]"
         }, {
             "val": "Add to group",
-            "key": "[Ctrl] + [g]"
+            "key": "[Ctrl] [g]"
         }],
         "Movements": [{
             "val": "Move",
@@ -151,26 +151,26 @@
             "key": "Numpad ."
         }, {
             "val": "Fly mode",
-            "key": "[Shift] + [f]"
+            "key": "[Shift] [f]"
         }],
         "Selection": [{
             "val": "Select oblect",
             "key": "Right click"
         }, {
             "val": "Select multiple",
-            "key": "[Shift] + [Right click]"
+            "key": "[Shift] [Right click]"
         }, {
             "val": "(De-)Select all",
             "key": "a"
         }, {
             "val": "Select object behind",
-            "key": "[Alt] + [Right click]"
+            "key": "[Alt] [Right click]"
         }, {
             "val": "Select linked",
             "key": "l"
         }, {
             "val": "Select all linked",
-            "key": "[Ctrl] + [l]"
+            "key": "[Ctrl] [l]"
         }, {
             "val": "Box select",
             "key": "b"
@@ -179,14 +179,14 @@
             "key": "c"
         }, {
             "val": "Lasso tool",
-            "key": "[Ctrl] + [Click]"
+            "key": "[Ctrl] [Click]"
         }, {
             "val": "Inverse selection",
-            "key": "[Ctrl] + [i]"
+            "key": "[Ctrl] [i]"
         }],
         "Fly mode": [{
             "val": "Start fly mode",
-            "key": "[Shift] + [f]"
+            "key": "[Shift] [f]"
         }, {
             "val": "Accelerate",
             "key": "[Mouse wheel \\{up\\}]"
@@ -223,56 +223,56 @@
             "key": "v"
         }, {
             "val": "Weight paint mode",
-            "key": "[Ctrl] + [Tab]"
+            "key": "[Ctrl] [Tab]"
         }, {
             "val": "Switching workspace",
-            "key": "[Ctrl] + [Left arrow] or [Ctrl] + [Right arrow]"
+            "key": "[Ctrl] [Left arrow] or [Ctrl] [Right arrow]"
         }, {
             "val": "Logic editor",
-            "key": "[Shift] + [F2]"
+            "key": "[Shift] [F2]"
         }, {
             "val": "Node editor",
-            "key": "[Shift] + [F3]"
+            "key": "[Shift] [F3]"
         }, {
             "val": "Console",
-            "key": "[Shift] + [F4]"
+            "key": "[Shift] [F4]"
         }, {
             "val": "3D viewport",
-            "key": "[Shift] + [F5]"
+            "key": "[Shift] [F5]"
         }, {
             "val": "F-curve editor",
-            "key": "[Shift] + [F6]"
+            "key": "[Shift] [F6]"
         }, {
             "val": "Properties",
-            "key": "[Shift] + [F7]"
+            "key": "[Shift] [F7]"
         }, {
             "val": "Video sequence editor",
-            "key": "[Shift] + [F8]"
+            "key": "[Shift] [F8]"
         }, {
             "val": "Outliner",
-            "key": "[Shift] + [F9]"
+            "key": "[Shift] [F9]"
         }, {
             "val": "UV/Image editor",
-            "key": "[Shift] + [F10]"
+            "key": "[Shift] [F10]"
         }, {
             "val": "Text editor",
-            "key": "[Shift] + [F11]"
+            "key": "[Shift] [F11]"
         }],
         "Editing curves": [{
             "val": "Close path",
-            "key": "[Alt] + [c]"
+            "key": "[Alt] [c]"
         }, {
             "val": "Add handle",
-            "key": "[Ctrl] + [Click]"
+            "key": "[Ctrl] [Click]"
         }, {
             "val": "Subdivide",
             "key": "w"
         }, {
             "val": "Tilt",
-            "key": "[Ctrl] + [t]"
+            "key": "[Ctrl] [t]"
         }, {
             "val": "Clear tilt",
-            "key": "[Alt] + [t]"
+            "key": "[Alt] [t]"
         }, {
             "val": "Change handle to bezier",
             "key": "h"
@@ -281,7 +281,7 @@
             "key": "v"
         }, {
             "val": "Reset to default handle",
-            "key": "[Shift] + [h]"
+            "key": "[Shift] [h]"
         }],
         "Modeling": [{
             "val": "Make face",
@@ -300,54 +300,54 @@
             "key": "v"
         }, {
             "val": "Create loop cut",
-            "key": "[Ctrl] + [r]"
+            "key": "[Ctrl] [r]"
         }, {
             "val": "Propostional editing",
             "key": "o"
         }, {
             "val": "Select edge loop",
-            "key": "[Alt] + [Right click]"
+            "key": "[Alt] [Right click]"
         }, {
             "val": "Make seam/sharp",
-            "key": "[Ctrl] + [e]"
+            "key": "[Ctrl] [e]"
         }, {
             "val": "Merge vertices",
-            "key": "[Alt] + [m]"
+            "key": "[Alt] [m]"
         }, {
             "val": "Mirror",
-            "key": "[Ctrl] + [m]"
+            "key": "[Ctrl] [m]"
         }, {
             "val": "Shrink/Flatten",
-            "key": "[Alt] + [s]"
+            "key": "[Alt] [s]"
         }, {
             "val": "Knife",
             "key": "[k] then [Click]"
         }, {
             "val": "Fill",
-            "key": "[Alt] + [f]"
+            "key": "[Alt] [f]"
         }, {
             "val": "Beauty fill",
-            "key": "[Shift] + [Alt] + [f]"
+            "key": "[Shift] [Alt] [f]"
         }, {
             "val": "Add subdivision level",
-            "key": "[Ctrl] + [1] / [2] / [3] / [4]"
+            "key": "[Ctrl] [1] / [2] / [3] / [4]"
         }],
         "Sculpting": [{
             "val": "Change brush size",
             "key": "f"
         }, {
             "val": "Change brush strength",
-            "key": "[Shift] + [f]"
+            "key": "[Shift] [f]"
         }, {
             "val": "Rotate brush texture",
-            "key": "[Ctrl] + [f]"
+            "key": "[Ctrl] [f]"
         }],
         "Animation": [{
             "val": "Play/Stop animation",
-            "key": "[Alt] + [a]"
+            "key": "[Alt] [a]"
         }, {
             "val": "Play animation in reverse",
-            "key": "[Alt] + [Shift] + [a]"
+            "key": "[Alt] [Shift] [a]"
         }, {
             "val": "Next frame",
             "key": "Right arrow"
@@ -362,81 +362,81 @@
             "key": "Down arrow"
         }, {
             "val": "Jump to start point",
-            "key": "[Shift] + [Left arrow]"
+            "key": "[Shift] [Left arrow]"
         }, {
             "val": "Jump to end point",
-            "key": "[Shift] + [Right arrow]"
+            "key": "[Shift] [Right arrow]"
         }, {
             "val": "Scroll through frames",
-            "key": "[Alt] + [Mouse wheel]"
+            "key": "[Alt] [Mouse wheel]"
         }, {
             "val": "Insert keyframe",
             "key": "i"
         }, {
             "val": "Remove keyframe",
-            "key": "[Alt] + [i]"
+            "key": "[Alt] [i]"
         }, {
             "val": "Jump to next keyframe",
-            "key": "[Ctrl] + [Page up]"
+            "key": "[Ctrl] [Page up]"
         }, {
             "val": "Jump to previous keyframe",
-            "key": "[Ctrl] + [Page down]"
+            "key": "[Ctrl] [Page down]"
         }],
         "Node editor": [{
             "val": "Add node",
-            "key": "[Shift] + [a]"
+            "key": "[Shift] [a]"
         }, {
             "val": "Cut links",
-            "key": "[Ctrl] + [Left mouse]"
+            "key": "[Ctrl] [Left mouse]"
         }, {
             "val": "(Un-)Hide node",
             "key": "h"
         }, {
             "val": "Make group",
-            "key": "[Ctrl] + [g]"
+            "key": "[Ctrl] [g]"
         }, {
             "val": "Ungroup",
-            "key": "[Alt] + [g]"
+            "key": "[Alt] [g]"
         }, {
             "val": "Edit group",
             "key": "Tab"
         }, {
             "val": "Move background",
-            "key": "[Alt] + [Middle mouse]"
+            "key": "[Alt] [Middle mouse]"
         }, {
             "val": "Zoom in background",
             "key": "v"
         }, {
             "val": "Zoom out background",
-            "key": "[Alt] + [v]"
+            "key": "[Alt] [v]"
         }, {
             "val": "Properties",
             "key": "n"
         }],
         "Armatures": [{
             "val": "Add bone",
-            "key": "[e] or [Ctrl] + [Click]"
+            "key": "[e] or [Ctrl] [Click]"
         }, {
             "val": "Rotate",
-            "key": "[Ctrl] + [r]"
+            "key": "[Ctrl] [r]"
         }, {
             "val": "Recalculate roll",
-            "key": "[Ctrl] + [n]"
+            "key": "[Ctrl] [n]"
         }, {
             "val": "Align bones",
-            "key": "[Ctrl] + [Alt] + [a]"
+            "key": "[Ctrl] [Alt] [a]"
         }, {
             "val": "Move to bone layers",
             "key": "m"
         }, {
             "val": "View bone layers",
-            "key": "[Shift] + [m]"
+            "key": "[Shift] [m]"
         }, {
             "val": "Set bone flag",
-            "key": "[Shift] + [w]"
+            "key": "[Shift] [w]"
         }, {
             "val": "Switch bone direction",
-            "key": "[Alt] + [f]"
+            "key": "[Alt] [f]"
         }, {
             "val": "Scroll hierachy",
             "key": "{\\]} / {\\[}"
@@ -449,34 +449,34 @@
         }],
         "Pose mode": [{
             "val": "Apply pose",
-            "key": "[Ctrl] + [a]"
+            "key": "[Ctrl] [a]"
         }, {
             "val": "Clear pose rotation",
-            "key": "[Alt] + [r]"
+            "key": "[Alt] [r]"
         }, {
             "val": "Clear pose location",
-            "key": "[Alt] + [l]"
+            "key": "[Alt] [l]"
         }, {
             "val": "Clear pose scale",
-            "key": "[Alt] + [s]"
+            "key": "[Alt] [s]"
         }, {
             "val": "Copy pose",
-            "key": "[Ctrl] + [c]"
+            "key": "[Ctrl] [c]"
         }, {
             "val": "Paste pose",
-            "key": "[Ctrl] + [v]"
+            "key": "[Ctrl] [v]"
         }, {
             "val": "Add IK",
-            "key": "[Shift] + [i]"
+            "key": "[Shift] [i]"
         }, {
             "val": "Remove IK",
-            "key": "[Ctrl] + [Alt] + [i]"
+            "key": "[Ctrl] [Alt] [i]"
         }, {
             "val": "Add to bone group",
-            "key": "[Ctrl] + [g]"
+            "key": "[Ctrl] [g]"
         }, {
             "val": "Relax pose",
-            "key": "[Alt] + [e]"
+            "key": "[Alt] [e]"
         }],
         "Timeline": [{
             "val": "Set start frame",
@@ -495,7 +495,7 @@
             "key": "[Right click \\{drag\\}]"
         }, {
             "val": "Toggle frames/seconds",
-            "key": "[Ctrl] + [t]"
+            "key": "[Ctrl] [t]"
         }],
         "Video Sequence Editor": [{
             "val": "Next strip",
@@ -508,35 +508,35 @@
             "key": "k"
         }, {
             "val": "Lock strip",
-            "key": "[Shift] + [l]"
+            "key": "[Shift] [l]"
         }, {
             "val": "Unlock strip",
-            "key": "[Shift] + [Alt] + [l]"
+            "key": "[Shift] [Alt] [l]"
         }, {
             "val": "Coyp strip",
-            "key": "[Ctrl] + [c]"
+            "key": "[Ctrl] [c]"
         }, {
             "val": "Paste strip",
-            "key": "[Ctrl] + [v]"
+            "key": "[Ctrl] [v]"
         }, {
             "val": "Seperate images",
             "key": "y"
         }, {
             "val": "Snap strip to scrubber",
-            "key": "[Shift] + [s]"
+            "key": "[Shift] [s]"
         }],
         "Advanced": [{
             "val": "Append file",
-            "key": "[Shift] + [F1]"
+            "key": "[Shift] [F1]"
         }, {
             "val": "Fullscreen mode",
-            "key": "[Alt] + [F11]"
+            "key": "[Alt] [F11]"
         }, {
             "val": "Maximize subwindow",
-            "key": "[Ctrl] + [Up arrow]"
+            "key": "[Ctrl] [Up arrow]"
         }, {
             "val": "Change active camera",
-            "key": "[Ctrl] + [o]"
+            "key": "[Ctrl] [o]"
         }, {
             "val": "Use render buffer",
             "key": "j"
@@ -545,13 +545,13 @@
             "key": "w"
         }, {
             "val": "Only render portion",
-            "key": "[Shift] + [b]"
+            "key": "[Shift] [b]"
         }, {
             "val": "Save over default scene",
-            "key": "[Ctrl] + [u]"
+            "key": "[Ctrl] [u]"
         }, {
             "val": "Make screen cast",
-            "key": "[Ctrl] + [F4]"
+            "key": "[Ctrl] [F4]"
         }]
     }
 }

--- a/share/goodie/cheat_sheets/blender.json
+++ b/share/goodie/cheat_sheets/blender.json
@@ -132,7 +132,7 @@
             "key": "[\\{hold\\} Ctrl]"
         }, {
             "val": "Lock to axis",
-            "key": "[Middle click] or [x] / [y] / [z]"
+            "key": "[Middle click] / [x] / [y] / [z]"
         }],
         "Navigation": [{
             "val": "Top view",
@@ -226,7 +226,7 @@
             "key": "[Ctrl] [Tab]"
         }, {
             "val": "Switching workspace",
-            "key": "[Ctrl] [Left arrow] or [Ctrl] [Right arrow]"
+            "key": "[Ctrl] ([←]/[→])"
         }, {
             "val": "Logic editor",
             "key": "[Shift] [F2]"
@@ -330,7 +330,7 @@
             "key": "[Shift] [Alt] [f]"
         }, {
             "val": "Add subdivision level",
-            "key": "[Ctrl] [1] / [2] / [3] / [4]"
+            "key": "[Ctrl] ([1]/[2]/[3]/[4])"
         }],
         "Sculpting": [{
             "val": "Change brush size",
@@ -350,22 +350,22 @@
             "key": "[Alt] [Shift] [a]"
         }, {
             "val": "Next frame",
-            "key": "Right arrow"
+            "key": "→"
         }, {
             "val": "Previous frame",
-            "key": "Left arrow"
+            "key": "←"
         }, {
             "val": "Forward 10 frames",
-            "key": "Up arrow"
+            "key": "↑"
         }, {
             "val": "Back 10 frames",
-            "key": "Down arrow"
+            "key": "↓"
         }, {
             "val": "Jump to start point",
-            "key": "[Shift] [Left arrow]"
+            "key": "[Shift] [←]"
         }, {
             "val": "Jump to end point",
-            "key": "[Shift] [Right arrow]"
+            "key": "[Shift] [→]"
         }, {
             "val": "Scroll through frames",
             "key": "[Alt] [Mouse wheel]"
@@ -442,7 +442,7 @@
             "key": "{\\]} / {\\[}"
         }, {
             "val": "Select hierarchy",
-            "key": "[Shift] + {\\]} / {\\[}"
+            "key": "[Shift] ({\\]} / {\\[})"
         }, {
             "val": "Select connected",
             "key": "l"
@@ -533,7 +533,7 @@
             "key": "[Alt] [F11]"
         }, {
             "val": "Maximize subwindow",
-            "key": "[Ctrl] [Up arrow]"
+            "key": "[Ctrl] [↑]"
         }, {
             "val": "Change active camera",
             "key": "[Ctrl] [o]"

--- a/share/goodie/cheat_sheets/duckduckgo.json
+++ b/share/goodie/cheat_sheets/duckduckgo.json
@@ -12,7 +12,7 @@
                 "val": "Go to the highlighted result, or use it right away to go to the first result"
             },
             {
-                "key": "[Ctrl]/[⌘] + [↵]",
+                "key": "[Ctrl]/[⌘] [↵]",
                 "val": "Open a result in the background"
             },
             {

--- a/share/goodie/cheat_sheets/duckduckgo.json
+++ b/share/goodie/cheat_sheets/duckduckgo.json
@@ -12,7 +12,7 @@
                 "val": "Go to the highlighted result, or use it right away to go to the first result"
             },
             {
-                "key": "[Ctrl]/[⌘] [↵]",
+                "key": "([Ctrl]/[⌘]) [↵]",
                 "val": "Open a result in the background"
             },
             {

--- a/share/goodie/cheat_sheets/gimp.json
+++ b/share/goodie/cheat_sheets/gimp.json
@@ -24,7 +24,7 @@
                 "val": "Help"
             },
             {
-                "key": "[Shift] + [F1]",
+                "key": "[Shift] [F1]",
                 "val": "Context Help"
             }
         ],
@@ -34,7 +34,7 @@
                 "val": "Zoom in"               
             }, 
             {
-                "key": "[Ctrl] + [click]",
+                "key": "[Ctrl] [click]",
                 "val": "Zoom out"
             },
             {
@@ -44,47 +44,47 @@
         ],
         "Filters": [
             {
-                "key": "[Ctrl] + [click]",
+                "key": "[Ctrl] [click]",
                 "val": "Repeat last filter"
             },
             {
-                "key": "[Shift] + [Ctrl] + [F]",
+                "key": "[Shift] [Ctrl] [F]",
                 "val": "Reshow last filter"
             }
         ],
         "Selections": [
             {
-                "key": "[Ctrl] + [T]",
+                "key": "[Ctrl] [T]",
                 "val": "Toggle selections"
             },
             {
-                "key": "[Ctrl] + [A]",
+                "key": "[Ctrl] [A]",
                 "val": "Select all"
             },
             {
-                "key": "[Shift] + [Ctrl] + [A]",
+                "key": "[Shift] [Ctrl] [A]",
                 "val": "Select none"
             },
             {
-                "key": "[Ctrl] + [I]",
+                "key": "[Ctrl] [I]",
                 "val": "Invert selection"
             },
             {
-                "key": "[Shift] + [Ctrl] + [L]",
+                "key": "[Shift] [Ctrl] [L]",
                 "val": "Float selection"
             },
             {
-                "key": "[Shift] + [V]",
+                "key": "[Shift] [V]",
                 "val": "Path to selection"
             }
         ],
         "Layers": [
             {
-                "key": "[PgUp] or [Ctrl] + [Tab]",
+                "key": "[PgUp] or [Ctrl] [Tab]",
                 "val": "Select the layer above"
             },
             {
-                "key": "[PgDn] or [Shift] + [Ctrl] + [Tab]",
+                "key": "[PgDn] or [Shift] [Ctrl] [Tab]",
                 "val": "Select the layer below"
             },
             {
@@ -96,33 +96,33 @@
                 "val": "Select the last layer"
             },
             {
-                "key": "[Ctrl] + [M]",
+                "key": "[Ctrl] [M]",
                 "val": "Merge visible layers"
             },
             {
-                "key": "[Ctrl] + [H]",
+                "key": "[Ctrl] [H]",
                 "val": "Anchor layer"
             }
         ],
         "Edit": [
             {
-                "key": "[Ctrl] + [Z]",
+                "key": "[Ctrl] [Z]",
                 "val": "Undo"
             },
             {
-                "key": "[Ctrl] + [Y]",
+                "key": "[Ctrl] [Y]",
                 "val": "Redo"
             },
             {
-                "key": "[Ctrl] + [C]",
+                "key": "[Ctrl] [C]",
                 "val": "Copy selection"
             },
             {
-                "key": "[Ctrl] + [X]",
+                "key": "[Ctrl] [X]",
                 "val": "Cut selection"
             },
             {
-                "key": "[Ctrl] + [V]",
+                "key": "[Ctrl] [V]",
                 "val": "Paste clipboard"
             },
             {
@@ -130,27 +130,27 @@
                 "val": "Erase selection"
             },
             {
-                "key": "[Shift] + [Ctrl] + [C]",
+                "key": "[Shift] [Ctrl] [C]",
                 "val": "Named copy selection"
             },
             {
-                "key": "[Shift] + [Ctrl] + [X]",
+                "key": "[Shift] [Ctrl] [X]",
                 "val": "Named cut selection"
             },
             {
-                "key": "[Shift] + [Ctrl] + [V]",
+                "key": "[Shift] [Ctrl] [V]",
                 "val": "Named paste clipboard"
             },
             {
-                "key": "[Ctrl] + [,]",
+                "key": "[Ctrl] [,]",
                 "val": "Fill with FG color"
             },
             {
-                "key": "[Ctrl] + [.]",
+                "key": "[Ctrl] [.]",
                 "val": "Fill with BG color"
             },
             {
-                "key": "[Ctrl] + [;]",
+                "key": "[Ctrl] [;]",
                 "val": "Fill with Pattern"
             }
         ],
@@ -172,7 +172,7 @@
                 "val": "Fuzzy Select"
             },
             {
-                "key": "[Shift] + [O]",
+                "key": "[Shift] [O]",
                 "val": "Select by Color"
             },
             {
@@ -192,27 +192,27 @@
                 "val": "Move"
             },
             {
-                "key": "[Shift] + [C]",
+                "key": "[Shift] [C]",
                 "val": "Crop and Resize"
             },
             {
-                "key": "[Shift] + [R]",
+                "key": "[Shift] [R]",
                 "val": "Rotate"
             },
             {
-                "key": "[Shift] + [T]",
+                "key": "[Shift] [T]",
                 "val": "Scale"
             },
             {
-                "key": "[Shift] + [S]",
+                "key": "[Shift] [S]",
                 "val": "Shear"
             },
             {
-                "key": "[Shift] + [P]",
+                "key": "[Shift] [P]",
                 "val": "Perspective"
             },
             {
-                "key": "[Shift] + [F]",
+                "key": "[Shift] [F]",
                 "val": "Flip"
             },
             {
@@ -220,7 +220,7 @@
                 "val": "Text"
             },
             {
-                "key": "[Shift] + [B]",
+                "key": "[Shift] [B]",
                 "val": "Bucket Fill"
             },
             {
@@ -236,7 +236,7 @@
                 "val": "Paintbrush"
             },
             {
-                "key": "[Shift] + [E]",
+                "key": "[Shift] [E]",
                 "val": "Eraser"
             },
             {
@@ -252,7 +252,7 @@
                 "val": "Clone"
             },
             {
-                "key": "[Shift] + [U]",
+                "key": "[Shift] [U]",
                 "val": "Blur / Sharpen"
             },
             {
@@ -260,7 +260,7 @@
                 "val": "Smudge"
             },
             {
-                "key": "[Shift] + [D]",
+                "key": "[Shift] [D]",
                 "val": "Dodge / Burn"
             },
             {
@@ -274,93 +274,93 @@
         ],
         "File": [
             {
-                "key": "[Ctrl] + [N]",
+                "key": "[Ctrl] [N]",
                 "val": "New image"
             },
             {
-                "key": "[Ctrl] + [O]",
+                "key": "[Ctrl] [O]",
                 "val": "Open image"
             },
             {
-                "key": "[Ctrl] + [Alt] + [O]",
+                "key": "[Ctrl] [Alt] [O]",
                 "val": "Open image as new layer"
             },
             {
-                "key": "[Ctrl] + [D]",
+                "key": "[Ctrl] [D]",
                 "val": "Duplicate"
             },
             {
-                "key": "[Ctrl] + [1]",
+                "key": "[Ctrl] [1]",
                 "val": "Open recent image #1"
             },
             {
-                "key": "[Ctrl] + [2]",
+                "key": "[Ctrl] [2]",
                 "val": "Open recent image #2"
             },
             {
-                "key": "[Ctrl] + [3]",
+                "key": "[Ctrl] [3]",
                 "val": "Open recent image #3"
             },
             {
-                "key": "[Ctrl] + [4]",
+                "key": "[Ctrl] [4]",
                 "val": "Open recent image #4"
             },
             {
-                "key": "[Ctrl] + [5]",
+                "key": "[Ctrl] [5]",
                 "val": "Open recent image #5"
             },
             {
-                "key": "[Ctrl] + [6]",
+                "key": "[Ctrl] [6]",
                 "val": "Open recent image #6"
             },
             {
-                "key": "[Ctrl] + [7]",
+                "key": "[Ctrl] [7]",
                 "val": "Open recent image #7"
             },
             {
-                "key": "[Ctrl] + [8]",
+                "key": "[Ctrl] [8]",
                 "val": "Open recent image #8"
             },
             {
-                "key": "[Ctrl] + [9]",
+                "key": "[Ctrl] [9]",
                 "val": "Open recent image #9"
             },
             {
-                "key": "[Ctrl] + [10]",
+                "key": "[Ctrl] [10]",
                 "val": "Open recent image #10"
             },
             {
-                "key": "[Ctrl] + [S]",
+                "key": "[Ctrl] [S]",
                 "val": "Save image"
             },
             {
-                "key": "[Shift] + [Ctrl] + [S]",
+                "key": "[Shift] [Ctrl] [S]",
                 "val": "Save under a new name"
             },
             {
-                "key": "[Ctrl] + [Q]",
+                "key": "[Ctrl] [Q]",
                 "val": "Quit"
             }
         ],
         "Dialogs": [
             {
-                "key": "[Ctrl] + [L]",
+                "key": "[Ctrl] [L]",
                 "val": "Layers"
             },
             {
-                "key": "[Shift] + [Ctrl] + [B]",
+                "key": "[Shift] [Ctrl] [B]",
                 "val": "Brushes"
             },
             {
-                "key": "[Shift] + [Ctrl] + [P]",
+                "key": "[Shift] [Ctrl] [P]",
                 "val": "Patterns"
             },
             {
-                "key": "[Ctrl] + [G]",
+                "key": "[Ctrl] [G]",
                 "val": "Gradients"
             },
             {
-                "key": "[Alt] + [F4] or [Ctrl] + [W]",
+                "key": "[Alt] [F4] or [Ctrl] [W]",
                 "val": "Close the window"
             },
             {
@@ -368,7 +368,7 @@
                 "val": "Jump to next widget"
             },
             {
-                "key": "[Shift] + [Tab]",
+                "key": "[Shift] [Tab]",
                 "val": "Jump to previous widget"
             },
             {
@@ -380,23 +380,23 @@
                 "val": "Activate current button or list"
             },
             {
-                "key": "[Ctrl] + [Alt] + [PgUp] / [PgDn]",
+                "key": "[Ctrl] [Alt] [PgUp] / [PgDn]",
                 "val": "Switch tabs (multi-tab dialog)"
             },
             {
-                "key": "[Shift] + [L]",
+                "key": "[Shift] [L]",
                 "val": "Open Location"
             },
             {
-                "key": "[Alt] + [Up]",
+                "key": "[Alt] [Up]",
                 "val": "Up-Folder"
             },
             {
-                "key": "[Alt] + [Down]",
+                "key": "[Alt] [Down]",
                 "val": "Down-Folder"
             },
             {
-                "key": "[Alt] + [Home]",
+                "key": "[Alt] [Home]",
                 "val": "Home-Folder"
             },
             {
@@ -410,7 +410,7 @@
                 "val": "Main Menu"
             },
             {
-                "key": "[Shift] + [F10] or [right click]",
+                "key": "[Shift] [F10] or [right click]",
                 "val": "Drop-down Menu"
             },
             {
@@ -418,11 +418,11 @@
                 "val": "Toggle fullscreen"
             },
             {
-                "key": "[Shift] + [Q]",
+                "key": "[Shift] [Q]",
                 "val": "Toggle quickmask"
             },
             {
-                "key": "[Ctrl] + [W]",
+                "key": "[Ctrl] [W]",
                 "val": "Close document window"
             },
             {
@@ -438,7 +438,7 @@
                 "val": "Zoom 1:1"
             },
             {
-                "key": "[Ctrl] + [E]",
+                "key": "[Ctrl] [E]",
                 "val": "Shrink wrap"
             },
             {
@@ -446,15 +446,15 @@
                 "val": "Drag off a ruler to create guide"
             },
             {
-                "key": "[Ctrl] + [mouse drag]",
+                "key": "[Ctrl] [mouse drag]",
                 "val": "Drag a sample point out of the rulers"
             },
             {
-                "key": "[Shift] + [Ctrl] + [R]",
+                "key": "[Shift] [Ctrl] [R]",
                 "val": "Toggle rulers"
             },
             {
-                "key": "[Shift] + [Ctrl] + [T]",
+                "key": "[Shift] [Ctrl] [T]",
                 "val": "Toggle guides"
             }
         ]

--- a/share/goodie/cheat_sheets/gnome-keyboard.json
+++ b/share/goodie/cheat_sheets/gnome-keyboard.json
@@ -10,7 +10,10 @@
     "sections": {
         "Desktop Shortcuts": [{
             "val": "Switch between the Activities overview and desktop",
-            "key": "[Alt] [F1] or [Super]"
+            "key": "[Alt] [F1]"
+        },{
+            "val": "Switch between the Activities overview and desktop (alternative)",
+            "key": "Super"
         }, {
             "val": "Pop up command window",
             "key": "[Alt] [F2] "
@@ -28,10 +31,10 @@
             "key": "[Super] [A] "
         }, {
             "val": "Switch between workspaces",
-            "key": "[Super] [Page Up] \/ [Page Down]"
+            "key": "[Super] ([Page Up]/[Page Down])"
         }, {
             "val": "Move the current window to a different workspace",
-            "key": "[Super] [Shift]+[Page Up] \/ [Page Down]"
+            "key": "[Super] [Shift] ([Page Up]/[Page Down])"
         }, {
             "val": "Power Off",
             "key": "[Ctrl] [Alt] [Delete] "

--- a/share/goodie/cheat_sheets/gnome-keyboard.json
+++ b/share/goodie/cheat_sheets/gnome-keyboard.json
@@ -10,66 +10,66 @@
     "sections": {
         "Desktop Shortcuts": [{
             "val": "Switch between the Activities overview and desktop",
-            "key": "[Alt] + [F1] or [Super]"
+            "key": "[Alt] [F1] or [Super]"
         }, {
             "val": "Pop up command window",
-            "key": "[Alt] + [F2] "
+            "key": "[Alt] [F2] "
         }, {
             "val": "Quickly switch between windows",
-            "key": "[Super] + [Tab] "
+            "key": "[Super] [Tab] "
         }, {
             "val": "Switch between windows from the same application",
-            "key": "[Super] + [`] "
+            "key": "[Super] [`] "
         }, {
             "val": "Give keyboard focus to the top bar",
-            "key": "[Ctrl] + [Alt] + [Tab] "
+            "key": "[Ctrl] [Alt] [Tab] "
         }, {
             "val": "Show the list of applications",
-            "key": "[Super] + [A] "
+            "key": "[Super] [A] "
         }, {
             "val": "Switch between workspaces",
-            "key": "[Super] + [Page Up] \/ [Page Down]"
+            "key": "[Super] [Page Up] \/ [Page Down]"
         }, {
             "val": "Move the current window to a different workspace",
-            "key": "[Super] + [Shift]+[Page Up] \/ [Page Down]"
+            "key": "[Super] [Shift]+[Page Up] \/ [Page Down]"
         }, {
             "val": "Power Off",
-            "key": "[Ctrl] + [Alt] + [Delete] "
+            "key": "[Ctrl] [Alt] [Delete] "
         }, {
             "val": "Lock the screen",
-            "key": "[Super] + [L] "
+            "key": "[Super] [L] "
         }, {
             "val": "Open the message tray",
-            "key": "[Super] + [M] "
+            "key": "[Super] [M] "
         }],
          "Common Editing": [{
             "val": "Select all text or items in a list",
-            "key": "[Ctrl] + [A] "
+            "key": "[Ctrl] [A] "
         }, {
             "val": "Cut selected text or items and place it on the clipboard",
-            "key": "[Ctrl] + [X] "
+            "key": "[Ctrl] [X] "
         }, {
             "val": "Copy selected text or items to the clipboard",
-            "key": "[Ctrl] + [C] "
+            "key": "[Ctrl] [C] "
         }, {
             "val": "Paste the contents of the clipboard",
-            "key": "[Ctrl] + [V] "
+            "key": "[Ctrl] [V] "
         }, {
             "val": "Undo the last action",
-            "key": "[Ctrl] + [Z] "
+            "key": "[Ctrl] [Z] "
         }],
          "Screen Capturing": [{
             "val": "Take a screenshot",
             "key": "[Prnt Scrn]"
         }, {
             "val": "Take a screenshot of a window",
-            "key": "[Alt] + [Prnt Scrn]"
+            "key": "[Alt] [Prnt Scrn]"
         }, {
             "val": "Take a screenshot of an area of the screen",
-            "key": "[Shift] + [Prnt Scrn]"
+            "key": "[Shift] [Prnt Scrn]"
         }, {
             "val": "Start and end screencast recording",
-            "key": "[Ctrl] + [Alt] + [Shift] + [R] "
+            "key": "[Ctrl] [Alt] [Shift] [R] "
         }]
     }
 }

--- a/share/goodie/cheat_sheets/mac-keyboard.json
+++ b/share/goodie/cheat_sheets/mac-keyboard.json
@@ -9,148 +9,148 @@
     "section_order" : ["General", "Finder", "Text Editing", "Web Browsing (Works on most modern browsers)", "Spotlight", "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)"],
     "sections":{
         "Finder": [{
-            "key" : "[Cmd] + [C]",
+            "key" : "[Cmd] [C]",
             "val" : "Copy selected files"
         }, {
-            "key" : "[Cmd] + [V]",
+            "key" : "[Cmd] [V]",
             "val" : "Paste files"
         }, {
-            "key" : "[Cmd] + [Opt] + [V]",
+            "key" : "[Cmd] [Opt] [V]",
             "val" : "Move the copied files to current directory"
         }, {
-            "key" : "[Cmd] + [Del]",
+            "key" : "[Cmd] [Del]",
             "val" : "Delete selected folder or file"
         }, {
             "key" : "Return/Enter",
             "val" : "Rename the selected file/folder"
         }, {
-            "key" : "[Cmd] + [1~4]",
+            "key" : "[Cmd] [1~4]",
             "val" : "Switch Finder views (Icon, List, Column, Cover Flow)"
         }, {
-            "key" : "[Cmd] + [↓]",
+            "key" : "[Cmd] [↓]",
             "val" : "Go into selected folder or open the selected file"
         }, {
-            "key" : "[Cmd] + [↑]",
+            "key" : "[Cmd] [↑]",
             "val" : "Go to parent folder"
         }, {
-            "key" : "[Cmd] + [T]",
+            "key" : "[Cmd] [T]",
             "val" : "Open new Finder tab"
         }, {
-            "key" : "[Cmd] + [W]",
+            "key" : "[Cmd] [W]",
             "val" : "Close current tab"
         }, {
-            "key" : "[Cmd] + [Shift] + [W]",
+            "key" : "[Cmd] [Shift] [W]",
             "val" : "Close current window"
         }, {
-            "key" : "[Cmd] + [N]",
+            "key" : "[Cmd] [N]",
             "val" : "Open new Finder window"
         }, {
-            "key" : "[Ctrl] + [Tab]",
+            "key" : "[Ctrl] [Tab]",
             "val" : "Cycle through tabs"
         }, {
             "key" : "Spacebar",
             "val" : "Preview selected item using Quick Look"
         }], "Spotlight": [{
-            "key" : "[Cmd] + [Space]",
+            "key" : "[Cmd] [Space]",
             "val" : "Open Spotlight"
         }, {
             "key" : "Enter",
             "val" : "Open selected item"
         }, {
-            "key" : "[Cmd] + [Enter]",
+            "key" : "[Cmd] [Enter]",
             "val" : "Open selected item in Finder"
         }, {
-            "key" : "[Cmd] + [↑/↓]",
+            "key" : "[Cmd] [↑/↓]",
             "val" : "Skip to next/previous result category"
         }], "Text Editing" :[{
-            "key" : "[Cmd] + [A]",
+            "key" : "[Cmd] [A]",
             "val" : "Select all"
         }, {
-            "key" : "[Cmd] + [X]",
+            "key" : "[Cmd] [X]",
             "val" : "Cut"
         }, {
-            "key" : "[Cmd] + [C]",
+            "key" : "[Cmd] [C]",
             "val" : "Copy"
         }, {
-            "key" : "[Cmd] + [V]",
+            "key" : "[Cmd] [V]",
             "val" : "Paste"
         }, {
-            "key" : "[Cmd] + [Z]",
+            "key" : "[Cmd] [Z]",
             "val" : "Undo"
         }, {
-            "key" : "[Cmd] + [Shift] + [Z]",
+            "key" : "[Cmd] [Shift] [Z]",
             "val" : "Redo"
         }, {
-            "key" : "[Cmd] + [←/→]",
+            "key" : "[Cmd] [←/→]",
             "val" : "Go to beginning/end of line"
         }, {
-            "key" : "[Cmd] + [↑]",
+            "key" : "[Cmd] [↑]",
             "val" : "Go to beginning of document"
         }, {
-            "key" : "[Cmd] + [↓]",
+            "key" : "[Cmd] [↓]",
             "val" : "Go to end of document"
         }, {
-            "key" : "[Opt] + [←]",
+            "key" : "[Opt] [←]",
             "val" : "Go to beginning of previous word"
         }, {
-            "key" : "[Opt] + [→]",
+            "key" : "[Opt] [→]",
             "val" : "Go to end of next word"
         }], "General" : [{
-            "key" : "[Cmd] + [Tab]",
+            "key" : "[Cmd] [Tab]",
             "val" : "Switch between apps. Holding Shift reverses."
         }, {
-            "key" : "[Cmd] + [~]",
+            "key" : "[Cmd] [~]",
             "val" : "Switch to next window of current app. Holding Shift reverses."
         }, {
-            "key" : "[Cmd] + [Q]",
+            "key" : "[Cmd] [Q]",
             "val" : "Quit app"
         }, {
-            "key" : "[Cmd] + [H]",
+            "key" : "[Cmd] [H]",
             "val" : "Hide windows of current app"
         }, {
-            "key" : "[Cmd] + [M]",
+            "key" : "[Cmd] [M]",
             "val" : "Minimize windows of current app"
         }, {
-            "key" : "[Cmd] + [,]",
+            "key" : "[Cmd] [,]",
             "val" : "Open Preferences (if available)"
         }, {
-            "key" : "[Ctrl] + [←/→]",
+            "key" : "[Ctrl] [←/→]",
             "val" : "Move one desktop left or right"
         }, {
-            "key" : "[Cmd] + [Opt] + [Esc]",
+            "key" : "[Cmd] [Opt] [Esc]",
             "val" : "Open force quit dialog"
         }], "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)" : [{
-            "key" : "[Cmd] + [Shift] + [3]",
+            "key" : "[Cmd] [Shift] [3]",
             "val" : "Take picture of the entire screen"
         }, {
-            "key" : "[Cmd] + [Shift] + [4]",
+            "key" : "[Cmd] [Shift] [4]",
             "val" : "Take picture of a selected area"
         }, {
-            "key" : "[Cmd] + [Shift] + [4], [Spacebar]",
+            "key" : "[Cmd] [Shift] [4], [Spacebar]",
             "val" : "Take picture of a specific window/object"
         }], "Web Browsing (Works on most modern browsers)" : [{
-            "key" : "[Cmd] + [T]",
+            "key" : "[Cmd] [T]",
             "val" : "Open a new tab"
         }, {
-            "key" : "[Cmd] + [W]",
+            "key" : "[Cmd] [W]",
             "val" : "Close current tab"
         }, {
-            "key" : "[Cmd] + [L]",
+            "key" : "[Cmd] [L]",
             "val" : "Focus on browser's location bar"
         }, {
-            "key" : "[Cmd] + [R]",
+            "key" : "[Cmd] [R]",
             "val" : "Refresh"
         }, {
-            "key" : "[Cmd] + [←]",
+            "key" : "[Cmd] [←]",
             "val" : "Go back a page"
         }, {
-            "key" : "[Cmd] + [→]",
+            "key" : "[Cmd] [→]",
             "val" : "Go forward a page"
         }, {
-            "key" : "[Ctrl] + [Tab]",
+            "key" : "[Ctrl] [Tab]",
             "val" : "Cycle through tabs. Holding Shift reverses."
         }, {
-            "key" : "[Cmd] + [F]",
+            "key" : "[Cmd] [F]",
             "val" : "Find"
         }]
     }

--- a/share/goodie/cheat_sheets/vim.json
+++ b/share/goodie/cheat_sheets/vim.json
@@ -25,7 +25,7 @@
             "key": "#gt"
         }, {
             "val": "move the current split window into its own tab",
-            "key": "[Ctrl] + [wt]"
+            "key": "[Ctrl] [wt]"
         }, {
             "val": "move current tab to the #th position (indexed from 0)",
             "key": ":tabmove #"
@@ -74,7 +74,7 @@
             "key": "u"
         }, {
             "val": "redo",
-            "key": "[Ctrl] + [r]"
+            "key": "[Ctrl] [r]"
         }, {
             "val": "repeat last command",
             "key": "."
@@ -168,7 +168,7 @@
             "key": "o"
         }, {
             "val": "start visual block mode",
-            "key": "[Ctrl] + [v]"
+            "key": "[Ctrl] [v]"
         }, {
             "val": "move to other corner of block",
             "key": "O"
@@ -211,22 +211,22 @@
             "key": ":vsp filename"
         }, {
             "val": "split window",
-            "key": "[Ctrl] + [ws]"
+            "key": "[Ctrl] [ws]"
         }, {
             "val": "switch windows",
-            "key": "[Ctrl] + [ww]"
+            "key": "[Ctrl] [ww]"
         }, {
             "val": "quit a window",
-            "key": "[Ctrl] + [wq]"
+            "key": "[Ctrl] [wq]"
         }, {
             "val": "split window vertically",
-            "key": "[Ctrl] + [wv]"
+            "key": "[Ctrl] [wv]"
         }, {
             "val": "move cursor to next buffer (right)",
-            "key": "[Ctrl] + [wh]"
+            "key": "[Ctrl] [wh]"
         }, {
             "val": "move cursor to previous buffer (left)",
-            "key": "[Ctrl] + [wl]"
+            "key": "[Ctrl] [wl]"
         }],
         "Cursor movement": [{
             "val": "move cursor left",


### PR DESCRIPTION
Cmd used: `find . -type f -exec sed -i 's!\] + \[!] [!g' {} \;`

## Results

Blender:
![screen shot 2015-08-05 at 22 55 59](https://cloud.githubusercontent.com/assets/873785/9102826/5646e0ea-3bc5-11e5-9352-4b0162628f61.png)

DuckDuckGo:
![screen shot 2015-08-05 at 22 59 31](https://cloud.githubusercontent.com/assets/873785/9103008/3fadd440-3bc7-11e5-80a9-986f56246729.png)

Gimp
![screen shot 2015-08-05 at 23 00 08](https://cloud.githubusercontent.com/assets/873785/9103007/3fad3de6-3bc7-11e5-92e8-2f81111182e4.png)

Gnome
![screen shot 2015-08-05 at 23 03 33](https://cloud.githubusercontent.com/assets/873785/9103009/3faee0c4-3bc7-11e5-92cf-561c44dc688c.png)

Mac:
![screen shot 2015-08-05 at 23 09 44](https://cloud.githubusercontent.com/assets/873785/9103011/3fb2bc44-3bc7-11e5-87eb-1e5b018bef3f.png)

Vim:
![screen shot 2015-08-05 at 23 10 41](https://cloud.githubusercontent.com/assets/873785/9103010/3fb070ba-3bc7-11e5-862a-1c53dc0b5d3c.png)

to @zachthompson 
/cc @jagtalon 