### PR TITLE
Emacs cheat sheet suggestion: Added "Go to line" shortcut

### DIFF
--- a/share/goodie/cheat_sheets/json/emacs.json
+++ b/share/goodie/cheat_sheets/json/emacs.json
@@ -86,6 +86,9 @@
         }, {
             "val": "Move to the end of a buffer",
             "key": "M->"
+        }, {
+            "val": "Go to line number #",
+            "key": "[M-g], [g], [#]"
         }],
         "Editing": [{
             "val": "Delete a character (forward)",


### PR DESCRIPTION
Hello guys, I didn't know whether to create a PR or submit this as a suggestion. If this creates more work for you let me know and I'll add a suggestion. I brought my forked repo up-to-date just before if that helps...

I use this shortcut very often and I thought it might be useful to others. One thing is that this shortcut is not on the current source for this cheat sheet. I am sure if that's an issue. In any case let me know what you think. My source is:
http://www.emacswiki.org/emacs/GotoLine