### PR TITLE
Fixes outdated nmap commands

### DIFF
--- a/share/goodie/cheat_sheets/json/nmap.json
+++ b/share/goodie/cheat_sheets/json/nmap.json
@@ -54,10 +54,10 @@
         }],
         "Discovery Options": [{
             "val": "Perform a ping-only scan",
-            "key": "nmap -sP \\[target\\]"
+            "key": "nmap -sn \\[target\\]"
         }, {
             "val": "Don't ping",
-            "key": "nmap -PN \\[target\\]"
+            "key": "nmap -Pn \\[target\\]"
         }, {
             "val": "TCP SYN ping",
             "key": "nmap -PS \\[target\\]"


### PR DESCRIPTION
Apparently, these two commands have a new preferred syntax since 2010.

I tested it out and it turns out that the old syntax in both of the cases are still functional, so I'm not sure should they be replaced or not, but what the heck, I'm submitting a pull request to fix my own cheat sheet.

Source: @bonsaiviking told me about this [on Twitter](https://twitter.com/r3bl_/status/650077864902193153) so maybe he would be interested in stepping in and explaining the issue a bit further.