### PR TITLE
Add more public DNS providers

### DIFF
--- a/share/goodie/public_dns/README.MD
+++ b/share/goodie/public_dns/README.MD
@@ -1,0 +1,28 @@
+## List of free & public DNS
+
+This readme provides information on how to contribute to the public dns goodie/IA.
+
+### Criterias
+
+Here are the criterias for adding new DNS providers
+
+- Free & public (naturally)
+  - free as in you don't have to pay to use it
+  - public as in you can find it on the internet
+
+- Basic content filtering
+  - Blocking allowed
+    - security : spam, botnets, viruses, malwares, infected/fraudulent sites.
+    - privacy : ad(s) and tracking servers.
+    - other : pornography/adult content
+  - Blocking forbidden
+    - blocking of legitimate and safe content or sites.
+
+
+
+- Other criterias
+  - free registration to have more control over what is filtered
+
+### Issue reporting
+
+If you have any problem, have a look at the [contributing.md] (https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/CONTRIBUTING.md) and open a new issue by going [here] (https://duck.co/ia/view/public_dns) and clicking "Create Issue".

--- a/share/goodie/public_dns/providers.yml
+++ b/share/goodie/public_dns/providers.yml
@@ -119,3 +119,40 @@ PowerNS:
     - 194.145.226.26
     - 77.220.232.44
   ip6: []
+DNSReactor:
+  info_url: http://dnsreactor.net/
+  ip4:
+    - 104.236.210.29
+    - 45.55.155.25
+  ip6: []
+Alternate DNS:
+  info_url: http://www.alternate-dns.com/
+  ip4:
+    - 198.101.242.72
+    - 23.253.163.53
+  ip6: []
+FoolDNS:
+  info_url: http://www.fooldns.com/fooldns-community/english-version/
+  ip4:
+    - 87.118.111.215
+    - 213.187.11.62
+  ip6: []
+SafeDNS:
+  info_url: https://www.safedns.com/features
+  ip4:
+    - 195.46.39.39
+    - 195.46.39.40
+  ip6: []
+Xiala.net:
+  info_url: https://xiala.net/services/dns.html
+  ip4:
+    - 77.109.148.136
+    - 77.109.148.137
+  ip6:
+    - 2001:1620:2078:136::
+    - 2001:1620:2078:137::
+SkyDNS:
+  info_url: https://www.skydns.ru/
+  ip4:
+    - 193.58.251.251
+  ip6: []

--- a/share/goodie/public_dns/providers.yml
+++ b/share/goodie/public_dns/providers.yml
@@ -156,3 +156,15 @@ SkyDNS:
   ip4:
     - 193.58.251.251
   ip6: []
+New Nations:
+  info_url: http://www.new-nations.net/
+  ip4:
+    - 5.45.96.220
+    - 185.82.22.133
+  ip6: []
+BlockAid Public DNS (or PeerDNS):
+  info_url: http://www.blockaid.me/
+  ip4:
+    - 205.204.88.60
+    - 178.21.23.150
+  ip6: []

--- a/share/goodie/public_dns/providers.yml
+++ b/share/goodie/public_dns/providers.yml
@@ -1,18 +1,18 @@
 ---
 Comodo Secure DNS:
-  info_url: http://www.comodo.com/secure-dns/
+  info_url: https://www.comodo.com/secure-dns/
   ip4:
     - 8.26.56.26
     - 8.20.247.20
   ip6: []
-DNS Advantage:
-  info_url: http://dnsadvantage.com
+Neustar DNS Advantage:
+  info_url: https://www.neustar.biz/services/dns-services/free-recursive-dns
   ip4:
     - 156.154.70.1
     - 156.154.71.1
   ip6: []
 Google Public DNS:
-  info_url: http://code.google.com/speed/public-dns/
+  info_url: https://developers.google.com/speed/public-dns/
   ip4:
     - 8.8.8.8
     - 8.8.4.4
@@ -20,13 +20,13 @@ Google Public DNS:
     - 2001:4860:4860::8888
     - 2001:4860:4860::8844
 Norton DNS:
-  info_url: http://dns.norton.com
+  info_url: https://dns.norton.com
   ip4:
     - 198.153.192.1
     - 198.153.194.1
   ip6: []
 OpenDNS:
-  info_url: http://opendns.com/
+  info_url: https://www.opendns.com/
   ip4:
     - 208.67.222.222
     - 208.67.220.220
@@ -42,13 +42,13 @@ DNS.Watch:
     - 2001:1608:10:25::1c04:b12f
     - 2001:1608:10:25::9249:d69b
 FreeDNS:
-  info_url: http://freedns.zone
+  info_url: https://freedns.zone
   ip4:
     - 37.235.1.174
     - 37.235.1.177
   ip6: []
 Verisign:
-  info_url: http://www.verisign.com/en_US/innovation/public-dns/index.xhtml
+  info_url: https://www.verisign.com/en_US/innovation/public-dns/index.xhtml
   ip4:
     - 64.6.64.6
     - 64.6.65.6
@@ -61,3 +61,61 @@ FDN:
     - 80.67.169.12
   ip6:
     - 2001:910:800::12
+Censurfridns:
+  info_url: http://blog.censurfridns.dk/en/ip
+  ip4:
+    - 91.239.100.100
+    - 89.233.43.71
+  ip6:
+    - 2001:67c:28a4::
+    - 2002:d596:2a92:1:71:53::
+puntCAT:
+  info_url: http://www.servidordenoms.cat/
+  ip4:
+    - 109.69.8.51
+  ip6:
+    - 2a00:1508:0:4::9
+SmartViper Public DNS:
+  info_url: http://www.markosweb.com/free-dns/
+  ip4:
+    - 208.76.50.50
+    - 208.76.51.51
+  ip6: []
+Dyn:
+  info_url: https://help.dyn.com/internet-guide-setup/
+  ip4:
+    - 216.146.35.35
+    - 216.146.36.36
+  ip6: []
+GreenTeamDNS:
+  info_url: http://www.greentm.co.uk/
+  ip4:
+    - 81.218.119.11
+    - 209.88.198.133
+  ip6: []
+Hurricane Electric:
+  info_url: https://he.net/
+  ip4:
+    - 74.82.42.42
+  ip6:
+    - 2001:470:20::2
+Level3:
+  info_url: 
+  ip4:
+    - 209.244.0.3
+    - 209.244.0.4
+  ip6: []
+Yandex.DNS:
+  info_url: https://dns.yandex.com/advanced/
+  ip4:
+    - 77.88.8.88
+    - 77.88.8.2
+  ip6:
+    - 2a02:6b8::feed:bad	
+    - 2a02:6b8:0:1::feed:bad	
+PowerNS:
+  info_url: http://www.powerns.de/
+  ip4:
+    - 194.145.226.26
+    - 77.220.232.44
+  ip6: []


### PR DESCRIPTION
What has been changed :
- updated links to newer ones and/or make use of https
- Added a lot of providers according to http://pcsupport.about.com/od/tipstricks/a/free-public-dns-servers.htm among others

I have a few questions before possibly merging :
- Is there a limit to the number of IPv4/6 per provider
  - OpenDNS has two additional basic DNS, Level3 has 4.2.2.1 to 6  

Adding up to four DNS servers would be enough in most case or displaying them with a "show more" button like in other IAs.
- What are the criteria for the providers
  - free & public (naturally)
  - basic filtering allowed (spam, botnets, viruses, malwares and the likes ; even pornography/adult content)
  - any other criteria such as free registration to have more control over what is filtered
- For the ones that offer different filtering policies (Yandex.DNS, OpenDNS, Norton, Comodo) is there a way to show more prominently these choices in the IA  

Adding another attribute to be able to sort by criteria (location, filtering, IPv4/6) would be great.
- Is there any restriction regarding the location of the DNS servers
  - It would be nice to display the DNS from the ISP of a given country (or is it out of the scope of this IA)

Depending of the answers to the above questions, I will modify my PR.

Feel free to tell me if there is anything else I should modify.

-----
IA Page: https://duck.co/ia/view/public_dns