### PR TITLE
Updated Lua cheat sheet: Fixed typing error

### DIFF
--- a/share/goodie/cheat_sheets/json/lua.json
+++ b/share/goodie/cheat_sheets/json/lua.json
@@ -4,7 +4,7 @@
     "name": "Lua",
 
     "metadata": { 
-        "sourceName": "Lua Cheat Sheet for Programers",
+        "sourceName": "Lua Cheat Sheet for Programmers",
         "sourceUrl": "http://coffeeghost.net/2010/11/01/lua-cheat-sheet-for-programmers/"
     },
 


### PR DESCRIPTION
The value "Lua Cheat Sheet for Programmers" has been corrected. Previously there was a typing error in the word "programmers".
Thanks to @preemeijer for informing me about this mistake.