### PR TITLE
Switch back to normal word-break css

### DIFF
--- a/share/goodie/cheat_sheets/cheat_sheets.css
+++ b/share/goodie/cheat_sheets/cheat_sheets.css
@@ -30,8 +30,7 @@
     border-radius: 2px;
     font-size: 0.833em;
     white-space: normal;
-    word-break: break-all;
-    word-wrap: break-word;
+    word-break: normal;
     margin-bottom: 0.2em;
     line-height: 1.17;
 }


### PR DESCRIPTION
Moving back to `normal` settings for `word-break`. The `break-all` we introduced to force long "words" (code snippets, etc) to wrap has some unexpected effects on other keys that shouldn't be wrapping.

This is a temporary fix to get things working again. We need to revisit the markup and implementation of the keys and values to make sure they work as we expect them to.

/cc @alohaas @russellholt 