### PR TITLE
german cheat sheet final touches (picks up #1368)

### DIFF
--- a/share/goodie/cheat_sheets/json/german.json
+++ b/share/goodie/cheat_sheets/json/german.json
@@ -14,22 +14,22 @@
       "Getting Help",
       "Travelling",
       "Etiquette",
-      "Dinner on the Town"
+      "Going out for Dinner"
    ],
    "description" : "Basic German words and phrases",
    "sections" : {
       "Etiquette" : [
          {
-            "val" : "Guten Nacht",
-            "key" : "Good Night"
-         },
-         {
-            "val" : "Guten Mittag",
-            "key" : "Good Afternoon"
+            "val" : "Guten Morgen",
+            "key" : "Good Morning"
          },
          {
             "val" : "Guten Abend",
             "key" : "Good Evening"
+         },
+         {
+            "val" : "Gute Nacht",
+            "key" : "Good night"
          },
          {
             "val" : "Es tut mir leid.",
@@ -48,30 +48,26 @@
             "key" : "Thank you very much!"
          },
          {
-            "val" : "Guten Morgen",
-            "key" : "Good Morning"
-         },
-         {
             "val" : "Bitteschön",
             "key" : "You're welcome"
          }
       ],
       "Getting Help" : [
          {
-            "val" : "Ruf die Polizei (an)!",
-            "key" : "Call the Police!"
+            "val" : "Rufen Sie die Polizei!",
+            "key" : "Call the police!"
          },
          {
-            "val" : "Können Sie bitte langsamer sprechen!",
-            "key" : "Please speak more slowly!"
+            "val" : "Können Sie bitte langsamer sprechen?",
+            "key" : "Can you speak more slowly, please?"
          },
          {
             "val" : "Ich bin allergisch.",
             "key" : "I am allergic."
          },
          {
-            "val" : "Bitte wiederholen.",
-            "key" : "Repeat, please."
+            "val" : "Können Sie das bitte wiederholen?",
+            "key" : "Can you repeat, please?"
          },
          {
             "val" : "Wie sagt man \"X\" auf Deutsch?",
@@ -167,7 +163,7 @@
          },
          {
             "val" : "Bitte halten Sie hier an.",
-            "key" : "Stop here please."
+            "key" : "Please stop here."
          },
          {
             "val" : "Biegen Sie rechts ab.",
@@ -182,7 +178,7 @@
             "key" : "How can I get a taxi?"
          }
       ],
-      "Dinner on the Town" : [
+      "Going out for Dinner" : [
          {
             "val" : "Haben Sie ein vegetarisches Gericht?",
             "key" : "Do you have vegetarian dishes?"

--- a/share/goodie/cheat_sheets/json/german.json
+++ b/share/goodie/cheat_sheets/json/german.json
@@ -14,18 +14,18 @@
       "Getting Help",
       "Travelling",
       "Etiquette",
-      "Going out for Dinner"
+      "Going out for dinner"
    ],
    "description" : "Basic German words and phrases",
    "sections" : {
       "Etiquette" : [
          {
             "val" : "Guten Morgen",
-            "key" : "Good Morning"
+            "key" : "Good morning"
          },
          {
             "val" : "Guten Abend",
-            "key" : "Good Evening"
+            "key" : "Good evening"
          },
          {
             "val" : "Gute Nacht",
@@ -178,7 +178,7 @@
             "key" : "How can I get a taxi?"
          }
       ],
-      "Going out for Dinner" : [
+      "Going out for dinner" : [
          {
             "val" : "Haben Sie ein vegetarisches Gericht?",
             "key" : "Do you have vegetarian dishes?"


### PR DESCRIPTION
So here we are, let's refine the german cheat sheet finally. I added everything from #1368 as suggested there, changed the order in one section and also changed some minor things i thought looked odd.

Question for the native english folks: In the ```Etiquette``` section, it was suggested to spell "night" lower case. But "Evening" and "Morning" is upper case. Please let me know is that is supposed to be like this. In general it would be good if both native german and native english folks can comment if this is ok now. If not please comment and i'll make the necessary changes. :+1: Maybe we can nail this one once and for all. :wink: 

/cc @moollaza 