### PR TITLE
move json into /json/ dir, switch to code template

### DIFF
--- a/share/goodie/cheat_sheets/json/english-braille.json
+++ b/share/goodie/cheat_sheets/json/english-braille.json
@@ -1,17 +1,18 @@
 {
     "id": "english_braille_cheat_sheet",
-    "name": "English Braille Cheat Sheet",
+    "name": "English Braille",
     "metadata": {
         "sourceName": "EnglishBraille",
         "sourceUrl": "https://en.wikipedia.org/wiki/English_braille"
     },
+    "template_type": "code",
     "section_order": [
         "Alphabet",
         "Digit",
         "Formatting Marks"
     ],
     "sections": {
-        "Alphabet": [            
+        "Alphabet": [
             {
                 "val": "a",
                 "key": "⠁"
@@ -117,7 +118,7 @@
                 "key": "⠵"
             }
         ],
-        "Digit": [            
+        "Digit": [
             {
                 "val": "0",
                 "key": "⠚"
@@ -188,7 +189,6 @@
                 "val": "DDG",
                 "key": "⠠⠠⠙⠙⠛"
             }
-            
         ]
     }
 }

--- a/share/goodie/cheat_sheets/json/english-braille.json
+++ b/share/goodie/cheat_sheets/json/english-braille.json
@@ -7,12 +7,13 @@
     },
     "template_type": "code",
     "section_order": [
-        "Alphabet",
+        "Alphabet (A-L)",
+        "Alphabet (M-Z)",
         "Digit",
         "Formatting Marks"
     ],
     "sections": {
-        "Alphabet": [
+        "Alphabet (A-L)": [
             {
                 "val": "a",
                 "key": "⠁"
@@ -60,7 +61,9 @@
             {
                 "val": "l",
                 "key": "⠇"
-            },
+            }
+        ],
+        "Alphabet (M-Z)": [
             {
                 "val": "m",
                 "key": "⠍"


### PR DESCRIPTION
@abeyang I think the "code" template works best here. The reference template looks a little odd because the bullets and braille dots are very similar.

Thoughts?

**Code Template**:
![english_braille_cheat_sheet_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/9348962/e4274b7e-460c-11e5-9b8f-cc0543875764.png)

**Reference Template**:
![english_braille_cheat_sheet_at_duckduckgo](https://cloud.githubusercontent.com/assets/873785/9348961/db02dd56-460c-11e5-8eeb-468b1935db51.png)
