### PR TITLE
Week: ensure we have a defined location and timezone

### DIFF
--- a/lib/DDG/Goodie/Week.pm
+++ b/lib/DDG/Goodie/Week.pm
@@ -65,8 +65,9 @@ handle query_lc => sub {
     ($week, $year) = qw/current current/ if (not defined $week);
 
     # ensure week number is legitimate
-	return unless $week eq 'current' or ($week > 0 && $week <=52);
-	
+    return unless $week eq 'current' or ($week > 0 && $week <=52);
+
+    return unless $loc && $loc->time_zone;
     my $dt = DateTime->now(time_zone => $loc->time_zone);
 
     my $response;


### PR DESCRIPTION
We don't always have a `$loc` or `$loc->time_zone` so we need to ensure we have on before creating a DateTime object.

/cc @mintsoft 