### PR TITLE
New Note Frequency Goodie

### DIFF
--- a/lib/DDG/Goodie/NoteFrequency.pm
+++ b/lib/DDG/Goodie/NoteFrequency.pm
@@ -1,0 +1,88 @@
+package DDG::Goodie::NoteFrequency;
+# ABSTRACT: Return the frequency (Hz) of the note given in the query
+
+use DDG::Goodie;
+use strict;
+
+zci answer_type => "note_frequency";
+zci is_cached   => 1;
+
+name "NoteFrequency";
+description "Calculate the frequency of a musical note";
+primary_example_queries "notefreq a4", "notefreq gb5";
+secondary_example_queries "notefreq c3 432";
+category "conversions";
+topics "music";
+code_url "https://github.com/duckduckgo/zeroclickinfo-goodies/blob/master/lib/DDG/Goodie/NoteFrequency.pm";
+attribution github => ["sublinear", "sublinear"];
+
+# Triggers
+triggers any => "notefreq", "notefrequency", "note frequency", "note frequency of", "frequency of note";
+
+# Handle statement
+handle remainder => sub {
+
+    return unless $_;
+
+    # must be a note letter, optional sharp or flat, octave number, and optional tuning frequency for A4
+    # e.g. "g#3 432"
+
+    if ( $_ =~ /^([A-Ga-g])([b#])?([0-8])(\s+[0-9]{1,5})?$/ ) {
+
+        my( $letter, $accidental, $octave, $tuning, $pitchClass, $midi, $frequency );
+
+        # regex captures
+        if (defined $1) { $letter     = uc($1); } else { $letter     = ""; }
+        if (defined $2) { $accidental = $2;     } else { $accidental = "";  }
+        if (defined $3) { $octave     = $3 + 0; } else { $octave     = 0;   }
+        if (defined $4) { $tuning     = $4 + 0; } else { $tuning     = 0;   }
+
+        # assume 440Hz tuning unless otherwise specified
+        if ( $tuning == 0 ) { $tuning = 440; }
+
+        # convert note letter to pitch class number
+        if    ( $letter eq "C" ) { $pitchClass = 0;  }
+        elsif ( $letter eq "D" ) { $pitchClass = 2;  }
+        elsif ( $letter eq "E" ) { $pitchClass = 4;  }
+        elsif ( $letter eq "F" ) { $pitchClass = 5;  }
+        elsif ( $letter eq "G" ) { $pitchClass = 7;  }
+        elsif ( $letter eq "A" ) { $pitchClass = 9;  }
+        else                     { $pitchClass = 11; }
+
+        # apply accidental to pitch class number
+        if    ( $accidental eq "b" ) { $pitchClass -= 1; }
+        elsif ( $accidental eq "#" ) { $pitchClass += 1; }
+
+        # calculate MIDI number
+        $midi = ( 12 * ($octave + 1) ) + $pitchClass;
+
+        # fix pitch class number
+        $pitchClass %= 12;
+
+        # validate note is between C0 and B8
+        if ( $midi >= 12 && $midi <= 119 ) {
+            # calculate frequency
+            $frequency = $tuning * ( 2 ** (($midi-69)/12) );
+
+            # result
+            return $frequency,
+                structured_answer => {
+                    input => [html_enc($letter.$accidental.$octave." in ".$tuning."Hz tuning")],
+                    operation => "Note Frequency",
+                    result => html_enc($frequency." Hz"),
+                };
+        }
+
+        # failed midi range validation
+        return;
+    }
+
+    else {
+
+        # failed regular expression
+        return;
+
+    }
+};
+
+1;

--- a/lib/DDG/Goodie/NoteFrequency.pm
+++ b/lib/DDG/Goodie/NoteFrequency.pm
@@ -33,9 +33,9 @@ handle remainder => sub {
 
         # regex captures
         if (defined $1) { $letter     = uc($1); } else { $letter     = ""; }
-        if (defined $2) { $accidental = $2;     } else { $accidental = "";  }
-        if (defined $3) { $octave     = $3 + 0; } else { $octave     = 0;   }
-        if (defined $4) { $tuning     = $4 + 0; } else { $tuning     = 0;   }
+        if (defined $2) { $accidental = $2;     } else { $accidental = ""; }
+        if (defined $3) { $octave     = $3 + 0; } else { $octave     = 0;  }
+        if (defined $4) { $tuning     = $4 + 0; } else { $tuning     = 0;  }
 
         # assume 440Hz tuning unless otherwise specified
         if ( $tuning == 0 ) { $tuning = 440; }

--- a/lib/DDG/Goodie/NoteFrequency.pm
+++ b/lib/DDG/Goodie/NoteFrequency.pm
@@ -67,7 +67,7 @@ handle remainder => sub {
             # result
             return $frequency,
                 structured_answer => {
-                    input => [html_enc($letter.$accidental.$octave." in ".$tuning."Hz tuning")],
+                    input => [html_enc($letter.$accidental.$octave." in A".$tuning." tuning")],
                     operation => "Note Frequency",
                     result => html_enc($frequency." Hz"),
                 };

--- a/t/NoteFrequency.t
+++ b/t/NoteFrequency.t
@@ -10,9 +10,27 @@ zci is_cached   => 1;
 
 ddg_goodie_test(
     [qw( DDG::Goodie::NoteFrequency )],
-    "notefreq a4" => test_zci("440"),
-    "notefreq gb5" => test_zci("739.988845423269"),
-    "notefreq c3 432" => test_zci("128.434368420294"),
+    "notefreq a4" => test_zci(
+        "440",
+        structured_answer => {
+            input     => ["A4 in A440 tuning"],
+            operation => "Note Frequency",
+            result    => "440 Hz"
+        }),
+    "notefreq gb5" => test_zci(
+        "739.988845423269",
+        structured_answer => {
+            input     => ["Gb5 in A440 tuning"],
+            operation => "Note Frequency",
+            result    => "739.988845423269 Hz"
+        }),
+    "notefreq c3 432" => test_zci(
+        "128.434368420294",
+        structured_answer => {
+            input     => ["C3 in A432 tuning"],
+            operation => "Note Frequency",
+            result    => "128.434368420294 Hz"
+        }),
     "notefreq a4 100000" => undef,
     "notefreq b#8" => undef,
     "notefreq cb0" => undef,

--- a/t/NoteFrequency.t
+++ b/t/NoteFrequency.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Goodie;
+
+zci answer_type => "note_frequency";
+zci is_cached   => 1;
+
+ddg_goodie_test(
+    [qw( DDG::Goodie::NoteFrequency )],
+    "notefreq a4" => test_zci("440"),
+    "notefreq gb5" => test_zci("739.988845423269"),
+    "notefreq c3 432" => test_zci("128.434368420294"),
+    "notefreq a4 100000" => undef,
+    "notefreq b#8" => undef,
+    "notefreq cb0" => undef,
+    "notefreq c9" => undef,
+);
+
+done_testing;

--- a/t/NoteFrequency.t
+++ b/t/NoteFrequency.t
@@ -31,6 +31,14 @@ ddg_goodie_test(
             operation => "Note Frequency",
             result    => "128.43 Hz"
         }),
+    "notefreq c3 432Hz" => test_zci(
+        "128.43",
+        structured_answer => {
+            input     => ["C3 in A432 tuning"],
+            operation => "Note Frequency",
+            result    => "128.43 Hz"
+        }),
+    "notefreq c3 432  Hz" => undef,
     "notefreq a4 100000" => undef,
     "notefreq b#8" => undef,
     "notefreq cb0" => undef,

--- a/t/NoteFrequency.t
+++ b/t/NoteFrequency.t
@@ -18,18 +18,18 @@ ddg_goodie_test(
             result    => "440 Hz"
         }),
     "notefreq gb5" => test_zci(
-        "739.988845423269",
+        "739.99",
         structured_answer => {
             input     => ["Gb5 in A440 tuning"],
             operation => "Note Frequency",
-            result    => "739.988845423269 Hz"
+            result    => "739.99 Hz"
         }),
     "notefreq c3 432" => test_zci(
-        "128.434368420294",
+        "128.43",
         structured_answer => {
             input     => ["C3 in A432 tuning"],
             operation => "Note Frequency",
-            result    => "128.434368420294 Hz"
+            result    => "128.43 Hz"
         }),
     "notefreq a4 100000" => undef,
     "notefreq b#8" => undef,


### PR DESCRIPTION
**What does your Instant Answer do?**

Calculates the frequency in hertz of any musical note.

**What problem does your Instant Answer solve (Why is it better than organic links)?**

The typical search results are static tables hosted on aging websites for a limited selection of tuning frequencies. This instant answer calculates the frequency for any note in any tuning.

**What is the data source for your Instant Answer? (Provide a link if possible)**

Goodie perl script.

**Why did you choose this data source?**

Because it's a goodie, and not a spice.

**Are there any other alternative (better) data sources?**

No.

**What are some example queries that trigger this Instant Answer?**

"note frequency of c5", "frequency of note c5 432", "notefreq g#6"

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**

Musicians and educators.

**Is this Instant Answer connected to a DuckDuckHack [Instant Answer idea](https://duck.co/ideas)?**

No.

**Which existing Instant Answers will this one supercede/overlap with?**

None.

**Are you having any problems? Do you need our help with anything?**

No. I don't think so.

**Where did you hear about DuckDuckHack? (For first time contributors)**

DuckDuckGo homepage.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**

![screenshot from 2015-11-06 15 43 27](https://cloud.githubusercontent.com/assets/9429614/11009942/dedf6c0a-84a0-11e5-8a7e-2e6b77428c14.png)

## Checklist
Please place an 'X' where appropriate.

```
- [X] Added metadata and attribution information (https://duck.co/duckduckhack/metadata)
- [X] Wrote test file and added to t/ directory (https://duck.co/duckduckhack/goodie_tests)
- [X] Verified that instant answer adheres to design guidelines (https://duck.co/duckduckhack/design_styleguide)
- [X] Verified that instant answer adheres to code styleguide (https://duck.co/duckduckhack/code_styleguide)
- [X] Tested cross-browser compatibility

    Please let us know which browsers/devices you've tested on:
    - Windows 10
        - [X] Google Chrome
        - [X] Firefox
        - [] Opera
        - [] IE 11
        - [] Microsoft edge
        
    - Windows 8
        - [] Google Chrome
        - [] Firefox
        - [] Opera
        - [] IE 10

    - Windows 7
        - [] Google Chrome
        - [] Firefox
        - [] Opera
        - [] IE 8
        - [] IE 9
        - [] IE 10

    - Windows XP
        - [] IE 7
        - [] IE 8

    - Linux
        - [X] Google Chrome
        - [X] Firefox
        
    - Mac OSX
        - [] Google Chrome
        - [] Firefox
        - [] Opera
        - [] Safari

    - iOS (iPhone)
        - [] Safari Mobile
        - [] Google Chrome
        - [] Opera

    - iOS (iPad)
        - [] Safari Mobile
        - [] Google Chrome
        - [] Opera

    - Android
        - [] Firefox
        - [] Native Browser
        - [X] Google Chrome
        - [X] Opera

```

-----
IA Page: https://duck.co/ia/view/note_frequency