### PR TITLE
No warnings on not found cheat sheets, new alias

### DIFF
--- a/lib/DDG/Goodie/CheatSheets.pm
+++ b/lib/DDG/Goodie/CheatSheets.pm
@@ -5,6 +5,8 @@ use JSON::XS;
 use DDG::Goodie;
 use DDP;
 
+no warnings 'uninitialized';
+
 zci answer_type => 'cheat_sheet';
 zci is_cached   => 1;
 

--- a/share/goodie/cheat_sheets/wu-tang.json
+++ b/share/goodie/cheat_sheets/wu-tang.json
@@ -6,6 +6,7 @@
         "sourceName": "Wikipedia",
         "sourceUrl": "https://en.wikipedia.org/wiki/Wu-Tang_Clan#Members"
     },
+    "aliases":["wu-tang"],
     "template_type": "reference-sheet",
     "section_order": ["Members"],
     "sections": {


### PR DESCRIPTION
* Add `no warnings 'uninitialized'` for missing cheat sheets.
* Add alias `wu-tang` to `wu-tang.json`