### PR TITLE
New Cheat Sheet for randomly generated DDG staff bands

### DIFF
--- a/share/goodie/cheat_sheets/json/duckduckgo-staff-bands.json
+++ b/share/goodie/cheat_sheets/json/duckduckgo-staff-bands.json
@@ -1,0 +1,102 @@
+{
+    "id": "duckduckgo_staff_bands_cheat_sheet",
+    "name": "DuckDuckGo Staff Bands",
+    "description": "Randomly generated bands comprised of DuckDuckGo staff members",
+    "template_type": "reference",
+    "section_order": [
+        "Crocodile And The Zipper Duck Boys",
+        "Wasp Duck Thanksgivings",
+        "The Martian Elbow Ducks",
+        "The Duck Ambush Chesterfield Renegade",
+        "The Sunbeam Ducks Ringing After Summers"
+    ],
+    "sections": {
+        "Crocodile And The Zipper Duck Boys": [
+        {
+            "val": "Saxophone",
+            "key": "Blake J."
+        }, {
+            "val": "Bongos",
+            "key": "Abe Y."
+        }, {
+            "val": "Violin",
+            "key": "Jason D."
+        }, {
+            "val": "Organ",
+            "key": "Prakash S."
+        }, {
+            "val": "Harmonica",
+            "key": "Zac P."
+        }
+    ],
+        "Wasp Duck Thanksgivings": [
+        {
+            "val": "Drums",
+            "key": "Tommy L."
+        }, {
+            "val": "Maracas",
+            "key": "Doug B."
+        }, {
+            "val": "Trombone",
+            "key": "Jag T."
+        }, {
+            "val": "Kazoo",
+            "key": "Gabe W."
+        }, {
+            "val": "Flute",
+            "key": "Caine T."
+        }
+    ],
+        "The Martian Elbow Ducks": [
+        {
+            "val": "Zither",
+            "key": "Thom v. d. W."
+        }, {
+            "val": "Steel Drums",
+            "key": "Russel H."
+        }, {
+            "val": "Snare Drum",
+            "key": "Jaryd M."
+        }, {
+            "val": "Bass Guitar",
+            "key": "Eric J."
+        }, {
+            "val": "Spoons",
+            "key": "Chris M."
+        }
+    ],
+        "The Duck Ambush Chesterfield Renegade": [
+        {
+            "val": "Stylophone",
+            "key": "Zach T."
+        }, {
+            "val": "French Horn",
+            "key": "John B."
+        }, {
+            "val": "Bamboo Flute",
+            "key": "Brian B."
+        }, {
+            "val": "Accordian",
+            "key": "Maria G. A."
+        }, {
+            "val": "Vibraphone",
+            "key": "Andrey P."
+        }
+    ],
+        "The Sunbeam Ducks Ringing After Summers": [
+        {
+            "val": "Xylophone",
+            "key": "Brian S."
+        }, {
+            "val": "Ukelele",
+            "key": "Zaahir M."
+        }, {
+            "val": "Saxophone",
+            "key": "Jeffrey V."
+        },{
+            "val": "Harp",
+            "key": "Marc S."
+        }
+    ]
+    }
+}

--- a/share/goodie/cheat_sheets/json/duckduckgo-staff-bands.json
+++ b/share/goodie/cheat_sheets/json/duckduckgo-staff-bands.json
@@ -1,7 +1,7 @@
 {
     "id": "duckduckgo_staff_bands_cheat_sheet",
     "name": "DuckDuckGo Staff Bands",
-    "description": "Randomly generated bands comprised of DuckDuckGo staff members",
+    "description": "Randomly generated bands comprised of DuckDuckGo Staff members",
     "template_type": "reference",
     "section_order": [
         "Crocodile And The Zipper Duck Boys",

--- a/share/goodie/cheat_sheets/json/duckduckgo-staff-bands.json
+++ b/share/goodie/cheat_sheets/json/duckduckgo-staff-bands.json
@@ -1,7 +1,7 @@
 {
     "id": "duckduckgo_staff_bands_cheat_sheet",
     "name": "DuckDuckGo Staff Bands",
-    "description": "Randomly generated bands comprised of DuckDuckGo Staff members",
+    "description": "Randomly generated bands comprised of DDG staff members",
     "template_type": "reference",
     "section_order": [
         "Crocodile And The Zipper Duck Boys",

--- a/share/goodie/cheat_sheets/json/duckduckgo-staff-bands.json
+++ b/share/goodie/cheat_sheets/json/duckduckgo-staff-bands.json
@@ -1,7 +1,7 @@
 {
     "id": "duckduckgo_staff_bands_cheat_sheet",
     "name": "DuckDuckGo Staff Bands",
-    "description": "Randomly generated bands comprised of DDG staff members",
+    "description": "Some randomly generated bands comprised of DuckDuckGo staff members",
     "template_type": "reference",
     "section_order": [
         "Crocodile And The Zipper Duck Boys",


### PR DESCRIPTION
**What does your Instant Answer do?**
Provides a list of some (potentially) awesome DuckDuckGo Bands comprised of DDG Staff members

**What is the data source for your Instant Answer? (Provide a link if possible)**
Randomly generated using a number generator and a couple websites: 

**Why did you choose this data source?**
It did what I needed.

**Are there any other alternative (better) data sources?**
Nope.

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
The DDG Staff.

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
Yes: https://duck.co/ideas/idea/6505/randomly-generated-duckduckgo-staff-bands

**Are you having any problems? Do you need our help with anything?**
Nope.

**Where did you hear about DuckDuckHack? (For first time contributors)**
@moollaza -- He's awesome.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![duckduckgo_staff_bands_cheat_sheet_at_duckduckgo](https://cloud.githubusercontent.com/assets/5800319/10294902/11ae8596-6b8b-11e5-8966-d5a50e3cdf54.png)

-----
IA Page: https://duck.co/ia/view/duckduckgo_staff_bands_cheat_sheet