### PR TITLE
Add group tabs to Firefox cheatsheet

### DIFF
--- a/share/goodie/cheat_sheets/firefox.json
+++ b/share/goodie/cheat_sheets/firefox.json
@@ -1,5 +1,5 @@
 {
-    "id": "firefox_cheat_sheet", 
+    "id": "firefox_cheat_sheet",
     "name": "Mozilla Firefox",
     "metadata": {
         "sourceName": "Firefox Help",
@@ -131,6 +131,15 @@
         }, {
             "val": "Undo Close Tab  ",
             "key": "[Ctrl]  [Shift]  [T]"
+        }, {
+            "val": "Group Tabs Manager",
+            "key": "[Ctrl]  [Shift]  [E]"
+        }, {
+            "val": "Next Tab Group",
+            "key": "[Ctrl] [`]"
+        }, {
+            "val": "Previous Tab Group",
+            "key": "[Ctrl] [Shift] [`]"
         }, {
             "val": "Select Tab 1 to 8  ",
             "key": "[Alt]  [1..8] "


### PR DESCRIPTION
This PR adds 3 more shortcuts to Firefox cheat sheet, to what I believe is the best feature on it: tab management and grouping.

This is useful for all Firefox users.

Also, this is my first PR for DDG, so I'm planning to contribute more often :smile: 

![ddg-firefox-tab-manager](https://cloud.githubusercontent.com/assets/24597/9116181/6147286e-3c39-11e5-9a0e-fcd6115e349f.png)
