### PR TITLE
CheatSheets: Don't add the .sep--after class if there is no sourceUrl.

### DIFF
--- a/share/goodie/cheat_sheets/detail.handlebars
+++ b/share/goodie/cheat_sheets/detail.handlebars
@@ -11,7 +11,7 @@
 </div>
 
 <div class="cheatsheet__footer c-list__links">
-    <a class="c-list__link  chomp--link  sep--after can-expand">
+    <a class="c-list__link  chomp--link  {{#if metadata.sourceUrl}}sep--after{{/if}} can-expand">
         <i class="chomp--link__icn"></i>
         <span class="chomp--link__mr">Show More</span>
         <span class="chomp--link__ls">Show Less</span>


### PR DESCRIPTION
We're doing this because we don't want to add a separator if we don't have any "More at ..." link.

Before:
<img width="1552" alt="screen shot 2015-11-13 at 9 43 50 am" src="https://cloud.githubusercontent.com/assets/81969/11148509/13909826-89eb-11e5-867f-ec632d1eda91.png">

After:
<img width="1552" alt="screen shot 2015-11-13 at 9 43 36 am" src="https://cloud.githubusercontent.com/assets/81969/11148514/178be94e-89eb-11e5-981d-2c31d3000591.png">

![giphy](https://cloud.githubusercontent.com/assets/81969/11148597/8e596312-89eb-11e5-9873-dcf4fedcc0c8.gif)
