### PR TITLE
Add a cheatsheet for Magit (Emacs Git major mode)

### DIFF
--- a/share/goodie/cheat_sheets/json/magit.json
+++ b/share/goodie/cheat_sheets/json/magit.json
@@ -107,7 +107,7 @@
         "val": "Execute commit"
       },
       {
-        "key": "C-c C-a",
+        "key": "[C-c], [C-a]",
         "val": "Make the next commit an amend"
       }
     ],

--- a/share/goodie/cheat_sheets/json/magit.json
+++ b/share/goodie/cheat_sheets/json/magit.json
@@ -1,0 +1,333 @@
+{
+  "id": "magit_cheat_sheet",
+  "name": "Magit",
+  "description": "Git Version Control via Emacs",
+  "metadata": {
+    "sourceName": "MagitCheatSheet",
+    "sourceUrl": "http://daemianmack.com/magit-cheatsheet.html"
+  },
+  "template_type": "keyboard",
+  "section_order": [
+    "Buffers",
+    "Section Visibility",
+    "Untracked Files",
+    "Staging and Committing",
+    "History",
+    "Reflogs",
+    "Diffing",
+    "Tagging",
+    "Resetting",
+    "Stashing",
+    "Branching",
+    "Wazzup",
+    "Merging",
+    "Rebasing",
+    "Rewriting",
+    "Pushing and Pulling",
+    "Interfacing with Subversion"
+  ],
+  "sections": {
+    "Buffers": [
+      {
+        "key": "M-x magit-status",
+        "val": "Magit's status buffer"
+      },
+      {
+        "key": "$",
+        "val": "magit-process buffer"
+      },
+      {
+        "key": "g",
+        "val": "reload status buffer"
+      }
+    ],
+    "Section Visibility": [
+      {
+        "key": "TAB",
+        "val": "Toggle visibility of current section"
+      },
+      {
+        "key": "S-TAB",
+        "val": "Toggle visibility of current section and its children"
+      },
+      {
+        "key": "1,2,3,4",
+        "val": "Expand current section to the corresponding level of detail - 1, 2, 3 or 4 "
+      },
+      {
+        "key": "M-1,2,3,4",
+        "val": "Expand all sections to the corresponding level of detail - 1, 2, 3 or 4"
+      }
+    ],
+    "Untracked Files": [
+      {
+        "key": "s",
+        "val": "Add untracked file to staging area"
+      },
+      {
+        "key": "i",
+        "val": "Add file to .gitignore"
+      },
+      {
+        "key": "C-u i",
+        "val": "Prompt for file/directory to add to .gitignore"
+      },
+      {
+        "key": "I",
+        "val": "Add file to .git/info/exclude instead of .gitignore"
+      }
+    ],
+    "Staging and Committing": [
+      {
+        "key": "s",
+        "val": "Stage current hunk"
+      },
+      {
+        "key": "u",
+        "val": "Unstage current hunk"
+      },
+      {
+        "key": "S",
+        "val": "Stage all hunks"
+      },
+      {
+        "key": "U",
+        "val": "Unstage all hunks"
+      },
+      {
+        "key": "k",
+        "val": "Discard uncommitted changes"
+      },
+      {
+        "key": "c",
+        "val": "Prepare for commit"
+      },
+      {
+        "key": "C-c C-c",
+        "val": "Execute commit"
+      },
+      {
+        "key": "C-c C-a",
+        "val": "Make the next commit an amend"
+      }
+    ],
+    "History": [
+      {
+        "key": "l",
+        "val": "History"
+      },
+      {
+        "key": "L",
+        "val": "Verbose history"
+      },
+      {
+        "key": "C-u l",
+        "val": "History segment"
+      },
+      {
+        "key": "RET",
+        "val": "Inspect commit"
+      },
+      {
+        "key": "a",
+        "val": "Stage current commit on your current branch"
+      },
+      {
+        "key": "A",
+        "val": "Commit current commit on your current branch"
+      },
+      {
+        "key": "C-w",
+        "val": "Copy sha1 of current commit into kill ring"
+      },
+      {
+        "key": "=",
+        "val": "Show differences between current and marked commits"
+      },
+      {
+        "key": "..",
+        "val": "Mark current commit"
+      },
+      {
+        "key": ".",
+        "val": "Unmark current commit if marked"
+      },
+      {
+        "key": "C-u ..",
+        "val": "Unmark marked commit from anywhere"
+      }
+    ],
+    "Reflogs": [
+      {
+        "key": "h",
+        "val": "Browse reflog from HEAD"
+      },
+      {
+        "key": "H",
+        "val": "Browse reflog from chosen point"
+      }
+    ],
+    "Diffing": [
+      {
+        "key": "d",
+        "val": "Show changes between working tree and HEAD"
+      },
+      {
+        "key": "D",
+        "val": "Show changes between two arbitrary revisions"
+      },
+      {
+        "key": "a",
+        "val": "Apply current changes to working tree"
+      },
+      {
+        "key": "v",
+        "val": "Apply current changes to working tree in reverse"
+      }
+    ],
+    "Tagging": [
+      {
+        "key": "t",
+        "val": "Make lightweight tag"
+      },
+      {
+        "key": "T",
+        "val": "Prepare annotated tag"
+      },
+      {
+        "key": "C-c C-c",
+        "val": "Commit annotated tag"
+      }
+    ],
+    "Resetting": [
+      {
+        "key": "x",
+        "val": "Reset your current head to chosen revision"
+      },
+      {
+        "key": "X",
+        "val": "Reset working tree and staging area to most recent committed state"
+      }
+    ],
+    "Stashing": [
+      {
+        "key": "z",
+        "val": "Create new stash"
+      },
+      {
+        "key": "Z",
+        "val": "Create new stash and maintain state"
+      },
+      {
+        "key": "a",
+        "val": "Apply stash"
+      },
+      {
+        "key": "A",
+        "val": "Pop stash"
+      },
+      {
+        "key": "k",
+        "val": "Drop stash"
+      }
+    ],
+    "Branching": [
+      {
+        "key": "b",
+        "val": "Switch to different branch"
+      },
+      {
+        "key": "B",
+        "val": "Create and switch to new branch"
+      }
+    ],
+    "Wazzup": [
+      {
+        "key": "w",
+        "val": "Show summary of how other branches relate to current branch"
+      },
+      {
+        "key": "i",
+        "val": "Toggle ignore branch"
+      },
+      {
+        "key": "C-u w",
+        "val": "Show all branches including ignored ones"
+      }
+    ],
+    "Merging": [
+      {
+        "key": "m",
+        "val": "Initiate manual merge"
+      },
+      {
+        "key": "M",
+        "val": "Initiate automatic merge"
+      }
+    ],
+    "Rebasing": [
+      {
+        "key": "R",
+        "val": "Initiate or continue a rebase"
+      }
+    ],
+    "Rewriting": [
+      {
+        "key": "r s",
+        "val": "Start a rewrite"
+      },
+      {
+        "key": "v",
+        "val": "Revert a given commit"
+      },
+      {
+        "key": "r t",
+        "val": "Remove bookkeeping information from buffer"
+      },
+      {
+        "key": "r a",
+        "val": "Abort rewriting"
+      },
+      {
+        "key": "r f",
+        "val": "Finish rewriting"
+      },
+      {
+        "key": "r *",
+        "val": "Toggle the * mark on a pending commit"
+      },
+      {
+        "key": "r ..",
+        "val": "Toggle the . mark on a pending commit"
+      }
+    ],
+    "Pushing and Pulling": [
+      {
+        "key": "P",
+        "val": "git push"
+      },
+      {
+        "key": "C-u P",
+        "val": "git push to specified remote repository"
+      },
+      {
+        "key": "f",
+        "val": "git remote update"
+      },
+      {
+        "key": "F",
+        "val": "git pull"
+      }
+    ],
+    "Interfacing with Subversion": [
+      {
+        "key": "N r",
+        "val": "git svn rebase"
+      },
+      {
+        "key": "N c",
+        "val": "git svn dcommit"
+      }
+    ]
+  }
+}

--- a/share/goodie/cheat_sheets/json/magit.json
+++ b/share/goodie/cheat_sheets/json/magit.json
@@ -29,7 +29,7 @@
   "sections": {
     "Buffers": [
       {
-        "key": "M-x magit-status",
+        "key": "[M-x], [magit-status]",
         "val": "Magit's status buffer"
       },
       {
@@ -69,7 +69,7 @@
         "val": "Add file to .gitignore"
       },
       {
-        "key": "C-u i",
+        "key": "[C-u], [i]",
         "val": "Prompt for file/directory to add to .gitignore"
       },
       {
@@ -103,7 +103,7 @@
         "val": "Prepare for commit"
       },
       {
-        "key": "C-c C-c",
+        "key": "[C-c], [C-c]",
         "val": "Execute commit"
       },
       {
@@ -121,7 +121,7 @@
         "val": "Verbose history"
       },
       {
-        "key": "C-u l",
+        "key": "[C-u], [l]",
         "val": "History segment"
       },
       {
@@ -145,7 +145,7 @@
         "val": "Show differences between current and marked commits"
       },
       {
-        "key": "..",
+        "key": "[.], [.]",
         "val": "Mark current commit"
       },
       {
@@ -153,7 +153,7 @@
         "val": "Unmark current commit if marked"
       },
       {
-        "key": "C-u ..",
+        "key": "[C-u], [.], [.]",
         "val": "Unmark marked commit from anywhere"
       }
     ],
@@ -195,7 +195,7 @@
         "val": "Prepare annotated tag"
       },
       {
-        "key": "C-c C-c",
+        "key": "[C-c], [C-c]",
         "val": "Commit annotated tag"
       }
     ],
@@ -251,7 +251,7 @@
         "val": "Toggle ignore branch"
       },
       {
-        "key": "C-u w",
+        "key": "[C-u], [w]",
         "val": "Show all branches including ignored ones"
       }
     ],
@@ -273,7 +273,7 @@
     ],
     "Rewriting": [
       {
-        "key": "r s",
+        "key": "[r], [s]",
         "val": "Start a rewrite"
       },
       {
@@ -281,23 +281,23 @@
         "val": "Revert a given commit"
       },
       {
-        "key": "r t",
+        "key": "[r], [t]",
         "val": "Remove bookkeeping information from buffer"
       },
       {
-        "key": "r a",
+        "key": "[r], [a]",
         "val": "Abort rewriting"
       },
       {
-        "key": "r f",
+        "key": "[r], [f]",
         "val": "Finish rewriting"
       },
       {
-        "key": "r *",
+        "key": "[r], [*]",
         "val": "Toggle the * mark on a pending commit"
       },
       {
-        "key": "r ..",
+        "key": "[r], [.], [.]",
         "val": "Toggle the . mark on a pending commit"
       }
     ],
@@ -307,7 +307,7 @@
         "val": "git push"
       },
       {
-        "key": "C-u P",
+        "key": "[C-u], [P]",
         "val": "git push to specified remote repository"
       },
       {
@@ -321,11 +321,11 @@
     ],
     "Interfacing with Subversion": [
       {
-        "key": "N r",
+        "key": "[N], [r]",
         "val": "git svn rebase"
       },
       {
-        "key": "N c",
+        "key": "[N], [c]",
         "val": "git svn dcommit"
       }
     ]


### PR DESCRIPTION
**What does your Instant Answer do?**

Displays a cheat sheet for [Magit](http://magit.vc/).

**What is the data source for your Instant Answer? (Provide a link if possible)**

http://daemianmack.com/magit-cheatsheet.html

**Why did you choose this data source?**

It's the cheat sheet that I always end up using.

**Are there any other alternative (better) data sources?**

The manual itself, but that sort of defeats the purpose of a cheat sheet.

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**

Programmers / Emacs users.

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**

Not that I know of.

**Are you having any problems? Do you need our help with anything?**

Nope!

**Where did you hear about DuckDuckHack? (For first time contributors)**

I've been on the duckduckgo mailing list for years, and have just never contributed.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**

![magit cheat sheet](https://i.imgur.com/xYF2CMJ.png)

-----
IA Page: https://duck.co/ia/view/magit_cheat_sheet