### PR TITLE
Is website up or down Goodie 

### DIFF
--- a/lib/DDG/Goodie/ISUP.pm
+++ b/lib/DDG/Goodie/ISUP.pm
@@ -1,0 +1,54 @@
+package DDG::Goodie::ISUP;
+
+use DDG::Goodie;
+use LWP::Simple;
+use strict;
+
+zci answer_type => "isup";
+zci is_cached   => 1;
+
+name "ISUP";
+description "Check if website is onine or not";
+primary_example_queries "isup duckduckgo.com", "isup https://duckduckgo.com";
+secondary_example_queries "online duckduckgo.com";
+topics 'computing';
+category 'computing_info';
+code_url "https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Isup.pm";
+attribution github => ["https://github.com/codenirvana", "Udit Vasu"],
+            twitter => "uditdistro";
+
+triggers any => "isup", "isdown", "online", "is up", "is down";
+
+# Handle statement
+handle remainder => sub {
+
+    return unless $_;
+    
+    my $url = $_;
+    
+    if (!( $url =~ /^htt(p|ps):\/\/.*$/ )) {
+        $url = 'http://' . $url
+    }
+ 
+    # URL Validator Regex, from: http://regexlib.com/REDetails.aspx?regexp_id=1854
+    return unless ( $url =~ /^(http(?:s)?\:\/\/[a-zA-Z0-9]+(?:(?:\.|\-)[a-zA-Z0-9]+)+(?:\:\d+)?(?:\/[\w\-]+)*(?:\/?|\/\w+\.[a-zA-Z]{2,4}(?:\?[\w]+\=[\w\-]+)?)?(?:\&[\w]+\=[\w\-]+)*)$/ );
+   
+    if ( head($url)) {
+        return "Seems up!",
+          structured_answer => {
+            input     => [],
+            operation => $_,
+            result    => 'Seems up!'
+        };
+    } else{
+        return "Seems to be down!",
+          structured_answer => {
+            input     => [],
+            operation => $_,
+            result    => 'Seems to be down!'
+        };
+    }
+    
+};
+
+1;

--- a/lib/DDG/Goodie/ISUP.pm
+++ b/lib/DDG/Goodie/ISUP.pm
@@ -8,16 +8,16 @@ zci answer_type => "isup";
 zci is_cached   => 1;
 
 name "ISUP";
-description "Check if website is onine or not";
-primary_example_queries "isup duckduckgo.com", "isup https://duckduckgo.com";
-secondary_example_queries "online duckduckgo.com";
+description "Check if given URL is onine or not";
+primary_example_queries "isup duckduckgo.com", "is up https://duckduckgo.com";
+secondary_example_queries "online duckduckgo.com", "github.com is down";
 topics 'computing';
 category 'computing_info';
-code_url "https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/Isup.pm";
+code_url "https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/ISUP.pm";
 attribution github => ["https://github.com/codenirvana", "Udit Vasu"],
             twitter => "uditdistro";
 
-triggers any => "isup", "isdown", "online", "is up", "is down";
+triggers any => "isup", "isdown", "is up", "is down", "online";
 
 # Handle statement
 handle remainder => sub {
@@ -26,6 +26,7 @@ handle remainder => sub {
     
     my $url = $_;
     
+    # Prefix http:// if not present
     if (!( $url =~ /^htt(p|ps):\/\/.*$/ )) {
         $url = 'http://' . $url
     }
@@ -33,6 +34,7 @@ handle remainder => sub {
     # URL Validator Regex, from: http://regexlib.com/REDetails.aspx?regexp_id=1854
     return unless ( $url =~ /^(http(?:s)?\:\/\/[a-zA-Z0-9]+(?:(?:\.|\-)[a-zA-Z0-9]+)+(?:\:\d+)?(?:\/[\w\-]+)*(?:\/?|\/\w+\.[a-zA-Z]{2,4}(?:\?[\w]+\=[\w\-]+)?)?(?:\&[\w]+\=[\w\-]+)*)$/ );
    
+    # Request URL
     if ( head($url)) {
         return "Seems up!",
           structured_answer => {

--- a/t/ISUP.t
+++ b/t/ISUP.t
@@ -1,0 +1,44 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Goodie;
+use LWP::Simple;
+
+zci answer_type => "isup";
+zci is_cached   => 1;
+
+ddg_goodie_test(
+    [qw( DDG::Goodie::ISUP )],
+    'isup duck.co' => test_zci(
+        'Seems up!',
+        structured_answer => {
+            input     => [],
+            operation => 'duck.co',
+            result    => 'Seems up!'
+        }
+    ),
+    'isup http://www.duckduckduck.com' => test_zci(
+        'Seems to be down!',
+        structured_answer => {
+            input     => [],
+            operation => 'http://www.duckduckduck.com',
+            result    => 'Seems to be down!'
+        }
+    ),
+    'isup codenirvana.net/p/contact-us.html' => test_zci(
+        'Seems up!',
+        structured_answer => {
+            input     => [],
+            operation => 'codenirvana.net/p/contact-us.html',
+            result    => 'Seems up!'
+        }
+    ),
+    'isup 123'    => undef,
+    'isup httpxyz://github.com' => undef,
+    'isup xyz' => undef,
+    'isup https://github' => undef,
+);
+
+done_testing;

--- a/t/ISUP.t
+++ b/t/ISUP.t
@@ -27,12 +27,44 @@ ddg_goodie_test(
             result    => 'Seems to be down!'
         }
     ),
-    'isup codenirvana.net/p/contact-us.html' => test_zci(
+    'isdown www.codenirvana.net' => test_zci(
         'Seems up!',
         structured_answer => {
             input     => [],
-            operation => 'codenirvana.net/p/contact-us.html',
+            operation => 'www.codenirvana.net',
             result    => 'Seems up!'
+        }
+    ),
+    'online codenirvana.net' => test_zci(
+        'Seems up!',
+        structured_answer => {
+            input     => [],
+            operation => 'codenirvana.net',
+            result    => 'Seems up!'
+        }
+    ),
+    'https://duck.co is down' => test_zci(
+        'Seems up!',
+        structured_answer => {
+            input     => [],
+            operation => 'https://duck.co',
+            result    => 'Seems up!'
+        }
+    ),
+    'is up www.gitduck.com' => test_zci(
+        'Seems up!',
+        structured_answer => {
+            input     => [],
+            operation => 'www.gitduck.com',
+            result    => 'Seems to be down!'
+        }
+    ),
+    'is down www.gitduck.com' => test_zci(
+        'Seems up!',
+        structured_answer => {
+            input     => [],
+            operation => 'www.gitduck.com',
+            result    => 'Seems to be down!'
         }
     ),
     'isup 123'    => undef,


### PR DESCRIPTION
**What does your Instant Answer do?**
Check if given URL is onine or not

**What problem does your Instant Answer solve (Why is it better than organic links)?**
Provides the status of URL user looking for.

**What are some example queries that trigger this Instant Answer?**
"isup duckduckgo.com", "is up https://duckduckgo.com",  "online duckduckgo.com", "github.com is down"

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Geeks, computing_info, Web Dev

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**
Yes, [Check if a site is online](https://duck.co/ideas/idea/6602/check-if-a-site-is-online)

**Which existing Instant Answers will this one supercede/overlap with?**
This will overlap !isup bang

**Are you having any problems? Do you need our help with anything?**
Yes I want to add multiple trigger like this- :start-trigger: query :end-trigger:

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![screenshot ](https://cloud.githubusercontent.com/assets/4865836/10799574/8e27d47e-7dd3-11e5-9a0a-da56181e30ab.JPG)