### PR TITLE
Move CheatSheet tests into subdir, rename JSON test

### DIFF
--- a/t/CheatSheets/CheatSheets.t
+++ b/t/CheatSheets/CheatSheets.t
@@ -15,18 +15,18 @@ sub getTests {
                                 ->name("*.json")
                                 ->in('share/goodie/cheat_sheets/json/');
     my %tests;
-    
+
     foreach my $file (@files) {
         open my $fh, $file or return;
         my $json = do { local $/;  <$fh> };
         my $data = decode_json($json);
-        
+
         my $defaultName = File::Basename::fileparse($file);
         $defaultName =~ s/-/ /g;
         $defaultName =~ s/.json//;
-        
+
         $tests{$defaultName." cheat sheet"} = test_zci(build_answer($data));
-        
+
         if ($data->{'aliases'}) {
             foreach my $alias (@{$data->{'aliases'}}) {
                 $tests{$alias." cheat sheet"} = test_zci(build_answer($data));
@@ -38,7 +38,7 @@ sub getTests {
 
 sub build_answer {
     my ($data) = @_;
-    
+
     return 'Cheat Sheet', structured_answer => {
         id => 'cheat_sheets',
         dynamic_id => $data->{id},

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -14,8 +14,6 @@ use IO::All;
 my $json_dir = "share/goodie/cheat_sheets/json";
 my $json;
 
-print "Testing CheatSheet JSON Files";
-
 # Iterate over all Cheat Sheet JSON files...
 foreach my $path (glob("$json_dir/*.json")){
     next if $ARGV[0] && $path ne  "$json_dir/$ARGV[0].json";

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -14,6 +14,9 @@ use IO::All;
 my $json_dir = "share/goodie/cheat_sheets/json";
 my $json;
 
+print "Testing CheatSheet JSON Files";
+
+# Iterate over all Cheat Sheet JSON files...
 foreach my $path (glob("$json_dir/*.json")){
     next if $ARGV[0] && $path ne  "$json_dir/$ARGV[0].json";
 
@@ -23,7 +26,7 @@ foreach my $path (glob("$json_dir/*.json")){
     ### File tests ###
     my $temp_pass = (my $content < io($path))? 1 : 0;
     push(@tests, {msg => 'file content can be read', critical => 1, pass => $temp_pass});
- 
+
     $temp_pass = ($json = decode_json($content))? 1 : 0;
     push(@tests, {msg => 'content is valid JSON', critical => 1, pass => $temp_pass});
 
@@ -31,17 +34,17 @@ foreach my $path (glob("$json_dir/*.json")){
     ### Headers tests ###
     $temp_pass = (exists $json->{id} && $json->{id})? 1 : 0;
     push(@tests, {msg => 'has id', critical => 1, pass => $temp_pass});;
-    
+
     $temp_pass = (exists $json->{name} && $json->{name})? 1 : 0;
     push(@tests, {msg => 'has name', critical => 1, pass => $temp_pass});
-    
+
     $temp_pass = (!exists $json->{description} && !$json->{description})? 0 : 1;
     push(@tests, {msg => "has description (optional but suggested)", critical => 0, pass => $temp_pass});
 
 
     ### Metadata tests ###
     my $has_meta = exists $json->{metadata};
-    
+
     $temp_pass = $has_meta? 1 : 0;
     push(@tests, {msg => 'has metadata (optional but suggested)', critical => 0, pass => $temp_pass, skip => 1});
 
@@ -50,7 +53,7 @@ foreach my $path (glob("$json_dir/*.json")){
 
     $temp_pass = exists $json->{metadata}{sourceUrl}? 1 : 0;
     push(@tests, {msg => "has metadata sourceUrl $name", critical => 0, pass => $temp_pass, skip => 1});
-    
+
     $temp_pass = (my $url = $json->{metadata}{sourceUrl})? 1 : 0;
     push(@tests, {msg => "sourceUrl is not undef $name", critical => 1, pass => $temp_pass, skip => 1});;
 
@@ -58,7 +61,7 @@ foreach my $path (glob("$json_dir/*.json")){
     ### Sections tests ###
     $temp_pass = (my $order = $json->{section_order})? 1 : 0;
     push(@tests, {msg => 'has section_order', critical => 1, pass => $temp_pass});
-      
+
     $temp_pass = (ref $order eq 'ARRAY')? 1 : 0;
     push(@tests, {msg => 'section_order is an array of section names', critical => 1, pass => $temp_pass});
 
@@ -71,18 +74,18 @@ foreach my $path (glob("$json_dir/*.json")){
     $temp_pass = (ref $sections eq 'HASH')? 1 : 0;
     push(@tests, {msg => 'sections is a hash of section key/pairs', critical => 1, pass => $temp_pass});
 
-    map{ 
-        $sections->{lc$_} = $sections->{$_}; 
+    map {
+        $sections->{lc$_} = $sections->{$_};
         delete $sections->{$_};
     } keys $sections;
-  
+
     for my $section_name (@$order) {
         push(@tests, {msg => "Expected '$section_name' but not found", critical => 0, pass => 0})  unless $sections->{$section_name};
     }
 
     for my $section_name (keys %$sections) {
         push(@tests, {msg => "Section '$section_name' defined, but not listed in section_order", critical => 0, pass => 0}) unless grep(/\Q$section_name\E/, @$order);
-     
+
         $temp_pass = (ref $sections->{$section_name} eq 'ARRAY')? 1 : 0;
         push(@tests, {msg => "'$section_name' is an array from $name",  critical => 1, pass => $temp_pass});
 
@@ -90,7 +93,7 @@ foreach my $path (glob("$json_dir/*.json")){
         for my $entry (@{$sections->{$section_name}}) {
             # Only show it when it fails, otherwise it clutters the output
             push(@tests, {msg => "'$section_name' entry: $entry_count has a key from $name", critical => 1, pass => 0}) unless exists $entry->{key};
-            
+
             #push(@tests, {msg => "'$section_name' entry: $entry_count has a val from $name", critical => 1, pass => 0}) unless exists $entry->{val};
             $entry_count++;
         }
@@ -98,7 +101,7 @@ foreach my $path (glob("$json_dir/*.json")){
 
 
     $sections = $json->{sections};
-    
+
     for my $section_name (keys %{$sections}) {
         for my $entry (@{$sections->{$section_name}}){
             # spacing in keys ([a]/[b])'
@@ -141,16 +144,17 @@ sub print_results {
             if (!$test->{pass}) {
                 if ($ok) {
                     $ok = 0;
-                    diag colored(["reset"], "Testing " . $name . "...........NOT OK");
                 }
 
                 if ($test->{critical}) {
+                    diag colored(["red"], "Testing " . $name . "...........NOT OK");
                     $temp_color = "red";
                     $temp_msg = "FAIL: " . $temp_msg;
                     %result = (pass => 0, msg => $temp_msg);
                     diag colored([$temp_color], "\t -> " . $temp_msg);
                     return \%result;
                 } else {
+                    diag colored(["green"], "Testing " . $name . "...........OK");
                     $temp_color = "yellow";
                     $temp_msg = "WARN: " . $temp_msg;
                     diag colored([$temp_color], "\t -> " . $temp_msg);
@@ -164,8 +168,7 @@ sub print_results {
     if ($ok) {
         diag colored(["green"], "Testing " . $name . "..........OK");
     }
-    
-    diag colored(["reset"], "\n");
+
     return \%result;
 }
 done_testing;


### PR DESCRIPTION
- Moved the tests into a new subdir
- Renamed `cheatsheets_check.t` -> `CheatSheetsJSON.t`
- Print green OK status when only non-fatal WARN's exist
- Remove newline between test to compact output (like regular Perl tests)

to @zachthompson 
/cc @jdorweiler @MariagraziaAlastra 
