### PR TITLE
Added English Braille Cheat Sheet

### DIFF
--- a/share/goodie/cheat_sheets/english-braille.json
+++ b/share/goodie/cheat_sheets/english-braille.json
@@ -7,7 +7,8 @@
     },
     "section_order": [
         "Alphabet",
-        "Digit"
+        "Digit",
+        "Formatting Marks"
     ],
     "sections": {
         "Alphabet": [            
@@ -114,37 +115,9 @@
             {
                 "val": "z",
                 "key": "⠵"
-            },
-            {
-                "val": "letter sign force the end of a series of numbers",
-                "key": "⠰"
-            },
-            {
-                "val": "4a",
-                "key": "⠼⠙⠰⠁"
-            },
-            {
-                "val": "capitalization sign marks the following letter to be capitalized",
-                "key": "⠠"
-            },
-            {
-                "val": "DuckDuckGo",
-                "key": "⠠⠙⠥⠉⠅⠠⠙⠥⠉⠅⠠⠛⠕"
-            },
-            {
-                "val": "double capitalization sign marks the following word to be in all caps",
-                "key": "⠠⠠"
-            },
-            {
-                "val": "DDG",
-                "key": "⠠⠠⠙⠙⠛"
             }
         ],
-        "Digit": [
-            {
-                "val": "number sign marks the beginning of a sequence of number(s)",
-                "key": "⠼"
-            },
+        "Digit": [            
             {
                 "val": "0",
                 "key": "⠚"
@@ -185,6 +158,37 @@
                 "val": "9",
                 "key": "⠊"
             }
+        ],
+        "Formatting Marks": [
+            {
+                "val": "number sign marks the beginning of a sequence of number(s)",
+                "key": "⠼"
+            },
+            {
+                "val": "letter sign force the end of a series of numbers",
+                "key": "⠰"
+            },
+            {
+                "val": "4a",
+                "key": "⠼⠙⠰⠁"
+            },
+            {
+                "val": "capitalization sign marks the following letter to be capitalized",
+                "key": "⠠"
+            },
+            {
+                "val": "DuckDuckGo",
+                "key": "⠠⠙⠥⠉⠅⠠⠙⠥⠉⠅⠠⠛⠕"
+            },
+            {
+                "val": "double capitalization sign marks the following word to be in all caps",
+                "key": "⠠⠠"
+            },
+            {
+                "val": "DDG",
+                "key": "⠠⠠⠙⠙⠛"
+            }
+            
         ]
     }
 }

--- a/share/goodie/cheat_sheets/english-braille.json
+++ b/share/goodie/cheat_sheets/english-braille.json
@@ -1,0 +1,162 @@
+{
+    "id": "english_braille_cheat_sheet",
+    "name": "English Braille Cheat Sheet",
+    "metadata": {
+        "sourceName": "EnglishBraille",
+        "sourceUrl": "https://en.wikipedia.org/wiki/English_braille"
+    },
+    "section_order": [
+        "Alphabet",
+        "Digit"
+    ],
+    "sections": {
+        "Alphabet": [
+            {
+                "key": "a",
+                "val": "⠁"
+            },
+            {
+                "key": "b",
+                "val": "⠃"
+            },
+            {
+                "key": "c",
+                "val": "⠉"
+            },
+            {
+                "key": "d",
+                "val": "⠙"
+            },
+            {
+                "key": "e",
+                "val": "⠑"
+            },
+            {
+                "key": "f",
+                "val": "⠋"
+            },
+            {
+                "key": "g",
+                "val": "⠛"
+            },
+            {
+                "key": "h",
+                "val": "⠓"
+            },
+            {
+                "key": "i",
+                "val": "⠊"
+            },
+            {
+                "key": "j",
+                "val": "⠚"
+            },
+            {
+                "key": "k",
+                "val": "⠅"
+            },
+            {
+                "key": "l",
+                "val": "⠇"
+            },
+            {
+                "key": "m",
+                "val": "⠍"
+            },
+            {
+                "key": "n",
+                "val": "⠝"
+            },
+            {
+                "key": "o",
+                "val": "⠕"
+            },
+            {
+                "key": "p",
+                "val": "⠏"
+            },
+            {
+                "key": "q",
+                "val": "⠟"
+            },
+            {
+                "key": "r",
+                "val": "⠗"
+            },
+            {
+                "key": "s",
+                "val": "⠎"
+            },
+            {
+                "key": "t",
+                "val": "⠞"
+            },
+            {
+                "key": "u",
+                "val": "⠥"
+            },
+            {
+                "key": "v",
+                "val": "⠧"
+            },
+            {
+                "key": "w",
+                "val": "⠺"
+            },
+            {
+                "key": "x",
+                "val": "⠭"
+            },
+            {
+                "key": "y",
+                "val": "⠽"
+            },
+            {
+                "key": "z",
+                "val": "⠵"
+            }
+        ],
+        "Digit": [
+            {
+                "key": "0",
+                "val": "⠚"
+            },
+            {
+                "key": "1",
+                "val": "⠁"
+            },
+            {
+                "key": "2",
+                "val": "⠃"
+            },
+            {
+                "key": "3",
+                "val": "⠉"
+            },
+            {
+                "key": "4",
+                "val": "⠙"
+            },
+            {
+                "key": "5",
+                "val": "⠑"
+            },
+            {
+                "key": "6",
+                "val": "⠋"
+            },
+            {
+                "key": "7",
+                "val": "⠛"
+            },
+            {
+                "key": "8",
+                "val": "⠓"
+            },
+            {
+                "key": "9",
+                "val": "⠊"
+            }
+        ]
+    }
+}

--- a/share/goodie/cheat_sheets/english-braille.json
+++ b/share/goodie/cheat_sheets/english-braille.json
@@ -10,152 +10,180 @@
         "Digit"
     ],
     "sections": {
-        "Alphabet": [
+        "Alphabet": [            
             {
-                "key": "a",
-                "val": "⠁"
+                "val": "a",
+                "key": "⠁"
             },
             {
-                "key": "b",
-                "val": "⠃"
+                "val": "b",
+                "key": "⠃"
             },
             {
-                "key": "c",
-                "val": "⠉"
+                "val": "c",
+                "key": "⠉"
             },
             {
-                "key": "d",
-                "val": "⠙"
+                "val": "d",
+                "key": "⠙"
             },
             {
-                "key": "e",
-                "val": "⠑"
+                "val": "e",
+                "key": "⠑"
             },
             {
-                "key": "f",
-                "val": "⠋"
+                "val": "f",
+                "key": "⠋"
             },
             {
-                "key": "g",
-                "val": "⠛"
+                "val": "g",
+                "key": "⠛"
             },
             {
-                "key": "h",
-                "val": "⠓"
+                "val": "h",
+                "key": "⠓"
             },
             {
-                "key": "i",
-                "val": "⠊"
+                "val": "i",
+                "key": "⠊"
             },
             {
-                "key": "j",
-                "val": "⠚"
+                "val": "j",
+                "key": "⠚"
             },
             {
-                "key": "k",
-                "val": "⠅"
+                "val": "k",
+                "key": "⠅"
             },
             {
-                "key": "l",
-                "val": "⠇"
+                "val": "l",
+                "key": "⠇"
             },
             {
-                "key": "m",
-                "val": "⠍"
+                "val": "m",
+                "key": "⠍"
             },
             {
-                "key": "n",
-                "val": "⠝"
+                "val": "n",
+                "key": "⠝"
             },
             {
-                "key": "o",
-                "val": "⠕"
+                "val": "o",
+                "key": "⠕"
             },
             {
-                "key": "p",
-                "val": "⠏"
+                "val": "p",
+                "key": "⠏"
             },
             {
-                "key": "q",
-                "val": "⠟"
+                "val": "q",
+                "key": "⠟"
             },
             {
-                "key": "r",
-                "val": "⠗"
+                "val": "r",
+                "key": "⠗"
             },
             {
-                "key": "s",
-                "val": "⠎"
+                "val": "s",
+                "key": "⠎"
             },
             {
-                "key": "t",
-                "val": "⠞"
+                "val": "t",
+                "key": "⠞"
             },
             {
-                "key": "u",
-                "val": "⠥"
+                "val": "u",
+                "key": "⠥"
             },
             {
-                "key": "v",
-                "val": "⠧"
+                "val": "v",
+                "key": "⠧"
             },
             {
-                "key": "w",
-                "val": "⠺"
+                "val": "w",
+                "key": "⠺"
             },
             {
-                "key": "x",
-                "val": "⠭"
+                "val": "x",
+                "key": "⠭"
             },
             {
-                "key": "y",
-                "val": "⠽"
+                "val": "y",
+                "key": "⠽"
             },
             {
-                "key": "z",
-                "val": "⠵"
+                "val": "z",
+                "key": "⠵"
+            },
+            {
+                "val": "letter sign force the end of a series of numbers",
+                "key": "⠰"
+            },
+            {
+                "val": "4a",
+                "key": "⠼⠙⠰⠁"
+            },
+            {
+                "val": "capitalization sign marks the following letter to be capitalized",
+                "key": "⠠"
+            },
+            {
+                "val": "DuckDuckGo",
+                "key": "⠠⠙⠥⠉⠅⠠⠙⠥⠉⠅⠠⠛⠕"
+            },
+            {
+                "val": "double capitalization sign marks the following word to be in all caps",
+                "key": "⠠⠠"
+            },
+            {
+                "val": "DDG",
+                "key": "⠠⠠⠙⠙⠛"
             }
         ],
         "Digit": [
             {
-                "key": "0",
-                "val": "⠚"
+                "val": "number sign marks the beginning of a sequence of number(s)",
+                "key": "⠼"
             },
             {
-                "key": "1",
-                "val": "⠁"
+                "val": "0",
+                "key": "⠚"
             },
             {
-                "key": "2",
-                "val": "⠃"
+                "val": "1",
+                "key": "⠁"
             },
             {
-                "key": "3",
-                "val": "⠉"
+                "val": "2",
+                "key": "⠃"
             },
             {
-                "key": "4",
-                "val": "⠙"
+                "val": "3",
+                "key": "⠉"
             },
             {
-                "key": "5",
-                "val": "⠑"
+                "val": "4",
+                "key": "⠙"
             },
             {
-                "key": "6",
-                "val": "⠋"
+                "val": "5",
+                "key": "⠑"
             },
             {
-                "key": "7",
-                "val": "⠛"
+                "val": "6",
+                "key": "⠋"
             },
             {
-                "key": "8",
-                "val": "⠓"
+                "val": "7",
+                "key": "⠛"
             },
             {
-                "key": "9",
-                "val": "⠊"
+                "val": "8",
+                "key": "⠓"
+            },
+            {
+                "val": "9",
+                "key": "⠊"
             }
         ]
     }


### PR DESCRIPTION
**What does your Instant Answer do?**

Add content to the cheatsheet instant answers.

**What is the data source for your Instant Answer? (Provide a link if possible)**

The cheat sheet for english braille is based on the article on wikipedia. <https://en.wikipedia.org/wiki/English_braille>

**Why did you choose this data source?**

It is easily accessible compared with digging through the standards which is in a pdf.

**Are there any other alternative (better) data sources?**

Alternative data sources could be from the International Council on English Braille (ICEB) <http://www.iceb.org/ueb> which has the same alphabet encoding on the "Rules of Unified English Braille 2013.pdf" on the same webpage. The encoding is on pg 41

**What are some example queries that trigger this Instant Answer?**

English Braille Cheat Sheet

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**

Reference, Special Interest

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**

No


**Are you having any problems? Do you need our help with anything?**

Not right now

**Where did you hear about DuckDuckHack? (For first time contributors)**

From the stopwatch/timer portion of duck duck go

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**

![image](https://cloud.githubusercontent.com/assets/2498638/9221142/520b2444-412b-11e5-8a70-c02e9e4e8da4.png)


-----
IA Page: https://duck.co/ia/view/english_braille_cheat_sheet