### PR TITLE
fixes a grammar/typo on german cheat sheet

### DIFF
--- a/share/goodie/cheat_sheets/german.json
+++ b/share/goodie/cheat_sheets/german.json
@@ -16,7 +16,7 @@
    "sections" : {
       "Etiquette" : [
          {
-            "val" : "Guten Nacht",
+            "val" : "Gute Nacht",
             "key" : "Good Night"
          },
          {


### PR DESCRIPTION
This is just a very simple grammar/typo fix on the german cheat sheet.