### PR TITLE
remove aliases from ubuntu.json that should trigger ubuntu-unity.json

### DIFF
--- a/share/goodie/cheat_sheets/json/ubuntu.json
+++ b/share/goodie/cheat_sheets/json/ubuntu.json
@@ -6,9 +6,6 @@
         "sourceName": "Ubuntu Unity",
         "sourceUrl": "http://www.cheat-sheets.org/saved-copy/ubunturef.pdf"
     },
-     "aliases": [
-        "ubuntu unity", "unity ubuntu"
-    ],
     "template_type": "terminal",
     "section_order": [
         "Privileges",

--- a/share/goodie/cheat_sheets/json/ubuntu.json
+++ b/share/goodie/cheat_sheets/json/ubuntu.json
@@ -3,7 +3,7 @@
     "name": "Linux Ubuntu",
     "description": "Ubuntu Reference",
     "metadata": {
-        "sourceName": "Ubuntu Unity",
+        "sourceName": "Cheat-Sheets.org",
         "sourceUrl": "http://www.cheat-sheets.org/saved-copy/ubunturef.pdf"
     },
     "template_type": "terminal",


### PR DESCRIPTION
This is a really weird edge case that likely won't occur again, but we should probably have the tests ensure that no alias maps to another cheat sheet (or that no aliases already exist elsewhere)

In most cases the correct IA was triggering, but on a few machines, the ubuntu.json triggered, causing problems because `ubuntu unity cheat sheet` is expected to trigger `ubuntu-unity.json`

/cc @zachthompson @jdorweiler 