### PR TITLE
Fixes #1457 - updated code styles for terminal cheat sheet templates

### DIFF
--- a/share/goodie/cheat_sheets/cheat_sheets.css
+++ b/share/goodie/cheat_sheets/cheat_sheets.css
@@ -55,26 +55,17 @@
 
 
 .zci--cheat_sheets .terminal td {
-  margin-bottom: 6px;
+  padding-bottom: 12px;
 }
 
 .zci--cheat_sheets .terminal code {
-  display: inline;
   width: 100%;
-  padding: 0;
-  margin: 0;
-  border: none;
-  background: none;
 }
 
 .zci--cheat_sheets .terminal td.cheatsheet__key {
   display: block;
   min-width: 100%;
-  padding: 3px 4px 1px;
-  line-height: 1.17;
-  border-radius: 2px;
-  word-break: break-all;
-  word-wrap: break-word;
+  padding-bottom: 1px;
 }
 
 .zci--cheat_sheets .terminal td.cheatsheet__value {

--- a/share/goodie/cheat_sheets/cheat_sheets.css
+++ b/share/goodie/cheat_sheets/cheat_sheets.css
@@ -30,7 +30,8 @@
     border-radius: 2px;
     font-size: 0.833em;
     white-space: normal;
-    word-break: normal;
+    word-break: break-all;
+    word-wrap: break-word;
     margin-bottom: 0.2em;
     line-height: 1.17;
 }
@@ -48,6 +49,10 @@
 }
 
 /* terminal-snippets.handlebars */
+.zci--cheat_sheets .terminal table {
+  width: 100%;
+}
+
 
 .zci--cheat_sheets .terminal td {
   margin-bottom: 6px;
@@ -68,6 +73,8 @@
   padding: 3px 4px 1px;
   line-height: 1.17;
   border-radius: 2px;
+  word-break: break-all;
+  word-wrap: break-word;
 }
 
 .zci--cheat_sheets .terminal td.cheatsheet__value {

--- a/share/goodie/cheat_sheets/cheat_sheets.css
+++ b/share/goodie/cheat_sheets/cheat_sheets.css
@@ -50,17 +50,24 @@
 /* terminal-snippets.handlebars */
 
 .zci--cheat_sheets .terminal td {
-  padding-bottom: 12px;
+  margin-bottom: 6px;
 }
 
 .zci--cheat_sheets .terminal code {
+  display: inline;
   width: 100%;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: none;
 }
 
 .zci--cheat_sheets .terminal td.cheatsheet__key {
   display: block;
   min-width: 100%;
-  padding-bottom: 1px;
+  padding: 3px 4px 1px;
+  line-height: 1.17;
+  border-radius: 2px;
 }
 
 .zci--cheat_sheets .terminal td.cheatsheet__value {

--- a/share/goodie/cheat_sheets/terminal.handlebars
+++ b/share/goodie/cheat_sheets/terminal.handlebars
@@ -2,8 +2,8 @@
   <tbody>
     {{#each items}}
       <tr>
-        <td class="cheatsheet__key">
-          {{cheatsheets_codeblock key 'bg-clr--platinum'}}
+        <td class="cheatsheet__key bg-clr--platinum">
+          {{cheatsheets_codeblock key ""}}
         </td>
         <td class="cheatsheet__value tx-clr--slate-light">
           {{val}}

--- a/share/goodie/cheat_sheets/terminal.handlebars
+++ b/share/goodie/cheat_sheets/terminal.handlebars
@@ -2,8 +2,8 @@
   <tbody>
     {{#each items}}
       <tr>
-        <td class="cheatsheet__key bg-clr--platinum">
-          {{cheatsheets_codeblock key ""}}
+        <td class="cheatsheet__key">
+          {{cheatsheets_codeblock key "bg-clr--platinum"}}
         </td>
         <td class="cheatsheet__value tx-clr--slate-light">
           {{val}}


### PR DESCRIPTION
Displaying the `<code>` elements as `inline-block` seemed to create a bubble of excess space in the right side of the column. Couldn't find a definitive answer as to why that was happening, but by moving a class assignment around in the `terminal.handlebars`, we can display `<code>` elements as `inline`, which solved the problem. CSS is weird :)