### PR TITLE
Figlet Hotfix

### DIFF
--- a/lib/DDG/Goodie/FIGlet.pm
+++ b/lib/DDG/Goodie/FIGlet.pm
@@ -32,6 +32,7 @@ closedir DIR;
 # Renders a figlet.
 sub render_figlet {
 	my ($font, $text) = @_;
+	$text = html_enc($text);
 	return Text::FIGlet->new(-f=>$font, -d=>share())->figify(-w=>$width, -A=>$text);
 }
 

--- a/lib/DDG/Goodie/FIGlet.pm
+++ b/lib/DDG/Goodie/FIGlet.pm
@@ -32,7 +32,6 @@ closedir DIR;
 # Renders a figlet.
 sub render_figlet {
 	my ($font, $text) = @_;
-	$text = html_enc($text);
 	return Text::FIGlet->new(-f=>$font, -d=>share())->figify(-w=>$width, -A=>$text);
 }
 
@@ -63,6 +62,7 @@ handle query => sub {
 
 	# Render the FIGlet
 	$figlet = render_figlet($font, $text);
+	$figlet = html_enc($figlet) if grep /^$font$/i, qw(rot13 mnemonic term); #ensure we escape input for plaintext formatted results
 
 	$html = "<div id='figlet-wrapper'><span>Font: </span><span id='figlet-font'>$font</span><pre contenteditable='true'>$figlet</pre></div>";
 


### PR DESCRIPTION
Hotfix for Figlet to plug XSS hole.

Now html encodes text when using one of the 3 plaintext fonts. I decided to only do this for these three fonts so that the output will still look correct in the "bigtext" fonts, like the default Figlet font.

Examples:

Encoded Plaintext
<img width="1447" alt="figlet_term__img_src___favicon_ico__onload__alert_1____at_duckduckgo_and_file_finder" src="https://cloud.githubusercontent.com/assets/873785/10617237/57cdf5fe-7737-11e5-83ae-ec3fc4393e3f.png">

Un-Encoded Non-plaintext
<img width="1439" alt="figlet__img_src___favicon_ico__onload__alert_1____at_duckduckgo_and_file_finder" src="https://cloud.githubusercontent.com/assets/873785/10617243/5dd7801e-7737-11e5-8423-ca65ee04bef6.png">

/cc @nilnilnil 
