### PR TITLE
TurkishCheatSheet: Remove unneeded apostrophe

### DIFF
--- a/share/goodie/cheat_sheets/json/turkish.json
+++ b/share/goodie/cheat_sheets/json/turkish.json
@@ -99,7 +99,7 @@
         "key" : "Can you please speak slower?"
       },
       {
-        "val" : "\"X\" Türkçe'de nasıl söylenir?",
+        "val" : "\"X\" Türkçede nasıl söylenir?",
         "key" : "How do you say \"X\" in Turkish?"
       },
       {


### PR DESCRIPTION
Fix for the apostrophe, pointed by https://twitter.com/bitigchi/status/650688207525408768

Turkish grammar rules state that "No additional apostrophe is needed after the 'Türkçe' word".