### PR TITLE
Preserve cheat sheet state and restore it on page load

### DIFF
--- a/share/goodie/cheat_sheets/cheat_sheets.js
+++ b/share/goodie/cheat_sheets/cheat_sheets.js
@@ -74,8 +74,17 @@ DDH.cheat_sheets.build = function(ops) {
         return new Handlebars.SafeString(out);
     });
 
+    var wasShown = false; // keep track whether onShow was run yet
+
     return {
         onShow: function() {
+            // make sure this function is only run once, the first time
+            // the IA is shown otherwise things will get initialized more than once
+            if (wasShown) { return; }
+
+            // set the flag to true so it doesn't get run again:
+            wasShown = true;
+
             var $dom = $("#zci-cheat_sheets"),
                 $container = $dom.find(".cheatsheet__container"),
                 $detail    = $dom.find(".zci__main--detail"),

--- a/share/goodie/cheat_sheets/cheat_sheets.js
+++ b/share/goodie/cheat_sheets/cheat_sheets.js
@@ -82,36 +82,54 @@ DDH.cheat_sheets.build = function(ops) {
                 $section   = $dom.find(".cheatsheet__section"),
                 $hideRow   = $section.find("tbody tr:nth-child(n+4)"),
                 $showhide  = $container.find(".cheatsheet__section.showhide"),
-                $more_btn  = $dom.find(".chomp--link");
-
-            // Removes all tr's after the 3rd before masonry fires
-            if ($container.hasClass("compressed")) {
-              $hideRow.toggleClass("is-hidden");
-            }
-
-            DDG.require('masonry.js', function(){
-
-                $container.masonry({
+                $more_btn  = $dom.find(".chomp--link"),
+                isExpanded = false,
+                loadedMasonry = false,
+                masonryOps = {
                     itemSelector: '.cheatsheet__section',
                     columnWidth: 295,
                     gutter: 30,
                     isFitWidth: true
-                });
+                },
+                showMoreLess = function() {
 
-                $more_btn.click(function() {
+                    // keep track of whether it's expanded or not:
+                    isExpanded = !isExpanded;
+
+                    // update the querystring param so the state
+                    // persists across page refreshes or if the link
+                    // is shared to someone else:
+                    if (isExpanded) {
+                        DDG.history.set({ iax: 1 });
+                    } else {
+                        DDG.history.clear('iax');
+                    }
+
                     $dom.toggleClass("has-chomp-expanded");
                     $detail.toggleClass("c-base");
                     $container.toggleClass("compressed");
                     $showhide.toggleClass("is-hidden");
                     $hideRow.toggleClass("is-hidden");
-                    $container.masonry({
-                        itemSelector: '.cheatsheet__section',
-                        columnWidth: 295,
-                        gutter: 30,
-                        isFitWidth: true
-                    });
-                });
-             });
+
+                    if (window.Masonry) {
+                        $container.masonry(masonryOps);
+                    }
+                };
+
+            // Removes all tr's after the 3rd before masonry fires
+            if ($container.hasClass("compressed")) {
+              $hideRow.toggleClass("is-hidden");
+            }
+            // if iax=1 is in the querystring, expand
+            // the cheatsheet automatically when the IA is shown:
+            if (DDG.history.get('iax')) {
+                showMoreLess();
+            }
+
+            DDG.require('masonry.js', function(){
+                $container.masonry(masonryOps);
+                $more_btn.click(showMoreLess);
+            });
          }
     };
 };


### PR DESCRIPTION
Adds `iax=1` to the querystring when you click Show More on a cheat sheet, and restores it to the expanded state on page load if `iax=1` is in the querystring. It uses the same `env.history` API that we use internally to preserve IA state.

This will allows cheat sheets to be bookmarked and shared in the expanded state.

@zachthompson @russellholt @moollaza 