### PR TITLE
Cheatsheets: Change format of keybindings having alternative keys.

### DIFF
--- a/share/goodie/cheat_sheets/json/blender.json
+++ b/share/goodie/cheat_sheets/json/blender.json
@@ -226,7 +226,7 @@
             "key": "[Ctrl] [Tab]"
         }, {
             "val": "Switching workspace",
-            "key": "[Ctrl] ([←]/[→])"
+            "key": "[Ctrl] ( [←] / [→] )"
         }, {
             "val": "Logic editor",
             "key": "[Shift] [F2]"
@@ -330,7 +330,7 @@
             "key": "[Shift] [Alt] [f]"
         }, {
             "val": "Add subdivision level",
-            "key": "[Ctrl] ([1]/[2]/[3]/[4])"
+            "key": "[Ctrl] ( [1] / [2] / [3] / [4] )"
         }],
         "Sculpting": [{
             "val": "Change brush size",

--- a/share/goodie/cheat_sheets/json/duckduckgo.json
+++ b/share/goodie/cheat_sheets/json/duckduckgo.json
@@ -12,7 +12,7 @@
                 "val": "Go to the highlighted result, or use it right away to go to the first result"
             },
             {
-                "key": "([Ctrl]/[⌘]) [↵]",
+                "key": "( [Ctrl] / [⌘] ) [↵]",
                 "val": "Open a result in the background"
             },
             {

--- a/share/goodie/cheat_sheets/json/firefox.json
+++ b/share/goodie/cheat_sheets/json/firefox.json
@@ -164,11 +164,11 @@
             },
             {  
                 "val":"Quickly switch between search engines (When Search Bar is focused)",
-                "key":"[Ctrl] ([↑]/[↓])"
+                "key":"[Ctrl] ( [↑] / [↓] )"
             },
             {  
                 "val":"View menu to switch, add or manage search engines (When Search Bar Focused)",
-                "key":"[Alt] ([↑]/[↓])"
+                "key":"[Alt] ( [↑] / [↓] )"
             }
         ],
         "Windows & Tabs":[  

--- a/share/goodie/cheat_sheets/json/gnome-keyboard.json
+++ b/share/goodie/cheat_sheets/json/gnome-keyboard.json
@@ -31,10 +31,10 @@
             "key": "[Super] [A] "
         }, {
             "val": "Switch between workspaces",
-            "key": "[Super] ([Page Up]/[Page Down])"
+            "key": "[Super] ( [Page Up] / [Page Down] )"
         }, {
             "val": "Move the current window to a different workspace",
-            "key": "[Super] [Shift] ([Page Up]/[Page Down])"
+            "key": "[Super] [Shift] ( [Page Up] / [Page Down] )"
         }, {
             "val": "Power Off",
             "key": "[Ctrl] [Alt] [Delete] "

--- a/share/goodie/cheat_sheets/json/mac-keyboard.json
+++ b/share/goodie/cheat_sheets/json/mac-keyboard.json
@@ -1,8 +1,8 @@
 {
-    "id": "mac_keyboard_cheat_sheet", 
+    "id": "mac_keyboard_cheat_sheet",
     "name": "Mac Keyboard Shortcuts",
-    "description": "List of useful keyboard shortcuts for Mac", 
-    "metadata": { 
+    "description": "List of useful keyboard shortcuts for Mac",
+    "metadata": {
         "sourceName": "Mac keyboard shortcuts",
         "sourceUrl": "https://support.apple.com/en-us/HT201236"
     },
@@ -81,7 +81,7 @@
             "key" : "[Cmd] [Shift] [Z]",
             "val" : "Redo"
         }, {
-            "key" : "[Cmd] [←/→]",
+            "key" : "[Cmd] [ ← / → ]",
             "val" : "Go to beginning/end of line"
         }, {
             "key" : "[Cmd] [↑]",
@@ -114,7 +114,7 @@
             "key" : "[Cmd] [,]",
             "val" : "Open Preferences (if available)"
         }, {
-            "key" : "[Ctrl] [←/→]",
+            "key" : "[Ctrl] [ ← / → ]",
             "val" : "Move one desktop left or right"
         }, {
             "key" : "[Cmd] [Opt] [Esc]",

--- a/share/goodie/cheat_sheets/json/microsoft-windows.json
+++ b/share/goodie/cheat_sheets/json/microsoft-windows.json
@@ -284,7 +284,7 @@
         }],
         "Browsers": [{
             "val": "Go to Address Bar",
-            "key": "[Alt] ([d]/[c])"
+            "key": "[Alt] ( [d] / [c] )"
         }, {
             "val": "Go to Address Bar (alternative)",
             "key": "F6"
@@ -434,7 +434,7 @@
             "key": "[Win] [Shift] [↑]"
         }, {
             "val": "Minimize all",
-            "key": "[Win] ([m]/[d])"
+            "key": "[Win] ( [m] / [d] )"
         }, {
             "val": "Minimize all non focused windows (Windows 7 and Windows 8.1)",
             "key": "[Win] [Home]"
@@ -449,10 +449,10 @@
             "key": "[Win] [Tab]"
         }, {
             "val": "Move window to left/right/up/down workspace (Windows 7 and Windows 8)",
-            "key": "[Win] ([←]/[→])"
+            "key": "[Win] ( [←] / [→] )"
         }, {
             "val": "Move window between multiple monitors (Windows 7 and Windows 8)",
-            "key": "[Win] [Shift] ([←]/[→])"
+            "key": "[Win] [Shift] ( [←] / [→] )"
         }, {
             "val": "Quit application of current window",
             "key": "[Alt] [F4]"

--- a/share/goodie/cheat_sheets/json/sublime-text.json
+++ b/share/goodie/cheat_sheets/json/sublime-text.json
@@ -18,255 +18,255 @@
         "Selection"
     ],
     "sections": {
-        "General": [{  
+        "General": [{
             "key":"[Ctrl] [N]",
             "val":"New file in new tab"
-          }, {  
+          }, {
             "key":"[Ctrl] [O]",
             "val":"Open file in new tab"
-          }, {  
+          }, {
             "key":"[Ctrl] [S]",
             "val":"Save"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [S]",
             "val":"Save as"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [N]",
             "val":"New file in new window"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [P]",
             "val":"Command pallette"
-          }, {  
+          }, {
             "key":"[Ctrl] [/]",
             "val":"Toggle comment"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [/]",
             "val":"Toggle block comment"
-          }, {  
+          }, {
             "key":"[Ctrl] [Space]",
             "val":"Show completions"
-        }, {  
-            "key":"[Ctrl] [W]",
-            "val":"Close current file"
-        }, {  
+          }, {
+              "key":"[Ctrl] [W]",
+              "val":"Close current file"
+          }, {
             "key":"[Ctrl] [Shift] [W]",
             "val":"Close current window"
         }],
-        "File Navigation": [{  
+        "File Navigation": [{
             "key":"[Ctrl] [P]",
             "val":"Goto Anything"
-          }, {  
+          }, {
             "key":"[Ctrl] [G]",
             "val":"Goto Line"
-          }, {  
+          }, {
             "key":"[Ctrl] [R]",
             "val":"Goto symbol (function name, table, etc.)"
-          }, {  
-            "key":"[Ctrl] ([Pageup]/[Pagedown])",
+          }, {
+            "key":"[Ctrl] ( [Pageup] / [Pagedown] )",
             "val":"Goto next/prev file"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [C]",
             "val":"Goto current selection"
-          }, {  
-            "key":"[Ctrl] ([↑]/[↓])",
+          }, {
+            "key":"[Ctrl] ( [↑] / [↓] )",
             "val":"Scroll up/down one line (doesn't move cursor)"
-          }, {  
+          }, {
             "key":"[Ctrl] [F2]",
             "val":"Set Bookmark"
-          }, {  
+          }, {
             "key":"[Alt] [Ctrl] [P]",
             "val":"Switch Project"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [F2]",
             "val":"Clear all bookmarks"
-          }, {  
+          }, {
             "key":"F2",
             "val":"Goto next bookmark"
         }],
-        "View/Window Manipulation": [{  
+        "View/Window Manipulation": [{
             "key":"[Ctrl] [`]",
             "val":"Show/Hide Console"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [B]",
             "val":"Show/Hide Sidebar"
-          }, {  
+          }, {
             "key":"F11",
             "val":"Fullscreen"
-          }, {  
+          }, {
             "key":"[Shift] [F11]",
             "val":"Distraction-free mode"
-          }, {  
-            "key":"[Alt] [Shift] ([2]/[3]/[4])",
+          }, {
+            "key":"[Alt] [Shift] ( [2] / [3] / [4] )",
             "val":"Set 2, 3, or 4 column layout"
-          }, {  
-            "key":"[Alt] [Shift] ([8]/[9])",
+          }, {
+            "key":"[Alt] [Shift] ( [8] / [9] )",
             "val":"Set 2 or 3 Row layout"
-          }, {  
+          }, {
             "key":"[Alt] [Shift] [5]",
             "val":"Set 4-pane grid layout"
-          }, {  
+          }, {
             "key":"[Alt] [Shift] [1]",
             "val":"Set single-pane layout"
-          }, {  
-            "key":"[Ctrl] ([1]/[2]/[3]/[4])",
+          }, {
+            "key":"[Ctrl] ( [1] / [2] / [3] / [4] )",
             "val":"Set focused group/pane"
-          }, {  
-            "key":"[Ctrl] [Shift] ([1]/[2]/[3]/[4])",
+          }, {
+            "key":"[Ctrl] [Shift] ( [1] / [2] / [3] / [4] )",
             "val":"Move current tab/file to pane"
         }],
-        "Find": [{  
+        "Find": [{
             "key":"[Ctrl] [F]",
             "val":"Find"
-          }, {  
+          }, {
             "key":"F3 ",
             "val":"Find Next"
-          }, {  
+          }, {
             "key":"[Ctrl] [F3]",
             "val":"Find previous"
-          }, {  
+          }, {
             "key":"[Ctrl] [I]",
             "val":"Incremental find"
-          }, {  
+          }, {
             "key":"[Ctrl] [H]",
             "val":"Replace"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [H]",
             "val":"Replace next"
-          }, {  
+          }, {
             "key":"[Ctrl] [F3]",
             "val":"Quick Find (find current word)"
-          }, {  
+          }, {
             "key":"[Alt] [F3]",
             "val":"Quick find all"
-          }, {  
+          }, {
             "key":"[Ctrl] [E]",
             "val":"Use selection for find"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [E]",
             "val":"Use selection for replace"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [F]",
             "val":"Find in files"
-          }, {  
+          }, {
             "key":"F4",
             "val":"Next result (find in files)"
-          }, {  
+          }, {
             "key":"[Shift] [F4]",
             "val":"Previous result (find in files)"
         }],
-        "Folding": [{  
+        "Folding": [{
             "key":"[Ctrl] ([\\[]\/[\\]])",
             "val":"Fold/expand"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [J]",
             "val":"Unfold all"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [1]",
             "val":"Fold all"
-          }, {  
+          }, {
             "key":"[Ctrl] ([2]-[9])",
             "val":"Fold level X"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [T]",
             "val":"Fold tag attributes"
         }],
-        "Marks": [{  
+        "Marks": [{
             "key":"[Ctrl] [K], [Space]",
             "val":"Set mark"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [A]",
             "val":"Select to mark"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [W]",
             "val":"Delete to mark"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [X]",
             "val":"Swap with mark"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [Y]",
             "val":"Yank"
         }],
-        "Word Manipulation": [{  
-            "key":"[Ctrl] ([Delete]/[BackSpace])",
+        "Word Manipulation": [{
+            "key":"[Ctrl] ( [Delete] / [BackSpace] )",
             "val":"Delete word forward/backward"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [K]",
             "val":"Delete to end of line"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [BackSpace]",
             "val":"Delete to beginning of line"
-          }, {  
+          }, {
             "key":"[Ctrl] [T]",
             "val":"Transpose (switch characters surrounding cursor)"
-          }, {  
+          }, {
             "key":"[Alt] [.]",
             "val":"Close Tag"
-          }, {  
-            "key":"[Ctrl] [K], ([U]/[L])",
+          }, {
+            "key":"[Ctrl] [K], ( [U] / [L] )",
             "val":"Convert to upper/lower case"
         }],
-        "Line Manipulation": [{  
+        "Line Manipulation": [{
             "key":"[Ctrl] [\\]], [\\[]",
             "val":"Indent/outdent"
-          }, {  
-            "key":"[Ctrl] [Shift] ([↑]/[↓])",
+          }, {
+            "key":"[Ctrl] [Shift] ( [↑] / [↓] )",
             "val":"Swap Line Up/Down"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [D]",
             "val":"Duplicate Line"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [K]",
             "val":"Delete line"
-          }, {  
+          }, {
             "key":"[Ctrl] [J]",
             "val":"Join Lines"
-          }, {  
+          }, {
             "key":"[Ctrl] [X]",
             "val":"Cut Line"
-          }, {  
+          }, {
             "key":"[Ctrl] [V]",
             "val":"Paste cut/copied line above"
-          }, {  
+          }, {
             "key":"[Ctrl] [Enter]",
             "val":"Insert line after"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [Enter]",
             "val":"Insert Line Before"
-          }, {  
+          }, {
             "key":"F9",
             "val":"Sort Lines"
-          }, {  
+          }, {
             "key":"[Ctrl] [F9]",
             "val":"Sort lines (case-sensitive)"
         }],
-        "Selection": [{  
+        "Selection": [{
             "key":"[Ctrl] [D]",
             "val":"Quick select (repeat to add next)"
-          }, {  
+          }, {
             "key":"[Ctrl] [U]",
             "val":"Undo quick select"
-          }, {  
+          }, {
             "key":"[Ctrl] [K], [D]",
             "val":"Skip and quick add next"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [L]",
             "val":"Split into lines (adds cursor to each line of current selection)"
-          }, {  
-            "key":"[Alt] [Ctrl] ([↑]/[↓])",
+          }, {
+            "key":"[Alt] [Ctrl] ( [↑] / [↓] )",
             "val":"Add previous/next line"
-          }, {  
+          }, {
             "key":"[Ctrl] [L]",
             "val":"Expand selection to line"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [Space]",
             "val":"Expand selection to scope"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [M]",
             "val":"Expand selection to brackets"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [J]",
             "val":"Expand selection to indent­ation"
-          }, {  
+          }, {
             "key":"[Ctrl] [Shift] [A]",
             "val":"Expand selection to tag"
           }

--- a/share/goodie/cheat_sheets/json/ubuntu.json
+++ b/share/goodie/cheat_sheets/json/ubuntu.json
@@ -93,7 +93,7 @@
                 "val": "Go to Desktop (minimize all windows)."
             },
             {
-                "key": "[Ctrl] [Super] ([←]/[→])",
+                "key": "[Ctrl] [Super] ( [←] / [→] )",
                 "val": "Dock Window to left or right side of screen."
             },
             {

--- a/share/goodie/cheat_sheets/json/vlc.json
+++ b/share/goodie/cheat_sheets/json/vlc.json
@@ -26,7 +26,7 @@
             "key":"B",
             "val":"Audio track cycle"
           }, {  
-            "key":"[Ctrl] ([↑]/[↓])",
+            "key":"[Ctrl] ( [↑] / [↓] )",
             "val":"Volume"
           }, {  
             "key":"[Ctrl] [O]",
@@ -46,16 +46,16 @@
             "key":"[Ctrl] [T]",
             "val":"Goto/jump to time"
           }, {  
-            "key":"[Shift] ([←]/[→])",
+            "key":"[Shift] ( [←] / [→] )",
             "val":"Very short jump – 3 secs"
           }, {  
-            "key":"[Alt] ([←]/[→])",
+            "key":"[Alt] ( [←] / [→] )",
             "val":"Short jump – 10 secs"
           }, {  
-            "key":"[Ctrl] ([←]/[→])",
+            "key":"[Ctrl] ( [←] / [→] )",
             "val":"Medium jump – 1 min"
           }, {  
-            "key":"[Ctrl] [Alt] ([←]/[→])",
+            "key":"[Ctrl] [Alt] ( [←] / [→] )",
             "val":"Long jump"
           }, {  
             "key":"E",
@@ -74,7 +74,7 @@
             "key":"[Ctrl] [F]",
             "val":"Open folder (browse folder menu)"
           }, {  
-            "key":"[Ctrl] ([R]/[S])",
+            "key":"[Ctrl] ( [R] / [S] )",
             "val":"Advanced open file"
           }, {  
             "key":"[Ctrl] [O]",
@@ -153,7 +153,7 @@
             "key":"[Ctrl] [Y]",
             "val":"Save playlist"
           }, {  
-            "key":"[Ctrl] ([I]/[J])",
+            "key":"[Ctrl] ( [I] / [J] )",
             "val":"Media information"
           }, {  
             "key":"[Alt] [A]",

--- a/share/goodie/cheat_sheets/json/vlc.json
+++ b/share/goodie/cheat_sheets/json/vlc.json
@@ -16,179 +16,179 @@
         "General": [{
             "key":"F",
             "val":"Fullscreen"
-          }, {  
+          }, {
             "key":"Space",
             "val":"Play/Pause"
-          }, {  
+          }, {
             "key":"V",
             "val":"Subtitles cycle/off"
-          }, {  
+          }, {
             "key":"B",
             "val":"Audio track cycle"
-          }, {  
+          }, {
             "key":"[Ctrl] ( [↑] / [↓] )",
             "val":"Volume"
-          }, {  
+          }, {
             "key":"[Ctrl] [O]",
             "val":"Open Single file(s)"
           }],
-        "Mouse actions": [{  
+        "Mouse actions": [{
             "key":"Double click",
             "val":"Fullscreen"
-          }, {  
+          }, {
             "key":"Scroll",
             "val":"Volume or Position"
-          }, {  
+          }, {
             "key":"Right click",
             "val":"Local menu (play controls, audio/video)"
           }],
-        "Navigation": [{  
+        "Navigation": [{
             "key":"[Ctrl] [T]",
             "val":"Goto/jump to time"
-          }, {  
+          }, {
             "key":"[Shift] ( [←] / [→] )",
             "val":"Very short jump – 3 secs"
-          }, {  
+          }, {
             "key":"[Alt] ( [←] / [→] )",
             "val":"Short jump – 10 secs"
-          }, {  
+          }, {
             "key":"[Ctrl] ( [←] / [→] )",
             "val":"Medium jump – 1 min"
-          }, {  
+          }, {
             "key":"[Ctrl] [Alt] ( [←] / [→] )",
             "val":"Long jump"
-          }, {  
+          }, {
             "key":"E",
             "val":"Next frame"
-          }, {  
+          }, {
             "key":"N",
             "val":"Next in playlist"
-          }, {  
+          }, {
             "key":"P",
             "val":"Current from beginning/Previous in playlist"
           }],
-        "Browsing & Playback Adjustments": [{  
+        "Browsing & Playback Adjustments": [{
             "key":"[Ctrl] [D]",
             "val":"Open disc menu"
-          }, {  
+          }, {
             "key":"[Ctrl] [F]",
             "val":"Open folder (browse folder menu)"
-          }, {  
+          }, {
             "key":"[Ctrl] ( [R] / [S] )",
             "val":"Advanced open file"
-          }, {  
+          }, {
             "key":"[Ctrl] [O]",
             "val":"Open single file(s)"
-          }, {  
+          }, {
             "key":"M",
             "val":"Mute and unmute audio"
-          }, {  
+          }, {
             "key":"S",
             "val":"Stop movie"
-          }, {  
+          }, {
             "key":"Esc",
             "val":"Exit full screen mode"
-          }, {  
+          }, {
             "key":"+",
             "val":"Faster"
-          }, {  
+          }, {
             "key":"-",
             "val":"Slower"
-          }, {  
+          }, {
             "key":"=",
             "val":"Normal"
-          }, {  
+          }, {
             "key":"A",
             "val":"Aspect ratio"
-          }, {  
+          }, {
             "key":"C",
             "val":"Crop screen"
-          }, {  
+          }, {
             "key":"[G]",
             "val":"Increase subtitle delay"
-          }, {  
+          }, {
             "key":"[H]",
             "val":"Decrease subtitle delay"
-          }, {  
+          }, {
             "key":"[J]",
             "val":"Increase audio delay"
-          }, {  
+          }, {
             "key":"[K]",
             "val":"Decrease audio delay"
-          }, {  
+          }, {
             "key":"Z",
             "val":"Change zoom mode"
-          }, {  
+          }, {
             "key":"T",
             "val":"Show time"
-          }, {  
+          }, {
             "key":"R",
             "val":"Random"
           }],
-        "Manage": [{  
+        "Manage": [{
             "key":"[Ctrl] [H]",
             "val":"Hide / unhide controls"
-          }, {  
+          }, {
             "key":"[Ctrl] [P]",
             "val":"Preferences / interface settings"
-          }, {  
+          }, {
             "key":"[Ctrl] [E]",
             "val":"Adjustments and audio/video effects"
-          }, {  
+          }, {
             "key":"[Ctrl] [B]",
             "val":"Edit bookmarks"
-          }, {  
+          }, {
             "key":"[Ctrl] [M]",
             "val":"Open messages"
-          }, {  
+          }, {
             "key":"[Ctrl] [N]",
             "val":"Open network"
-          }, {  
+          }, {
             "key":"[Ctrl] [C]",
             "val":"Open capture device"
-          }, {  
+          }, {
             "key":"[Ctrl] [L]",
             "val":"Open playlist"
-          }, {  
+          }, {
             "key":"[Ctrl] [Y]",
             "val":"Save playlist"
-          }, {  
+          }, {
             "key":"[Ctrl] ( [I] / [J] )",
             "val":"Media information"
-          }, {  
+          }, {
             "key":"[Alt] [A]",
             "val":"Open audio menu"
-          }, {  
+          }, {
             "key":"[Alt] [H]",
             "val":"Open help menu"
-          }, {  
+          }, {
             "key":"[Alt] [M]",
             "val":"Open media menu"
-          }, {  
+          }, {
             "key":"[Alt] [P]",
             "val":"Open playlist menu"
-          }, {  
+          }, {
             "key":"[Alt] [T]",
             "val":"Open tool menu"
-          }, {  
+          }, {
             "key":"[Alt] [V]",
             "val":"Open video menu"
-          }, {  
+          }, {
             "key":"[Alt] [L]",
             "val":"Open playback menu"
-          }, {  
+          }, {
             "key":"D",
             "val":"Show movie path"
-          }, {  
+          }, {
             "key":"F1",
             "val":"Show Help"
-          }, {  
+          }, {
             "key":"F11",
             "val":"Window fullscreen"
-          }, {  
+          }, {
             "key":"[Alt] [F4]",
             "val":"Quit VLC"
-          }, {  
+          }, {
             "key":"[Ctrl] [Q]",
             "val":"Quit VLC (alternative)"
           }]


### PR DESCRIPTION
([A]/[B]/[C]) are spaced out to look like this: ( [A] / [B] / [C] )

Used this [script](https://gist.github.com/cskksc/cd410ab4a3e45351146e).

Fixes #1407 