### PR TITLE
Cheatsheet for vcgencmd, Raspberry Pi's firmware command

### DIFF
--- a/share/goodie/cheat_sheets/json/vcgencmd.json
+++ b/share/goodie/cheat_sheets/json/vcgencmd.json
@@ -7,7 +7,7 @@
         "sourceUrl": "http://elinux.org/RPI_vcgencmd_usage"
     },
     "aliases": [
-        "vcgencmd", "raspberry pi temperature", "raspberry pi voltage"
+        "vcgencmd"
     ],
     "template_type": "terminal",
     "section_order": [

--- a/share/goodie/cheat_sheets/json/vcgencmd.json
+++ b/share/goodie/cheat_sheets/json/vcgencmd.json
@@ -17,57 +17,57 @@
     "sections": {
         "Utility": [
             {
-                "key": "$ vcgencmd commands",
+                "key": "vcgencmd commands",
                 "val": "Shows a list of all the available commands"
             },
             {
-                "key": "$ vcgencmd version",
+                "key": "vcgencmd version",
                 "val": "Shows the firmware version"
             },
             {
-                "key": "$ vcgencmd get_config \\[config|int|str\\]",
+                "key": "vcgencmd get_config \\[config|int|str\\]",
                 "val": "Will print the configurations you have set. Argument can ether be - 'config', a specific option or 'int', showing all configs with number-datatype or 'str', showing all configurations with datatype string (aka text)."
             },
             {
-                "key": "$ vcgencmd codec_enabled <codec>",
+                "key": "vcgencmd codec_enabled <codec>",
                 "val": "Shows if the specified codec is enabled, codec can be one of 'H264', 'MPG2', 'WVC1', 'MPG4', 'MJPG', 'WMV9'."
             },
             {
-                "key": "$ vcgencmd get_mem arm/gpu",
+                "key": "vcgencmd get_mem arm/gpu",
                 "val": "Shows how much memory is split between the CPU (arm) and GPU."
             },
             {
-                "key": "$ vcgencmd cache_flush",
+                "key": "vcgencmd cache_flush",
                 "val": "Flush GPU's L1 cache."
             },
             {
-                "key": "$ vcgencmd otp_dump",
+                "key": "vcgencmd otp_dump",
                 "val": "Displays the contents of the OTP (One Time Programmable) memory embedded inside the SoC."
             },
             {
-                "key": "$ vcgencmd display_power \\[0|1\\]",
+                "key": "vcgencmd display_power \\[0|1\\]",
                 "val": "Turns video output off or on. '0' turns it off, '1' turns it on."
             },
             {
-                "key": "$ vcgencmd mem_oom",
+                "key": "vcgencmd mem_oom",
                 "val": "Reports statistics on Out of Memory events."
             },
             {
-                "key": "$ vcgencmd mem_reloc_stats",
+                "key": "vcgencmd mem_reloc_stats",
                 "val": "Reports statics on relocatable memory."
             }
         ],
         "Sensors": [
             {
-                "key": "$ vcgencmd measure_temp",
+                "key": "vcgencmd measure_temp",
                 "val": "Shows core temperature"
             },
             {
-                "key": "$ vcgencmd measure_volts <id>",
+                "key": "vcgencmd measure_volts <id>",
                 "val": "Shows voltage. id can be one of 'core', 'sdram_c', 'sdram_i', 'sdram_p', and defaults to 'core' if not specified."
             },
             {
-                "key": "$ vcgencmd measure_clock <clock>",
+                "key": "vcgencmd measure_clock <clock>",
                 "val": "Shows clock frequency, clock can be one of 'arm', 'core', 'h264', 'isp', 'v3d', 'uart', 'pwm', 'emmc', 'pixel', 'vec', 'hdmi' and 'dpi'."
             }
         ]

--- a/share/goodie/cheat_sheets/json/vcgencmd.json
+++ b/share/goodie/cheat_sheets/json/vcgencmd.json
@@ -1,0 +1,75 @@
+{
+    "id": "vcgencmd_cheat_sheet",
+    "name": "vcgencmd",
+    "description": "Raspberry Pi Firmware Command",
+    "metadata": {
+        "sourceName": "Embedded Linux Wiki",
+        "sourceUrl": "http://elinux.org/RPI_vcgencmd_usage"
+    },
+    "aliases": [
+        "vcgencmd", "raspberry pi temperature", "raspberry pi voltage"
+    ],
+    "template_type": "terminal",
+    "section_order": [
+        "Utility",
+        "Sensors"
+    ],
+    "sections": {
+        "Utility": [
+            {
+                "key": "$ vcgencmd commands",
+                "val": "Shows a list of all the available commands"
+            },
+            {
+                "key": "$ vcgencmd version",
+                "val": "Shows the firmware version"
+            },
+            {
+                "key": "$ vcgencmd get_config \\[config|int|str\\]",
+                "val": "Will print the configurations you have set. Argument can ether be - 'config', a specific option or 'int', showing all configs with number-datatype or 'str', showing all configurations with datatype string (aka text)."
+            },
+            {
+                "key": "$ vcgencmd codec_enabled <codec>",
+                "val": "Shows if the specified codec is enabled, codec can be one of 'H264', 'MPG2', 'WVC1', 'MPG4', 'MJPG', 'WMV9'."
+            },
+            {
+                "key": "$ vcgencmd get_mem arm/gpu",
+                "val": "Shows how much memory is split between the CPU (arm) and GPU."
+            },
+            {
+                "key": "$ vcgencmd cache_flush",
+                "val": "Flush GPU's L1 cache."
+            },
+            {
+                "key": "$ vcgencmd otp_dump",
+                "val": "Displays the contents of the OTP (One Time Programmable) memory embedded inside the SoC."
+            },
+            {
+                "key": "$ vcgencmd display_power \\[0|1\\]",
+                "val": "Turns video output off or on. '0' turns it off, '1' turns it on."
+            },
+            {
+                "key": "$ vcgencmd mem_oom",
+                "val": "Reports statistics on Out of Memory events."
+            },
+            {
+                "key": "$ vcgencmd mem_reloc_stats",
+                "val": "Reports statics on relocatable memory."
+            }
+        ],
+        "Sensors": [
+            {
+                "key": "$ vcgencmd measure_temp",
+                "val": "Shows core temperature"
+            },
+            {
+                "key": "$ vcgencmd measure_volts <id>",
+                "val": "Shows voltage. id can be one of 'core', 'sdram_c', 'sdram_i', 'sdram_p', and defaults to 'core' if not specified."
+            },
+            {
+                "key": "$ vcgencmd measure_clock <clock>",
+                "val": "Shows clock frequency, clock can be one of 'arm', 'core', 'h264', 'isp', 'v3d', 'uart', 'pwm', 'emmc', 'pixel', 'vec', 'hdmi' and 'dpi'."
+            }
+        ]
+    }
+}


### PR DESCRIPTION
**What does your Instant Answer do?**
Shows a cheat sheet/reference of `vcgencmd`, Raspberry Pi's firmware command for querying the sensors etc

**What is the data source for your Instant Answer? (Provide a link if possible)**
[Embedded Linux wiki](http://elinux.org/RPI_vcgencmd_usage).

**Why did you choose this data source?**
It's the preferred source from multiple places.

**Are there any other alternative (better) data sources?**
There is [this source](https://github.com/nezticle/RaspberryPi-BuildRoot/wiki/VideoCore-Tools) which I also consulted. It's not better than the other one.

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Raspberry Pi enthusiasts.

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
No.

**Are you having any problems? Do you need our help with anything?**
No.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![selection_013](https://cloud.githubusercontent.com/assets/357253/9855078/dfd9509e-5b29-11e5-91b2-2ddc35e8dfe4.png)

-----
IA Page: https://duck.co/ia/view/vcgencmd_cheat_sheet