### PR TITLE
changes "command" to "⌘", implements #1433

### DIFF
--- a/share/goodie/cheat_sheets/json/xcode.json
+++ b/share/goodie/cheat_sheets/json/xcode.json
@@ -7,18 +7,18 @@
         "sourceUrl": "https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/xcode_help-command_shortcuts/MenuCommands/MenuCommands014.html"
     },
     "section_order": [
-        "Xcode menu command",
-        "File menu command",
-        "Edit menu command",
-        "View menu command",
-        "Navigate menu command",
-        "Editor menu command",
-        "Product menu command",
-        "Window menu command",
-        "Help menu command"
+        "Xcode Menu",
+        "File Menu",
+        "Edit Menu",
+        "View Menu",
+        "Navigate Menu",
+        "Editor Menu",
+        "Product Menu",
+        "Window Menu",
+        "Help Menu"
     ],
     "sections": {
-        "Xcode menu command": [
+        "Xcode Menu": [
             {
                 "key": "⌘",
                 "val": "Preferences"
@@ -36,7 +36,7 @@
                 "val": "Quit Xcode"
             }
         ],
-        "File menu command": [
+        "File Menu": [
             {
                 "key": "[⌘] [T]",
                 "val": "New Tab"
@@ -134,7 +134,7 @@
                 "val": "Print"
             }
         ],
-        "Edit menu command": [
+        "Edit Menu": [
             {
                 "key": "[⌘] [Z]",
                 "val": "Undo"
@@ -220,7 +220,7 @@
                 "val": "Show Spelling and Grammar"
             }
         ],
-        "View menu command": [
+        "View Menu": [
             {
                 "key": "[⌘] [1]",
                 "val": "Project"
@@ -270,7 +270,7 @@
                 "val": "Show Related Items"
             }
         ],
-        "Navigate menu command": [
+        "Navigate Menu": [
             {
                 "key": "[⌘] [L]",
                 "val": "Reveal in Project Navigator"
@@ -296,7 +296,7 @@
                 "val": "Jump To"
             }
         ],
-        "Editor menu command": [
+        "Editor Menu": [
             {
                 "key": "[Control] [⌘] [A]",
                 "val": "Add Attribute"
@@ -314,7 +314,7 @@
                 "val": "Comment Selection"
             }
         ],
-        "Product menu command": [
+        "Product Menu": [
             {
                 "key": "[⌘] [R]",
                 "val": "Run"
@@ -328,7 +328,7 @@
                 "val": "Build"
             }
         ],
-        "Window menu command": [
+        "Window Menu": [
             {
                 "key": "[⌘] [M]",
                 "val": "Minimize"
@@ -338,7 +338,7 @@
                 "val": "Welcome to Xcode"
             }
         ],
-        "Help menu command": [
+        "Help Menu": [
             {
                 "key": "[Control] [⌘] [?]",
                 "val": "Quick Help"

--- a/share/goodie/cheat_sheets/json/xcode.json
+++ b/share/goodie/cheat_sheets/json/xcode.json
@@ -20,331 +20,331 @@
     "sections": {
         "Xcode menu command": [
             {
-                "key": "Command",
+                "key": "⌘",
                 "val": "Preferences"
             },
             {
-                "key": "[Command] [H]",
+                "key": "[⌘] [H]",
                 "val": "Hide Xcode"
             },
             {
-                "key": "[Option] [Command] [H]",
+                "key": "[Option] [⌘] [H]",
                 "val": "Hide others"
             },
             {
-                "key": "[Command] [Q]",
+                "key": "[⌘] [Q]",
                 "val": "Quit Xcode"
             }
         ],
         "File menu command": [
             {
-                "key": "[Command] [T]",
+                "key": "[⌘] [T]",
                 "val": "New Tab"
             },
             {
-                "key": "[Shift] [Command] [T]",
+                "key": "[Shift] [⌘] [T]",
                 "val": "New Window"
             },
             {
-                "key": "[Command] [N]",
+                "key": "[⌘] [N]",
                 "val": "New File"
             },
             {
-                "key": "[Shift] [Command] [N]",
+                "key": "[Shift] [⌘] [N]",
                 "val": "New Project"
             },
             {
-                "key": "[Control] [Command] [N]",
+                "key": "[Control] [⌘] [N]",
                 "val": "New Workspace"
             },
             {
-                "key": "[Option] [Command] [N]",
+                "key": "[Option] [⌘] [N]",
                 "val": "New Group"
             },
             {
-                "key": "[Option] [Command] [A]",
+                "key": "[Option] [⌘] [A]",
                 "val": "Add Files"
             },
             {
-                "key": "[Command] [O]",
+                "key": "[⌘] [O]",
                 "val": "Open"
             },
             {
-                "key": "[Shift] [Command] [O]",
+                "key": "[Shift] [⌘] [O]",
                 "val": "Open Quickly"
             },
             {
-                "key": "[Command] [W]",
+                "key": "[⌘] [W]",
                 "val": "Close Window"
             },
             {
-                "key": "[Option] [Command] [W]",
+                "key": "[Option] [⌘] [W]",
                 "val": "Close All Windows"
             },
             {
-                "key": "[Shift] [Command] [W]",
+                "key": "[Shift] [⌘] [W]",
                 "val": "Close Tab"
             },
             {
-                "key": "[Option] [Shift] [Command] [W]",
+                "key": "[Option] [Shift] [⌘] [W]",
                 "val": "Close Other Tabs"
             },
             {
-                "key": "[Control] [Command] [W]",
+                "key": "[Control] [⌘] [W]",
                 "val": "Close Document"
             },
             {
-                "key": "[Command] [S]",
+                "key": "[⌘] [S]",
                 "val": "Save"
             },
             {
-                "key": "[Option] [Command] [S]",
+                "key": "[Option] [⌘] [S]",
                 "val": "Save All"
             },
             {
-                "key": "[Option] [Shift] [Command] [S]",
+                "key": "[Option] [Shift] [⌘] [S]",
                 "val": "Save Multiple"
             },
             {
-                "key": "[Shift] [Command] [S]",
+                "key": "[Shift] [⌘] [S]",
                 "val": "Save As"
             },
             {
-                "key": "[Option] [Command] [C]",
+                "key": "[Option] [⌘] [C]",
                 "val": "Commit"
             },
             {
-                "key": "[Option] [Command] [X]",
+                "key": "[Option] [⌘] [X]",
                 "val": "Update"
             },
             {
-                "key": "[Control] [Option] [Command] [X]",
+                "key": "[Control] [Option] [⌘] [X]",
                 "val": "Update All"
             },
             {
-                "key": "[Control] [Command] [S]",
+                "key": "[Control] [⌘] [S]",
                 "val": "Create Snapshot"
             },
             {
-                "key": "[Shift] [Command] [P]",
+                "key": "[Shift] [⌘] [P]",
                 "val": "Page Setup"
             },
             {
-                "key": "[Command] [P]",
+                "key": "[⌘] [P]",
                 "val": "Print"
             }
         ],
         "Edit menu command": [
             {
-                "key": "[Command] [Z]",
+                "key": "[⌘] [Z]",
                 "val": "Undo"
             },
             {
-                "key": "[Shift] [Command] [Z]",
+                "key": "[Shift] [⌘] [Z]",
                 "val": "Redo"
             },
             {
-                "key": "[Command] [X]",
+                "key": "[⌘] [X]",
                 "val": "Cut"
             },
             {
-                "key": "[Command] [C]",
+                "key": "[⌘] [C]",
                 "val": "Copy"
             },
             {
-                "key": "[Command] [V]",
+                "key": "[⌘] [V]",
                 "val": "Paste"
             },
             {
-                "key": "[Option] [Command] [V]",
+                "key": "[Option] [⌘] [V]",
                 "val": "Paste Special"
             },
             {
-                "key": "[Option] [Shift] [Command] [V]",
+                "key": "[Option] [Shift] [⌘] [V]",
                 "val": "Paste and Match Style"
             },
             {
-                "key": "[Command] [D]",
+                "key": "[⌘] [D]",
                 "val": "Duplicate"
             },
             {
-                "key": "[Command] [A]",
+                "key": "[⌘] [A]",
                 "val": "Select All"
             },
             {
-                "key": "[Shift] [Command] [F]",
+                "key": "[Shift] [⌘] [F]",
                 "val": "Find in Workspace"
             },
             {
-                "key": "[Option] [Shift] [Command] [F]",
+                "key": "[Option] [Shift] [⌘] [F]",
                 "val": "Find and Replace in Workspace"
             },
             {
-                "key": "[Command] [F]",
+                "key": "[⌘] [F]",
                 "val": "Find"
             },
             {
-                "key": "[Option] [Command] [F]",
+                "key": "[Option] [⌘] [F]",
                 "val": "Find and Replace"
             },
             {
-                "key": "[Command] [G]",
+                "key": "[⌘] [G]",
                 "val": "Find Next"
             },
             {
-                "key": "[Shift] [Command] [G]",
+                "key": "[Shift] [⌘] [G]",
                 "val": "Find Previous"
             },
             {
-                "key": "[Command] [E]",
+                "key": "[⌘] [E]",
                 "val": "Use Selection for Find"
             },
             {
-                "key": "[Shift] [Command] [E]",
+                "key": "[Shift] [⌘] [E]",
                 "val": "Use Selection for Replace"
             },
             {
-                "key": "[Option] [Command] [J]",
+                "key": "[Option] [⌘] [J]",
                 "val": "Filter in Navigator"
             },
             {
-                "key": "[Option] [Command] [L]",
+                "key": "[Option] [⌘] [L]",
                 "val": "Filter in Library"
             },
             {
-                "key": "[Control] [Shift] [Command] [T]",
+                "key": "[Control] [Shift] [⌘] [T]",
                 "val": "Show Fonts"
             },
             {
-                "key": "[Command] [:]",
+                "key": "[⌘] [:]",
                 "val": "Show Spelling and Grammar"
             }
         ],
         "View menu command": [
             {
-                "key": "[Command] [1]",
+                "key": "[⌘] [1]",
                 "val": "Project"
             },
             {
-                "key": "[Command] [2]",
+                "key": "[⌘] [2]",
                 "val": "Symbol"
             },
             {
-                "key": "[Command] [3]",
+                "key": "[⌘] [3]",
                 "val": "Search"
             },
             {
-                "key": "[Command] [4]",
+                "key": "[⌘] [4]",
                 "val": "Issue"
             },
             {
-                "key": "[Command] [5]",
+                "key": "[⌘] [5]",
                 "val": "Debug"
             },
             {
-                "key": "[Command] [6]",
+                "key": "[⌘] [6]",
                 "val": "Breakpoint"
             },
             {
-                "key": "[Command] [7]",
+                "key": "[⌘] [7]",
                 "val": "Log"
             },
             {
-                "key": "[Command] [0]",
+                "key": "[⌘] [0]",
                 "val": "Show Navigator"
             },
             {
-                "key": "[Command] [↩]",
+                "key": "[⌘] [↩]",
                 "val": "Standard"
             },
             {
-                "key": "[Option] [Command] [↩]",
+                "key": "[Option] [⌘] [↩]",
                 "val": "Assistant"
             },
             {
-                "key": "[Option] [Shift] [Command] [↩]",
+                "key": "[Option] [Shift] [⌘] [↩]",
                 "val": "Version"
             },
             {
-                "key": "[Command] [F]",
+                "key": "[⌘] [F]",
                 "val": "Show Related Items"
             }
         ],
         "Navigate menu command": [
             {
-                "key": "[Command] [L]",
+                "key": "[⌘] [L]",
                 "val": "Reveal in Project Navigator"
             },
             {
-                "key": "[Control] [Command] [⇢]",
+                "key": "[Control] [⌘] [⇢]",
                 "val": "Go Forward"
             },
             {
-                "key": "[Control] [Command] [⇠]",
+                "key": "[Control] [⌘] [⇠]",
                 "val": "Go Back"
             },
             {
-                "key": "[Command] [J]",
+                "key": "[⌘] [J]",
                 "val": "Jump to Selection"
             },
             {
-                "key": "[Shift] [Command] [D]",
+                "key": "[Shift] [⌘] [D]",
                 "val": "Jump to Definition"
             },
             {
-                "key": "[Shift] [Command] [J]",
+                "key": "[Shift] [⌘] [J]",
                 "val": "Jump To"
             }
         ],
         "Editor menu command": [
             {
-                "key": "[Control] [Command] [A]",
+                "key": "[Control] [⌘] [A]",
                 "val": "Add Attribute"
             },
             {
-                "key": "[Control] [Command] [R]",
+                "key": "[Control] [⌘] [R]",
                 "val": "Add Relationship"
             },
             {
-                "key": "[Command] [=]",
+                "key": "[⌘] [=]",
                 "val": "Size to Fit"
             },
             {
-                "key": "[Command] [/]",
+                "key": "[⌘] [/]",
                 "val": "Comment Selection"
             }
         ],
         "Product menu command": [
             {
-                "key": "[Command] [R]",
+                "key": "[⌘] [R]",
                 "val": "Run"
             },
             {
-                "key": "[Control] [Command] [B]",
+                "key": "[Control] [⌘] [B]",
                 "val": "Analyze"
             },
             {
-                "key": "[Command] [B]",
+                "key": "[⌘] [B]",
                 "val": "Build"
             }
         ],
         "Window menu command": [
             {
-                "key": "[Command] [M]",
+                "key": "[⌘] [M]",
                 "val": "Minimize"
             },
             {
-                "key": "[Shift] [Command] [1]",
+                "key": "[Shift] [⌘] [1]",
                 "val": "Welcome to Xcode"
             }
         ],
         "Help menu command": [
             {
-                "key": "[Control] [Command] [?]",
+                "key": "[Control] [⌘] [?]",
                 "val": "Quick Help"
             },
             {
-                "key": "[Option] [Command] [?]",
+                "key": "[Option] [⌘] [?]",
                 "val": "Developer Documentation"
             }
         ]


### PR DESCRIPTION
As suggested here (#1433) i quickly made this change for everyone to see how it looks.

<img width="754" alt="xcode-cheat-sheet" src="https://cloud.githubusercontent.com/assets/9606362/9467418/d708d744-4b3b-11e5-8edc-bcc1049c72d8.png">
