### PR TITLE
Sublime Text Cheat Sheet for OSX

### DIFF
--- a/share/goodie/cheat_sheets/json/sublime-text-mac.json
+++ b/share/goodie/cheat_sheets/json/sublime-text-mac.json
@@ -1,7 +1,8 @@
 {
-    "id": "sublime_text_mac",
-    "name": "Sublime Text",
-    "description": "Sublime 2 Keyboard Shortcuts for OSX ",
+    "id": "sublime_text_osx_cheat_sheet",
+    "name": "Sublime Text OSX",
+    "description": "Sublime Text 2 Keyboard Shortcuts for OS X",
+    "aliases": ["sublime text mac", "sublime mac", "sublime osx", "sublime for mac", "sublime 2 for osx" "sublime text osx", "sublimetext mac", "sublime text os x", "sublimetext os x"],
     "metadata": {
         "sourceName": "Cheatography",
         "sourceUrl": "http://www.cheatography.com/gelicia/cheat-sheets/sublime-text-2-shortcuts-verbose-mac/"

--- a/share/goodie/cheat_sheets/json/sublime-text-mac.json
+++ b/share/goodie/cheat_sheets/json/sublime-text-mac.json
@@ -1,0 +1,176 @@
+{
+    "id": "sublime_text_mac",
+    "name": "Sublime Text",
+    "description": "Sublime 2 Keyboard Shortcuts for OSX ",
+    "metadata": {
+        "sourceName": "Cheatography",
+        "sourceUrl": "http://www.cheatography.com/gelicia/cheat-sheets/sublime-text-2-shortcuts-verbose-mac/"
+    },
+    "template_type": "keyboard",
+    "section_order": [
+        "General",
+        "File Navigation",
+        "View/Window Manipulation",
+        "Find",
+        "Line Manipulation",
+        "Selection"
+    ],
+    "sections": {
+        "General": [{  
+            "key":"[⌘] [Shift] [N]",
+            "val":"New File in New Tab"
+          }, {  
+            "key":"[⌘] [S]",
+            "val":"Save"
+          }, {  
+            "key":"[⌘] [Shift] [S]",
+            "val":"Save As"
+          }, {  
+            "key":"[⌘] [KU]",
+            "val":"Upper Case"
+          }, {  
+            "key":"[⌘] [KL]",
+            "val":"Lower Case"
+          },  {  
+            "key":"[⌘] [Z]",
+            "val":"Undo"
+          }, {  
+            "key":"[⌘] [Y]",
+            "val":"Re-do"
+          }, {  
+            "key":"[⌘] [U]",
+            "val":"Undo Movement (Soft Undo)"
+          }, {  
+            "key":"[⌘] [Shift] [U]",
+            "val":"Re-do Movement (Soft Re-do)"
+          }, {  
+            "key":"[Ctrl] [Space]",
+            "val":"Auto Complete (Repeat for Next Selection)"
+          }, {  
+            "key":"[Ctrl] [M]",
+            "val":"Jump to Matching Bracket"
+          }, {  
+            "key":"[⌘] [/]",
+            "val":"Toggle comment"
+          }, {  
+            "key":"[⌘] [Option] [/]",
+            "val":"Toggle Block Comment"
+          }, {  
+            "key":"[⌘] [Space]",
+            "val":"Show Completions"
+        }, {  
+            "key":"[⌘] [Shift] [P]",
+            "val":"Command Prompt"
+        }],
+        "File Navigation": [{  
+            "key":"[⌘] [Shift] [N]",
+            "val":"New File in New Window"
+          }, {  
+            "key":"[⌘] [W]",
+            "val":"Close Current File"
+          }, {  
+            "key":"[⌘] [G]",
+            "val":"Go to Line"
+          }, {  
+            "key":"[⌘] [F2]",
+            "val":"Set Bookmark"
+          }, {  
+            "key":"[Shift] [F2]",
+            "val":"Previous Bookmarks"
+          }, {  
+            "key":"[⌘] [Shift] [F2]",
+            "val":"Clear all Bookmarks"
+          }, {  
+            "key":"F2",
+            "val":"Go to Next Bookmark"
+        }],
+        "View/Window Manipulation": [{  
+            "key":"[⌘] [KB]",
+            "val":"Toggle Side Bar"
+          }, {  
+            "key":"[⌘] [Option] [1]",
+            "val":"Single Column Layout"
+          }, {  
+            "key":"[⌘] [Option] [2]",
+            "val":"Two Column Layout"
+          }, {  
+            "key":"[⌘] [Option] [5]",
+            "val":"Grid Layout"
+          }, {  
+            "key":"[Ctrl] [\\[1,2,3,4\\]]",
+            "val":"Focus Group"
+          }, {  
+            "key":"[Ctrl] [Shift] [\\[1,2,3,4\\]]",
+            "val":"Move File to Group"
+          }, {  
+            "key":"[⌘] [\\[1,2,3,4\\]]",
+            "val":"Select Tab"
+        }],
+        "Find": [{  
+            "key":"[⌘] [F]",
+            "val":"Find"
+          }, {  
+            "key":"[Option] [⌘] [G]",
+            "val":"Find Next"
+          }, {  
+            "key":"[Ctrl] [⌘] [G]",
+            "val":"Find All Occurrences"
+          },{  
+            "key":"[⌘] [Option] [F]",
+            "val":"Replace"
+          }, {  
+            "key":"[⌘] [Shift] [F]",
+            "val":"Find in Files"
+          }],
+        "Line Manipulation": [{  
+            "key":"[⌘] [L]",
+            "val":"Select Line"
+          }, {  
+            "key":"[⌘] [D]",
+            "val":"Select Word"
+          }, {  
+            "key":"[Ctrl] [Shift] [M]",
+            "val":"Select Content in Brackets"
+          }, {  
+            "key":"[⌘] [Shift] [Enter]",
+            "val":"Insert Line Before Cursor"
+          }, {  
+            "key":"[⌘] [Enter]",
+            "val":"Insert Line After"
+          }, {  
+            "key":"[⌘] [Shift] [D]",
+            "val":"Duplicate Line or Lines"
+          }, {  
+            "key":"[⌘] [J]",
+            "val":"Join Lines"
+          }, {  
+            "key":"[⌘] [Shift] [A]",
+            "val":"Select Content Into Tag"
+          }, {  
+            "key":"[Ctrl] [Shift] [K]",
+            "val":"Delete Line"
+          }, {  
+            "key":"[⌘] [KK]",
+            "val":"Delete from Cursor to End of Line"
+          }, {  
+            "key":"[⌘] [K] [Delete]",
+            "val":"Delete from Cursor to Beginning of Line"
+          }, {  
+            "key":"[⌘] [Option] [.]",
+            "val":"Close Tag"
+          }, {  
+            "key":"[⌘] [X]",
+            "val":"Cut Line"
+          }, {  
+            "key":"[⌘] [V]",
+            "val":"Paste Cut/Copied line above"
+          }, {  
+            "key":"[⌘] [Shift] [V]",
+            "val":"Paste and Indent"
+          }, {  
+            "key":"[Ctrl] [M]",
+            "val":"Jump to Matching Bracket"
+          }
+        ]
+    }
+}


### PR DESCRIPTION
**What does your Instant Answer do?**
Helps users with shortcuts for OSX in Sublime 2 and provides an easier Format and more readable shortcuts for people using DuckDuckGo.

**What is the data source for your Instant Answer? (Provide a link if possible)**
http://www.cheatography.com/gelicia/cheat-sheets/sublime-text-2-shortcuts-verbose-mac/

**Why did you choose this data source?**
Seemed like the best option for Sublime 2 (especially since Sublime 3 is still in beta).

**Are there any other alternative (better) data sources?**
Maybe, but this is the best I found for now. There are a few other shortcut pages for OSX on cheatography.com

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Developers, Computer Science Majors, people who use pretty text editors, Mac users.

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
Not sure. I didn't look.

**Are you having any problems? Do you need our help with anything?**
No. All seems to work! However, the one thing I would say/recommend is that, if possible, there should be a way to have the two instant answers on sublime text shortcuts appear together in the instant answer area, with the tab option to see PC or OSX shortcuts.

**Where did you hear about DuckDuckHack? (For first time contributors)**
GDI Philly

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**

![image](https://cloud.githubusercontent.com/assets/12848168/9623142/dd5bfb2e-510a-11e5-87bb-d9b830f9145d.png)

-----
IA Page: https://duck.co/ia/view/sublime_text_osx_cheat_sheet