### PR TITLE
JavaScript cheatsheet: Fixed typo

### DIFF
--- a/share/goodie/cheat_sheets/json/javascript.json
+++ b/share/goodie/cheat_sheets/json/javascript.json
@@ -7,7 +7,8 @@
         "sourceUrl": "http://overapi.com/javascript/"
     },
     "aliases": [
-        "js", "java script" 
+        "js",
+        "java script" 
     ],
     "template_type": "code",
     "section_order": [
@@ -21,7 +22,7 @@
     "sections": {
         "Array Methods": [{
             "val": "Joins two or more arrays, and returns a copy of the joined arrays",
-            "key": "concact()"
+            "key": "concat()"
         }, {
             "val": "Searches array for an element, and returns element's position",
             "key": "indexOf()"  


### PR DESCRIPTION
concact() -> concat()

Thanks to @jbinto for spotting.