### PR TITLE
Improve BinaryLogic Goodie, validate input before formatting subtitle.

### DIFF
--- a/lib/DDG/Goodie/BinaryLogic.pm
+++ b/lib/DDG/Goodie/BinaryLogic.pm
@@ -99,13 +99,17 @@ sub BinaryLogic_Actions::do_not {
 }
 
 handle query_raw => sub {
+    my $input = $_;
+    
+    my $testError = $input;
+    $testError =~ s/(?:0x|0b|[\d\s]|and|or|xor|not|\(|\)|⊕|∧|∨|¬)//ig;
+    return undef if length $testError != 0;
+
     my $grammar = Marpa::R2::Scanless::G->new({ source => \$rules });
     my $recce = Marpa::R2::Scanless::R->new({
         grammar => $grammar,
         semantics_package => 'BinaryLogic_Actions'
     });
-
-    my $input = $_;
 
     # Substitute the unicode characters. The parser does not seem to
     # like unicode.

--- a/t/BinaryLogic.t
+++ b/t/BinaryLogic.t
@@ -64,7 +64,7 @@ ddg_goodie_test(
     'sentence containing not then words' => undef,
     'sentence containing or then words' => undef,
     'not words or word and number' => undef,
-    'what do number and letter codes in a lens name mean' => test_zci(undef)
+    'what do number and letter codes in a lens name mean' => undef
 );
 
 done_testing;

--- a/t/BinaryLogic.t
+++ b/t/BinaryLogic.t
@@ -57,6 +57,8 @@ ddg_goodie_test(
     '0x01 or 0x02' => test_zci(build_answer('3', sprintf "%b OR %b", hex(1), hex(2))),
     '0b01 or 0b10' => test_zci(build_answer('3', sprintf "01 OR 10")),
     '0B11 xor 0B10' => test_zci(build_answer('1', sprintf "11 XOR 10")),
+    
+    'what do number and letter codes in a lens name mean' => test_zci(undef)
 );
 
 done_testing;


### PR DESCRIPTION
Fixes #1403

Re-ordered logic to validate input (run through parser) before working on subtitle. @Sloff has added another regex check before parsing to verify the query contains expected logical operators.

/cc @Sloff 