### PR TITLE
Update and rename mac-keyboard.json to apple-mac-os.json

### DIFF
--- a/share/goodie/cheat_sheets/json/apple-mac-os.json
+++ b/share/goodie/cheat_sheets/json/apple-mac-os.json
@@ -1,16 +1,18 @@
 {
     "id": "apple_mac_os_cheat_sheet",
     "name": "Apple OS X",
-    "description": "List of useful keyboard shortcuts for Mac, works on all versions of mac os including OS X 10.10 Yosermite",
+    "description": "List of useful keyboard shortcuts for Mac, works on all versions of Mac OS including Yosemite",
     "metadata": {
-        "sourceName": "Apple Mac OS Cheat Sheet",
-        "sourceUrl": "https://support.apple.com/en-us/HT201236"
+    "sourceName": "Apple Mac OS Cheat Sheet",
+    "sourceUrl": "https://support.apple.com/en-us/HT201236"
     },
     "aliases": [
     "osx",
     "os x",
     "mac",
-    "apple mac"
+    "apple mac",
+    "mac os",
+    "mac osx"
     ],
     "template_type": "keyboard",
     "section_order" : ["General", "Finder", "Text Editing", "Web Browsing (Works on most modern browsers)", "Spotlight", "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)"],

--- a/share/goodie/cheat_sheets/json/apple-mac-os.json
+++ b/share/goodie/cheat_sheets/json/apple-mac-os.json
@@ -1,11 +1,17 @@
 {
-    "id": "mac_keyboard_cheat_sheet",
-    "name": "Mac Keyboard Shortcuts",
-    "description": "List of useful keyboard shortcuts for Mac",
+    "id": "apple_mac_os_cheat_sheet",
+    "name": "Apple OS X",
+    "description": "List of useful keyboard shortcuts for Mac, works on all versions of mac os including OS X 10.10 Yosermite",
     "metadata": {
-        "sourceName": "Mac keyboard shortcuts",
+        "sourceName": "Apple Mac OS Cheat Sheet",
         "sourceUrl": "https://support.apple.com/en-us/HT201236"
     },
+    "aliases": [
+    "osx",
+    "os x",
+    "mac",
+    "apple mac"
+    ],
     "template_type": "keyboard",
     "section_order" : ["General", "Finder", "Text Editing", "Web Browsing (Works on most modern browsers)", "Spotlight", "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)"],
     "sections":{

--- a/share/goodie/cheat_sheets/json/apple-mac-os.json
+++ b/share/goodie/cheat_sheets/json/apple-mac-os.json
@@ -7,12 +7,12 @@
     "sourceUrl": "https://support.apple.com/en-us/HT201236"
     },
     "aliases": [
-    "osx",
-    "os x",
-    "mac",
-    "apple mac",
-    "mac os",
-    "mac osx"
+        "osx",
+        "os x",
+        "mac",
+        "apple mac",
+        "mac os",
+        "mac osx"
     ],
     "template_type": "keyboard",
     "section_order" : ["General", "Finder", "Text Editing", "Web Browsing (Works on most modern browsers)", "Spotlight", "Screenshots (Hold Ctrl with any of these to copy screenshot to clipboard)"],


### PR DESCRIPTION
made changes to fix the issue:
https://github.com/duckduckgo/zeroclickinfo-goodies/issues/1498
* id: changed to apple_mac_os_cheat_sheet (to match or other Operating System Cheat Sheets
* name: changed to Apple OS X
* description: updated to specify which versions of Mac OS this applies to
* filename: changed to apple-mac-os.json
* aliases: added osx, os x, mac, apple mac
