### PR TITLE
iss1466 RandomNumber Correction for bounds of 0

### DIFF
--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -37,9 +37,11 @@ handle query_lc => sub {
 
     ($end, $start) = ($start, $end) if ($start > $end);
 
+    my $valDiff = $end - $start;
+
     my $rand = rand;
 
-    if ($start && $end) {
+    if ($start && $end || $valDiff > 1) {
         $rand *= ($end - $start + 1);
         $rand = int($rand) + $start;
     }

--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -10,7 +10,9 @@ name 'RandomNumber';
 code_url 'https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodies/RandomNumber.pm';
 category 'computing_tools';
 topics 'cryptography';
-attribution github => ['duckduckgo', 'DuckDuckGo'];
+attribution github => ['duckduckgo', 'DuckDuckGo'],
+            github => ['https://github.com/loganom', 'loganom'],
+            twitter => ['https://twitter.com/loganmccamon', 'loganom'];
 
 zci answer_type => 'rand';
 zci is_cached   => 0;
@@ -42,7 +44,7 @@ handle query_lc => sub {
     my $rand = rand;
 
     if ($start && $end || $valDiff > 1) {
-        $rand *= ($end - $start + 1);
+        $rand *= ($valDiff + 1);
         $rand = int($rand) + $start;
     }
 

--- a/t/RandomNumber.t
+++ b/t/RandomNumber.t
@@ -25,6 +25,30 @@ ddg_goodie_test(
             result    => qr/\d{1}\.\d+/,
         }
     ),
+    'random number between 0 and 1' => test_zci(
+        qr/\d{1} \(random number\)/,
+        structured_answer => {
+            input => [0, 1],
+            operation => 'Random number between',
+            result => qr/^\d{1}\.\d+$/
+        }
+    ),
+    'random number between 0 and 10' => test_zci(
+        qr/\d{1,2} \(random number\)/,
+        structured_answer => {
+            input => [0, 10],
+            operation => 'Random number between',
+            result => qr/^\d{1,2}$/
+        }
+    ),
+    'random number between 0 and 100' => test_zci(
+        qr/\d{1,3} \(random number\)/,
+        structured_answer => {
+            input => [0, 100],
+            operation => 'Random number between',
+            result => qr/^\d{1,3}$/
+        }
+    ),
     'random day'    => undef,
     'random access' => undef,
 );


### PR DESCRIPTION
If the start or end value was 0, then no matter what, the default rand() value was returned (which is a fractional number). I added a check for the difference of the two numbers. If it's greater than 1, then we enter the random number if block.

Added a few tests to show this.

Here's to hoping I've done PR creation correctly.. it's been a while.

#1466 