### PR TITLE
Disable LWP SSL host verification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 sudo: false
+env:
+  - PERL_LWP_SSL_VERIFY_HOSTNAME=0
 cache:
   directories:
     - $HOME/.cpanm


### PR DESCRIPTION
So we can use HTTPS with S3 and not fail travis tests, disable host verification for travis only.