### PR TITLE
add cheat sheet for GitHub

### DIFF
--- a/share/goodie/cheat_sheets/json/github.json
+++ b/share/goodie/cheat_sheets/json/github.json
@@ -1,0 +1,193 @@
+{
+    "id": "github_cheat_sheet",
+    "name": "GitHub",
+    "metadata": {
+        "sourceName": "Using keyboard shortcuts",
+        "sourceUrl": "https://help.github.com/articles/using-keyboard-shortcuts/"
+    },
+    "template_type": "keyboard",
+    "section_order": [
+        "Site wide shortcuts",
+        "Repositories",
+        "Source code browsing",
+        "Issues",
+        "Browsing commits",
+        "Commit list",
+        "Dashboards",
+        "Notifications",
+        "Pull request list",
+        "Network Graph"
+    ],
+    "sections": {
+        "Site wide shortcuts": [{
+            "val": "Focus search bar",
+            "key": "s"
+        }, {
+            "val": "Go to Notifications",
+            "key": "[g] [n]"
+        }, {
+            "val": "Go to Dashboard",
+            "key": "[g] [d]"
+        }, {
+            "val": "Show keyboard shortcuts",
+            "key": "?"
+        }, {
+            "val": "Move selection down",
+            "key": "j"
+        }, {
+            "val": "Move selection up",
+            "key": "k"
+        }, {
+            "val": "Toggle selection",
+            "key": "x"
+        }, {
+            "val": "Open selection",
+            "key": "[o] / [enter]"
+        }],
+
+        "Repositories": [{
+            "val": "Go to Code",
+            "key": "[g] [c]"
+        }, {
+            "val": "Go to Issues",
+            "key": "[g] [i]"
+        }, {
+            "val": "Go to Pull Requests",
+            "key": "[g] [p]"
+        }, {
+            "val": "Go to Wiki",
+            "key": "[g] [w]"
+        }],
+
+        "Source code browsing": [{
+            "val": "Activates the file finder",
+            "key": "t"
+        }, {
+            "val": "Jump to line",
+            "key": "l"
+        }, {
+            "val": "Switch branch/tag",
+            "key": "w"
+        }, {
+            "val": "Expand URL to its canonical form (permanent link)",
+            "key": "y"
+        }, {
+            "val": "Show/hide all inline notes",
+            "key": "i"
+        }],
+
+        "Issues": [{
+            "val": "Create an issue",
+            "key": "c"
+        }, {
+            "val": "Focus the issues search bar",
+            "key": "/"
+        }, {
+            "val": "Filter by or edit labels",
+            "key": "l"
+        }, {
+            "val": "Filter by or edit milestones",
+            "key": "m"
+        }, {
+            "val": "Filter by or edit assignee",
+            "key": "a"
+        }, {
+            "val": "Reply (quoting selected text)",
+            "key": "r"
+        }, {
+            "val": "Submit comment",
+            "key": "[Ctrl] [enter]"
+        }, {
+            "val": "Preview comment",
+            "key": "[Ctrl] [Shift] [p]"
+        }, {
+            "val": "Go fullscreen",
+            "key": "[Ctrl] [Shift] [l]"
+        }],
+
+        "Browsing commits": [{
+            "val": "Submit comment",
+            "key": "[Ctrl] [enter]"
+        }, {
+            "val": "Close form",
+            "key": "escape"
+        }, {
+            "val": "Parent commit",
+            "key": "p"
+        }, {
+            "val": "Other parent commit",
+            "key": "o"
+        }],
+
+        "Commit list": [{
+            "val": "Expand URL to its canonical form",
+            "key": "y"
+        }],
+
+        "Dashboards": [{
+            "val": "Go to your issues",
+            "key": "[g] [i]"
+        }, {
+            "val": "Go to your pull requests",
+            "key": "[g] [p]"
+        }],
+
+
+        "Notifications": [{
+            "val": "Mark as read",
+            "key": "[e] / [I] / [y]"
+        }, {
+            "val": "Mute thread",
+            "key": "[Shift] [m]"
+        }],
+
+        "Pull request list": [{
+            "val": "Reply (quoting selected text)",
+            "key": "r"
+        }, {
+            "val": "Focus the pull request search bar",
+            "key": "/"
+        }, {
+            "val": "Open issue",
+            "key": "[o] / [enter]"
+        }, {
+            "val": "Submit comment",
+            "key": "[Ctrl] [enter]"
+        }, {
+            "val": "Preview comment",
+            "key": "[Ctrl] [Shift] [p]"
+        }, {
+            "val": "Go fullscreen",
+            "key": "[Ctrl] [Shift] [l]"
+        }],
+
+        "Network Graph": [{
+            "val": "Scroll left",
+            "key": "[←] / [h]"
+        }, {
+            "val": "Scroll right",
+            "key": "[→] / [l]"
+        }, {
+            "val": "Scroll down",
+            "key": "[↓] / [j]"
+        }, {
+            "val": "Scroll up",
+            "key": "[↑] / [k]"
+        }, {
+            "val": "Scroll all the way down",
+            "key": "[Shift] ([↓] / [j])"
+        }, {
+            "val": "Scroll all the way left",
+            "key": "[Shift] ([←] / [h])"
+        }, {
+            "val": "Scroll all the way right",
+            "key": "[Shift] ([→] / [l])"
+        }, {
+            "val": "Scroll all the way up",
+            "key": "[Shift] ([↑] / [k])"
+        }, {
+            "val": "Scroll all the way down",
+            "key": "[Shift] ([↓] / [j])"
+        }]
+    }
+}


### PR DESCRIPTION
**What does your Instant Answer do?**
Shows the keyboard shortcuts on <https://github.com>.

**What is the data source for your Instant Answer? (Provide a link if possible)**
<https://help.github.com/articles/using-keyboard-shortcuts/> and pressing ? on any github page.

**Why did you choose this data source?**
It's straight from github.

**Are there any other alternative (better) data sources?**
Not aware of any.

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Programmers that use github.

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
No.

**Are you having any problems? Do you need our help with anything?**
I haven't tested all keyboard shortcuts.  One that github reports but doesn't work for me is the "Go fullscreen" in the issues and pull request section.

**Where did you hear about DuckDuckHack? (For first time contributors)**
Had been using DDG for a while, DuckDuckHack was linked somewhere on the website.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![cheat_sheet](https://cloud.githubusercontent.com/assets/6839756/10611368/15c20492-774c-11e5-86e1-e40429ef0768.png)


-----
IA Page: https://duck.co/ia/view/github_cheat_sheet