### PR TITLE
Updated gnome cheatsheet. Added more shortcuts.

### DIFF
--- a/share/goodie/cheat_sheets/json/gnome.json
+++ b/share/goodie/cheat_sheets/json/gnome.json
@@ -4,76 +4,180 @@
     "description": "List of useful keyboard shortcuts for GNOME", 
     "metadata": {
         "sourceName": "GNOME Help",
-        "sourceUrl": "https://help.gnome.org/users/gnome-help/stable/shell-keyboard-shortcuts.html.en"
+        "sourceUrl": "https://help.gnome.org/users/gnome-help/stable/keyboard-shortcuts-set.html.en"
     },
     "template_type": "keyboard",
-    "section_order": ["Desktop Shortcuts", "Common Editing", "Screen Capturing"],
+    "section_order": ["Windows", "System", "Navigation", "Common Editing", "Screen Capturing", "Universal Access", "Typing"],
     "sections": {
-        "Desktop Shortcuts": [{
-            "val": "Switch between the Activities overview and desktop",
-            "key": "[Alt] [F1]"
-        },{
-            "val": "Switch between the Activities overview and desktop (alternative)",
-            "key": "Super"
-        }, {
-            "val": "Pop up command window",
-            "key": "[Alt] [F2] "
-        }, {
-            "val": "Quickly switch between windows",
-            "key": "[Super] [Tab] "
-        }, {
-            "val": "Switch between windows from the same application",
-            "key": "[Super] [`] "
-        }, {
-            "val": "Give keyboard focus to the top bar",
-            "key": "[Ctrl] [Alt] [Tab] "
-        }, {
-            "val": "Show the list of applications",
-            "key": "[Super] [A] "
-        }, {
-            "val": "Switch between workspaces",
-            "key": "[Super] ( [Page Up] / [Page Down] )"
-        }, {
-            "val": "Move the current window to a different workspace",
-            "key": "[Super] [Shift] ( [Page Up] / [Page Down] )"
-        }, {
-            "val": "Power Off",
-            "key": "[Ctrl] [Alt] [Delete] "
-        }, {
-            "val": "Lock the screen",
-            "key": "[Super] [L] "
-        }, {
-            "val": "Open the message tray",
-            "key": "[Super] [M] "
-        }],
-         "Common Editing": [{
+        "Windows": [
+            {
+                "val": "Maximize window",
+                "key": "[Super] [↑]"
+            },
+            {
+                "val": "Restore window",
+                "key": "[Super] [↓]"
+            },
+            {
+                "val": "Close window",
+                "key": "[Alt] [F4]"
+            },
+            {
+                "val": "Hide window",
+                "key": "[Super] [H]"
+            },
+            {
+                "val": "View split on left",
+                "key": "[Super] [←]"
+            },
+            {
+                "val": "View split on right",
+                "key": "[Super] [→]"
+            },
+            {
+                "val": "Move window",
+                "key": "[Alt] [F7]"
+            },
+            {
+                "val": "Resize window",
+                "key": "[Alt] [F8]"
+            },
+            {
+                "val": "Activate the window menu",
+                "key": "[Alt] [Space]"
+            }
+        ],
+        "Navigation": [
+            {
+                "val": "Move to workspace above",
+                "key": "[Super] [Page Up]"
+            },
+            {
+                "val": "Move to workspace below",
+                "key": "[Super] [Page Down]"
+            },
+            {
+                "val": "Move window one workspace up",
+                "key": "[Shift] [Super] [Page Up]"
+            },
+            {
+                "val": "Move window one workspace down",
+                "key": "[Shift] [Super] [Page Down]"
+            },
+            {
+                "val": "Switch applications",
+                "key": "[Super] [Tab]"
+            },
+            {
+                "val": "Switch windows directly",
+                "key": "[Alt] [Esc]"
+            },
+            {
+                "val": "Switch windows of an application directly",
+                "key": "[Alt] [F6]"
+            },
+            {
+                "val" : "Switch system controls",
+                "key": "[Ctrl] [Alt] [Tab]"
+            },
+            {
+                "val": "Switch system controls directly",
+                "key": "[Ctrl] [Alt] [Esc]"
+            }
+        ],
+        "System": [
+            {
+                "val": "Show the run command prompt",
+                "key": "[Alt] [F2]"
+            },
+            {
+                "val": "Show the activities overview",
+                "key": "[Alt] [F1] / [Super]"
+            },
+            {
+                "val": "Power Off",
+                "key": "[Ctrl] [Alt] [Delete]"
+            },
+            {
+                "val": "Lock Screen",
+                "key": "[Super] [L]"
+            },
+            {
+                "val": "Show the message tray",
+                "key": "[Super] [M]"
+            },
+            {
+                "val": "Focus the active notification",
+                "key": "[Super] [N]"
+            },
+            {
+                "val": "Show all applications",
+                "key": "[Super] [A]"
+            },
+            {
+                "val": "Open the application menu",
+                "key": "[Super] [F10]"
+            }
+        ],
+         "Common Editing": [
+            {
             "val": "Select all text or items in a list",
             "key": "[Ctrl] [A] "
-        }, {
+            },
+            {
             "val": "Cut selected text or items and place it on the clipboard",
             "key": "[Ctrl] [X] "
-        }, {
+            },
+            {
             "val": "Copy selected text or items to the clipboard",
             "key": "[Ctrl] [C] "
-        }, {
+            },
+            {
             "val": "Paste the contents of the clipboard",
             "key": "[Ctrl] [V] "
-        }, {
+            },
+            {
             "val": "Undo the last action",
             "key": "[Ctrl] [Z] "
-        }],
-         "Screen Capturing": [{
+            }
+         ],
+         "Screen Capturing": [
+            {
             "val": "Take a screenshot",
             "key": "[Prnt Scrn]"
-        }, {
+            },
+            {
             "val": "Take a screenshot of a window",
             "key": "[Alt] [Prnt Scrn]"
-        }, {
+            },
+            {
             "val": "Take a screenshot of an area of the screen",
             "key": "[Shift] [Prnt Scrn]"
-        }, {
+            },
+            {
             "val": "Start and end screencast recording",
             "key": "[Ctrl] [Alt] [Shift] [R] "
-        }]
+            }
+        ],
+        "Universal Access": [
+            {
+                "val": "Turn zoom on or off",
+                "key": "[Alt] [Super] [8]"
+            },
+            {
+                "val": "Zoom in",
+                "key": "[Alt] [Super] [=]"
+            },
+            {
+                "val": "Zoom out",
+                "key": "[Alt] [Super] [-]"
+            }
+        ],
+        "Typing": [
+            {
+                "val": "Switch to next input source",
+                "key": "[Super] [Space]"
+            }
+        ]
     }
 }

--- a/share/goodie/cheat_sheets/json/gnome.json
+++ b/share/goodie/cheat_sheets/json/gnome.json
@@ -92,7 +92,7 @@
             },
             {
                 "val": "Show the activities overview",
-                "key": "[Alt] [F1] / [Super]"
+                "key": "Super"
             },
             {
                 "val": "Power Off",


### PR DESCRIPTION
I've included some more keyboard shortcuts in this cheat sheet. Also, I've updated the sourceURL as the previous sourceURL (https://help.gnome.org/users/gnome-help/stable/shell-keyboard-shortcuts.html.en) does not contains all of the shortcuts.

**Screenshots**
***Previously***
![previous](https://cloud.githubusercontent.com/assets/7776696/10175738/3ce249ea-670e-11e5-9dcb-c4c2d9996e33.png)

***Updated***
![present](https://cloud.githubusercontent.com/assets/7776696/10175750/483564f8-670e-11e5-8a8a-83c3ae768229.png)
-----
IA Page: https://duck.co/ia/view/gnome_cheat_sheet