### PR TITLE
Changed Rust Language Object Types Cheat Sheet to reference type

### DIFF
--- a/share/goodie/cheat_sheets/json/rust-types.json
+++ b/share/goodie/cheat_sheets/json/rust-types.json
@@ -17,7 +17,7 @@
         "Enumerated Types",
         "Pointer Types"
     ],
-    "template_type": "keyboard",
+    "template_type": "reference",
     "sections": {
         "Primitive Types": [
             {


### PR DESCRIPTION
fix for #1626 

-----
IA Page: https://duck.co/ia/view/rust_types_cheat_sheet