### PR TITLE
New Cheat Sheet for Default Port Numbers in Networks

### DIFF
--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -1,20 +1,20 @@
 {
     "id": "default_port_numbers_cheat_sheet",
-    "name": "Default Port Numbers",
-    "description": "List of port numbers used in computer networks",
+    "name": "Standard Port Numbers",
+    "description": "List of official TCP and UDP Port Numbers",
     "metadata": {
         "sourceName": "Wikipedia",
         "sourceUrl": "https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers"
     },
     "aliases": [
-    "default port", "network ports" 
+        "default port", "network ports", "tcp ports", "udp ports", "tcp port numbers", "udp port numbers" 
     ],
-    "template_type": "keyboard",
+    "template_type": "reference",
     "section_order": [
-        "Well Known Protocols", "Registered Protocols"
+        "Well Known Protocols (Standard Ports)", "Registered Ports"
     ],
     "sections": {
-        "Well Known Protocols": [{
+        "Well Known Protocols (Standard Ports)": [{
             "val": "FTP Data Transfer",
             "key": "20"
         }, {
@@ -27,7 +27,7 @@
             "val": "Telnet Protocol",
             "key": "23"
         }, {
-            "val": "Simple Mail Transfer Protocol",
+            "val": "Simple Mail Transfer Protocol (SMTP)",
             "key": "25"
         }, {
             "val": "Domain Name System (DNS)",
@@ -42,8 +42,11 @@
             "val": "Hypertext Transfer Protocol (HTTP)",
             "key": "80"
         }, {
-            "val": "Internet Message Access Protocol",
+            "val": "Internet Message Access Protocol (IMAP)",
             "key": "143"
+        }, {
+            "val": "Internet Relay Chat (IRC)",
+            "key": "194"
         }, {
             "val": "Hypertext Transfer Protocol over TLS/SSL (HTTPS)",
             "key": "443"
@@ -54,7 +57,7 @@
             "val": "Telnet Protocol over TLS/SSL",
             "key": "992"
         }],
-        "Registered Protocols": [{
+        "Registered Ports": [{
             "val": "SOCKS Proxy",
             "key": "1080"
         }, {

--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -1,0 +1,50 @@
+{
+    "id": "default_port_numbers",
+    "name": "Default Port Numbers",
+    "description": "Default port numbers in networking",
+    "metadata": {
+        "sourceName": "Wikipedia",
+        "sourceUrl": "https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers"
+    },
+	
+	"aliases": [
+		"default port numbers", "default port", 
+	],
+    "template_type": "keyboard",
+    "section_order": [
+        "Default Port Numbers"
+    ],
+    "sections": {
+        "Default Port Numbers": [{
+            "val": "FTP Data Transfer",
+            "key": "20"
+        }, {
+            "val": "FTP control (command)",
+            "key": "21"
+        }, {
+            "val": "Secure Shell (SSH)"
+            "key": "22"
+        }, {
+            "val": "Telnet Protocol",
+            "key": "23"
+        }, {
+            "val": "Simple Mail Transfer Protocol",
+            "key": "25"
+        }, {
+            "val": "Domain Name System (DNS)",
+            "key": "53"
+        }, {
+            "val": "Hypertext Transfer Protocol (HTTP)",
+            "key": "80"
+        }, {
+            "val": "Internet Message Access Protocol",
+            "key": "143"
+        }, {
+            "val": "Hypertext Transfer Protocol over TLS/SSL (HTTPS)",
+            "key": "443"
+        }, {
+            "val": "Remote Procedure Call (RPC)",
+            "key": "530"
+        }]
+    }
+}

--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -11,7 +11,8 @@
     ],
     "template_type": "reference",
     "section_order": [
-        "Well Known Protocols (Standard Ports)", "Registered Ports"
+        "Well Known Protocols (Standard Ports)",
+        "Registered Ports"
     ],
     "sections": {
         "Well Known Protocols (Standard Ports)": [{

--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -7,11 +7,11 @@
         "sourceUrl": "https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers"
     },
     "aliases": [
-        "default port", "network ports", "tcp ports", "udp ports", "tcp port numbers", "udp port numbers" 
+        "default ports", "network ports", "tcp ports", "udp ports", "tcp port numbers", "udp port numbers"
     ],
     "template_type": "reference",
     "section_order": [
-        "Well Known Protocols (Standard Ports)",
+        "Well Known Ports (System Ports)",
         "Registered Ports"
     ],
     "sections": {

--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -7,7 +7,7 @@
         "sourceUrl": "https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers"
     },
     "aliases": [
-	"default port", "default port number", "network ports" 
+	"default port", "network ports" 
     ],
     "template_type": "keyboard",
     "section_order": [

--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -7,7 +7,7 @@
         "sourceUrl": "https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers"
     },
     "aliases": [
-	"default port", "network ports" 
+    "default port", "network ports" 
     ],
     "template_type": "keyboard",
     "section_order": [
@@ -33,12 +33,12 @@
             "val": "Domain Name System (DNS)",
             "key": "53"
         }, {
-		    "val": "Dynamic Host Configuration Protocol (DHCP) Server",
-		    "key": "67"
-		}, {
-		    "val": "Dynamic Host Configuration Protocol (DHCP) Client",
-		    "key": "68"
-		}, {
+            "val": "Dynamic Host Configuration Protocol (DHCP) Server",
+            "key": "67"
+        }, {
+            "val": "Dynamic Host Configuration Protocol (DHCP) Client",
+            "key": "68"
+        }, {
             "val": "Hypertext Transfer Protocol (HTTP)",
             "key": "80"
         }, {
@@ -51,24 +51,24 @@
             "val": "Remote Procedure Call (RPC)",
             "key": "530"
         }, {
-		    "val": "Telnet Protocol over TLS/SSL",
-		    "key": "992"
-		}],
-		"Registered Protocols": [{
-			"val": "SOCKS Proxy",
-			"key": "1080"
-		}, {
-			"val": "OpenVPN",
-			"key": "1194"
-		}, {
-			"val": "Internet Protocol Security (IPSec)",
-			"key": "1293"
-		}, {
-			"val": "Real-time Transport Protocol media data (RTP)",
-			"key": "5004"
-		}, {
-			"val": "Real-time Transport Protocol control protocol (RTCP)",
-			"key": "5005"
-		}]
+            "val": "Telnet Protocol over TLS/SSL",
+            "key": "992"
+        }],
+        "Registered Protocols": [{
+            "val": "SOCKS Proxy",
+            "key": "1080"
+        }, {
+            "val": "OpenVPN",
+            "key": "1194"
+        }, {
+            "val": "Internet Protocol Security (IPSec)",
+            "key": "1293"
+        }, {
+            "val": "Real-time Transport Protocol media data (RTP)",
+            "key": "5004"
+        }, {
+            "val": "Real-time Transport Protocol control protocol (RTCP)",
+            "key": "5005"
+        }]
     }
 }

--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -22,7 +22,7 @@
             "val": "FTP control (command)",
             "key": "21"
         }, {
-            "val": "Secure Shell (SSH)"
+            "val": "Secure Shell (SSH)",
             "key": "22"
         }, {
             "val": "Telnet Protocol",
@@ -45,6 +45,9 @@
         }, {
             "val": "Remote Procedure Call (RPC)",
             "key": "530"
-        }]
+        }, {
+			"val": "Telent Protocol over TLS/SSL",
+			"key": "992"
+		}]
     }
 }

--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -8,7 +8,7 @@
     },
 	
 	"aliases": [
-		"default port numbers", "default port", 
+		"default port numbers", "default port" 
 	],
     "template_type": "keyboard",
     "section_order": [

--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -15,7 +15,7 @@
         "Registered Ports"
     ],
     "sections": {
-        "Well Known Protocols (Standard Ports)": [{
+        "Well Known Ports (System Ports)": [{
             "val": "FTP Data Transfer",
             "key": "20"
         }, {

--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -1,15 +1,14 @@
 {
-    "id": "default_port_numbers",
+    "id": "default_port_numbers_cheat_sheet",
     "name": "Default Port Numbers",
     "description": "Default port numbers in networking",
     "metadata": {
         "sourceName": "Wikipedia",
         "sourceUrl": "https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers"
     },
-	
-	"aliases": [
-		"default port numbers", "default port", "default port number", "netowrk ports" 
-	],
+    "aliases": [
+	"default port", "default port number", "netowrk ports" 
+    ],
     "template_type": "keyboard",
     "section_order": [
         "Default Port Numbers"
@@ -34,12 +33,12 @@
             "val": "Domain Name System (DNS)",
             "key": "53"
         }, {
-			"val": "Dynamic Host Configuration Protocol (DHCP) Server",
-			"key": "67"
-		}, {
-			"val": "Dynamic Host Configuration Protocol (DHCP) Client",
-			"key": "68"
-		}, {
+	    "val": "Dynamic Host Configuration Protocol (DHCP) Server",
+	    "key": "67"
+	}, {
+	    "val": "Dynamic Host Configuration Protocol (DHCP) Client",
+	    "key": "68"
+	}, {
             "val": "Hypertext Transfer Protocol (HTTP)",
             "key": "80"
         }, {
@@ -52,8 +51,8 @@
             "val": "Remote Procedure Call (RPC)",
             "key": "530"
         }, {
-			"val": "Telent Protocol over TLS/SSL",
-			"key": "992"
-		}]
+	    "val": "Telent Protocol over TLS/SSL",
+	    "key": "992"
+	}]
     }
 }

--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -1,20 +1,20 @@
 {
     "id": "default_port_numbers_cheat_sheet",
     "name": "Default Port Numbers",
-    "description": "Default port numbers in networking",
+    "description": "List of port numbers used in computer networks",
     "metadata": {
         "sourceName": "Wikipedia",
         "sourceUrl": "https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers"
     },
     "aliases": [
-	"default port", "default port number", "netowrk ports" 
+	"default port", "default port number", "network ports" 
     ],
     "template_type": "keyboard",
     "section_order": [
-        "Default Port Numbers"
+        "Well Known Protocols", "Registered Protocols"
     ],
     "sections": {
-        "Default Port Numbers": [{
+        "Well Known Protocols": [{
             "val": "FTP Data Transfer",
             "key": "20"
         }, {
@@ -33,12 +33,12 @@
             "val": "Domain Name System (DNS)",
             "key": "53"
         }, {
-	    "val": "Dynamic Host Configuration Protocol (DHCP) Server",
-	    "key": "67"
-	}, {
-	    "val": "Dynamic Host Configuration Protocol (DHCP) Client",
-	    "key": "68"
-	}, {
+		    "val": "Dynamic Host Configuration Protocol (DHCP) Server",
+		    "key": "67"
+		}, {
+		    "val": "Dynamic Host Configuration Protocol (DHCP) Client",
+		    "key": "68"
+		}, {
             "val": "Hypertext Transfer Protocol (HTTP)",
             "key": "80"
         }, {
@@ -51,8 +51,24 @@
             "val": "Remote Procedure Call (RPC)",
             "key": "530"
         }, {
-	    "val": "Telent Protocol over TLS/SSL",
-	    "key": "992"
-	}]
+		    "val": "Telnet Protocol over TLS/SSL",
+		    "key": "992"
+		}],
+		"Registered Protocols": [{
+			"val": "SOCKS Proxy",
+			"key": "1080"
+		}, {
+			"val": "OpenVPN",
+			"key": "1194"
+		}, {
+			"val": "Internet Protocol Security (IPSec)",
+			"key": "1293"
+		}, {
+			"val": "Real-time Transport Protocol media data (RTP)",
+			"key": "5004"
+		}, {
+			"val": "Real-time Transport Protocol control protocol (RTCP)",
+			"key": "5005"
+		}]
     }
 }

--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -8,7 +8,7 @@
     },
 	
 	"aliases": [
-		"default port numbers", "default port" 
+		"default port numbers", "default port", "default port number", "netowrk ports" 
 	],
     "template_type": "keyboard",
     "section_order": [
@@ -34,6 +34,12 @@
             "val": "Domain Name System (DNS)",
             "key": "53"
         }, {
+			"val": "Dynamic Host Configuration Protocol (DHCP) Server",
+			"key": "67"
+		}, {
+			"val": "Dynamic Host Configuration Protocol (DHCP) Client",
+			"key": "68"
+		}, {
             "val": "Hypertext Transfer Protocol (HTTP)",
             "key": "80"
         }, {


### PR DESCRIPTION
**What does your Instant Answer do?**
This instant answer shows the default port numbers that are used in computer networks

**What is the data source for your Instant Answer? (Provide a link if possible)**
https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers

**Why did you choose this data source?**
I chose this data source because of its authenticity.

**Are there any other alternative (better) data sources?**
Yes, there are other data sources as well but the information is scattered. You have to lookup different websites. Wikipedia provides consolidated information.
 
**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Developers, Computer Programmers, Computer Scientists

**Is this Instant Answer connected to a DuckDuckHack Instant Answer idea?**
No

**Are you having any problems? Do you need our help with anything?**
No

**Where did you hear about DuckDuckHack? (For first time contributors)**
I was using the search engine and wanted to be a part of it. 

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![default port numbers](https://cloud.githubusercontent.com/assets/1548906/11637731/1c241c26-9d49-11e5-9a01-ec0da440f5f4.png)

-----
IA Page: https://duck.co/ia/view/default_port_numbers_cheat_sheet