### PR TITLE
#1703 Removed unnecessary alias

### DIFF
--- a/share/goodie/cheat_sheets/json/atom.json
+++ b/share/goodie/cheat_sheets/json/atom.json
@@ -7,7 +7,8 @@
         "sourceUrl": "https://bugsnag.com/blog/atom-editor-cheat-sheet"
     },
     "aliases": [
-        "atom", "github atom", "atom text editor"
+        "github atom",
+        "atom text editor"
     ],
     "template_type": "keyboard",
     "section_order":[


### PR DESCRIPTION
@moollaza this will fix #1703
You was right ```atom``` alias is unnecessary, it works without that.