### PR TITLE
only return Unicode match result when there is a match

### DIFF
--- a/lib/DDG/Goodie/Unicode.pm
+++ b/lib/DDG/Goodie/Unicode.pm
@@ -41,7 +41,8 @@ handle sub {
 
     # Search term starts with "unicode "
     if ($term =~ UNICODE_RE) {
-        return unicode_lookup($1);
+        return unless my $result = unicode_lookup($1);
+        return $result;
     }
 
     return codepoint_description($term);

--- a/t/Unicode.t
+++ b/t/Unicode.t
@@ -30,6 +30,8 @@ ddg_goodie_test(
         'unicode white smiling face' => test_zci("\x{263A} U+263A WHITE SMILING FACE, decimal: 9786, HTML: &#9786;, UTF-8: 0xE2 0x98 0xBA, block: Miscellaneous Symbols"),
 
         '\x{2764}' => test_zci("\x{2764} U+2764 HEAVY BLACK HEART, decimal: 10084, HTML: &#10084;, UTF-8: 0xE2 0x9D 0xA4, block: Dingbats"),
+
+        'unicode unknown' => undef
 );
 
 done_testing;


### PR DESCRIPTION
Sorry about the late response...

As discussed in the issue, the problem was that the code was returning whatever `unicode_lookup` returns, without validating if it was a defined result

fixes #1430 