### PR TITLE
Add Ruby Globals cheat sheet

### DIFF
--- a/share/goodie/cheat_sheets/json/ruby-globals.json
+++ b/share/goodie/cheat_sheets/json/ruby-globals.json
@@ -3,7 +3,7 @@
   "name": "Ruby Globals",
   "description": "Pre-defined global variables and constants in the Ruby programming language",
   "metadata": {
-    "sourceName": "Documentation for Ruby",
+    "sourceName": "Ruby Lang",
     "sourceUrl": "http://docs.ruby-lang.org/en/trunk/globals_rdoc.html"
   },
   "aliases": [

--- a/share/goodie/cheat_sheets/json/ruby-globals.json
+++ b/share/goodie/cheat_sheets/json/ruby-globals.json
@@ -24,225 +24,225 @@
     "Short Variables": [
       {
         "key": "$!",
-        "val": "Last raised exception."
+        "val": "Last raised exception"
       },
       {
         "key": "$@",
-        "val": "Backtrace array of the last raised exception."
+        "val": "Backtrace array of the last raised exception"
       },
       {
         "key": "$&",
-        "val": "Last successfully matched string."
+        "val": "Last successfully matched string"
       },
       {
         "key": "$`",
-        "val": "String to the left  of the last successful match."
+        "val": "String to the left  of the last successful match"
       },
       {
         "key": "$'",
-        "val": "String to the right of the last successful match."
+        "val": "String to the right of the last successful match"
       },
       {
         "key": "$+",
-        "val": "Highest group matched by the last successful match."
+        "val": "Highest group matched by the last successful match"
       },
       {
         "key": "$1",
-        "val": "Nth group of the last successful match, may be > 1."
+        "val": "Nth group of the last successful match, may be > 1"
       },
       {
         "key": "$~",
-        "val": "Match data from the last match in the current scope."
+        "val": "Match data from the last match in the current scope"
       },
       {
         "key": "$=",
-        "val": "Case insensitive flag, nil by default, ineffective."
+        "val": "Case insensitive flag, nil by default, ineffective"
       },
       {
         "key": "$/",
-        "val": "Input record separator, newline by default."
+        "val": "Input record separator, newline by default"
       },
       {
         "key": "$\\",
-        "val": "Output record separator for print and IO#write, nil by default."
+        "val": "Output record separator for print and IO#write, nil by default"
       },
       {
         "key": "$,",
-        "val": "Output field separator for print and Array#join, nil by default."
+        "val": "Output field separator for print and Array#join, nil by default"
       },
       {
         "key": "$;",
-        "val": "Default split pattern for String#split, nil by default."
+        "val": "Default split pattern for String#split, nil by default"
       },
       {
-        "key": "$.",
-        "val": "Current input line number of the last file that was read."
+        "key": "$",
+        "val": "Current input line number of the last file that was read"
       },
       {
         "key": "$<",
-        "val": "Virtual concatenation file of files from command line or $stdin."
+        "val": "Virtual concatenation file of files from command line or $stdin"
       },
       {
         "key": "$>",
-        "val": "Default output for print and printf, $stdout by default."
+        "val": "Default output for print and printf, $stdout by default"
       },
       {
         "key": "$_",
-        "val": "Last input line of string by gets or readline."
+        "val": "Last input line of string by gets or readline"
       },
       {
         "key": "$0",
-        "val": "Name of the script being executed, may be assignable."
+        "val": "Name of the script being executed, may be assignable"
       },
       {
         "key": "$*",
-        "val": "Command line arguments given for the script sans args."
+        "val": "Command line arguments given for the script sans args"
       },
       {
         "key": "$$",
-        "val": "Process number of the Ruby running this script."
+        "val": "Process number of the Ruby running this script"
       },
       {
         "key": "$?",
-        "val": "Status of the last executed child process, thread-local."
+        "val": "Status of the last executed child process, thread-local"
       },
       {
         "key": "$:",
-        "val": "Load path for scripts and binary modules by load or require."
+        "val": "Load path for scripts and binary modules by load or require"
       },
       {
         "key": "$\"",
-        "val": "Array of module names loaded by require."
+        "val": "Array of module names loaded by require"
       }
     ],
     "Long Variables": [
       {
         "key": "$DEBUG",
-        "val": "Debug flag, set by -d switch, enables printing of each exception raised to $stderr (but not its backtrace) when true."
+        "val": "Debug flag, set by -d switch, enables printing of each exception raised to $stderr (but not its backtrace) when true"
       },
       {
         "key": "$LOADED_FEATURES",
-        "val": "Alias of $\"."
+        "val": "Alias of $\""
       },
       {
         "key": "$FILENAME",
-        "val": "Current input file from $<, same as $<.filename."
+        "val": "Current input file from $<, same as $<.filename"
       },
       {
         "key": "$LOAD_PATH",
-        "val": "Alias of $:."
+        "val": "Alias of $:"
       },
       {
         "key": "$stderr",
-        "val": "Current standard error output."
+        "val": "Current standard error output"
       },
       {
         "key": "$stdin",
-        "val": "Current standard input."
+        "val": "Current standard input"
       },
       {
         "key": "$stdout",
-        "val": "Current standard output."
+        "val": "Current standard output"
       },
       {
         "key": "$VERBOSE",
-        "val": "Verbose flag, set by -w or -v switch, enables warnings when true."
+        "val": "Verbose flag, set by -w or -v switch, enables warnings when true"
       }
     ],
     "Command Line Switches": [
       {
         "key": "$-0",
-        "val": "Alias of input record separator $/."
+        "val": "Alias of input record separator $/"
       },
       {
         "key": "$-a",
-        "val": "Autosplit mode flag, read-only."
+        "val": "Autosplit mode flag, read-only"
       },
       {
         "key": "$-d",
-        "val": "Alias of $DEBUG."
+        "val": "Alias of $DEBUG"
       },
       {
         "key": "$-F",
-        "val": "Alias of split pattern $;."
+        "val": "Alias of split pattern $;"
       },
       {
         "key": "$-i",
-        "val": "Extension for in-place-edit mode, otherwise nil."
+        "val": "Extension for in-place-edit mode, otherwise nil"
       },
       {
         "key": "$-I",
-        "val": "Alias of load path $:."
+        "val": "Alias of load path $:"
       },
       {
         "key": "$-l",
-        "val": "Line ending processing mode flag, read-only."
+        "val": "Line ending processing mode flag, read-only"
       },
       {
         "key": "$-p",
-        "val": "Print loop flag, read-only."
+        "val": "Print loop flag, read-only"
       },
       {
         "key": "$-v",
-        "val": "Alias of $VERBOSE."
+        "val": "Alias of $VERBOSE"
       },
       {
         "key": "$-w",
-        "val": "Alias of $VERBOSE."
+        "val": "Alias of $VERBOSE"
       }
     ],
     "Global Constants": [
       {
         "key": "TRUE",
-        "val": "Value of true, the singleton instance of TrueClass."
+        "val": "Value of true, the singleton instance of TrueClass"
       },
       {
         "key": "FALSE",
-        "val": "Value of false, the singleton instance of FalseClass."
+        "val": "Value of false, the singleton instance of FalseClass"
       },
       {
         "key": "NIL",
-        "val": "Value of nil, the singleton instance of NilClass."
+        "val": "Value of nil, the singleton instance of NilClass"
       },
       {
         "key": "STDIN",
-        "val": "Standard input, default value for $stdin."
+        "val": "Standard input, default value for $stdin"
       },
       {
         "key": "STDOUT",
-        "val": "Standard output, default value for $stdout."
+        "val": "Standard output, default value for $stdout"
       },
       {
         "key": "STDERR",
-        "val": "Standard error output, default value for $stderr."
+        "val": "Standard error output, default value for $stderr"
       },
       {
         "key": "ENV",
-        "val": "Hash of current environment variables."
+        "val": "Hash of current environment variables"
       },
       {
         "key": "ARGF",
-        "val": "Alias of virtual input file $<."
+        "val": "Alias of virtual input file $<"
       },
       {
         "key": "ARGV",
-        "val": "Alias of command line arguments $*."
+        "val": "Alias of command line arguments $*"
       },
       {
         "key": "DATA",
-        "val": "Script file object, pointing just after __END__."
+        "val": "Script file object, pointing just after __END__"
       },
       {
         "key": "RUBY_VERSION",
-        "val": "Version string."
+        "val": "Version string"
       },
       {
         "key": "RUBY_RELEASE_DATE",
-        "val": "Release date string."
+        "val": "Release date string"
       },
       {
         "key": "RUBY_PLATFORM",
-        "val": "Platform identifier string."
+        "val": "Platform identifier string"
       }
     ]
   }

--- a/share/goodie/cheat_sheets/json/ruby-globals.json
+++ b/share/goodie/cheat_sheets/json/ruby-globals.json
@@ -1,0 +1,249 @@
+{
+  "id": "ruby_globals_cheat_sheet",
+  "name": "Ruby Globals",
+  "description": "Pre-defined global variables and constants in the Ruby programming language",
+  "metadata": {
+    "sourceName": "Documentation for Ruby",
+    "sourceUrl": "http://docs.ruby-lang.org/en/trunk/globals_rdoc.html"
+  },
+  "aliases": [
+    "ruby global constant",
+    "ruby global constants",
+    "ruby global variable",
+    "ruby global variables",
+    "ruby global"
+  ],
+  "template_type": "code",
+  "section_order": [
+    "Short Variables",
+    "Long Variables",
+    "Command Line Switches",
+    "Global Constants"
+  ],
+  "sections": {
+    "Short Variables": [
+      {
+        "key": "$!",
+        "val": "The exception information message set by 'raise'."
+      },
+      {
+        "key": "$@",
+        "val": "Array of backtrace of the last exception thrown."
+      },
+      {
+        "key": "$&",
+        "val": "The string matched by the last successful match."
+      },
+      {
+        "key": "$`",
+        "val": "The string to the left  of the last successful match."
+      },
+      {
+        "key": "$'",
+        "val": "The string to the right of the last successful match."
+      },
+      {
+        "key": "$+",
+        "val": "The highest group matched by the last successful match."
+      },
+      {
+        "key": "$1",
+        "val": "The Nth group of the last successful match. May be > 1."
+      },
+      {
+        "key": "$~",
+        "val": "The information about the last match in the current scope."
+      },
+      {
+        "key": "$=",
+        "val": "The flag for case insensitive, nil by default."
+      },
+      {
+        "key": "$/",
+        "val": "The input record separator, newline by default."
+      },
+      {
+        "key": "$\\",
+        "val": "The output record separator for the print and IO#write. Default is nil."
+      },
+      {
+        "key": "$,",
+        "val": "The output field separator for the print and Array#join."
+      },
+      {
+        "key": "$;",
+        "val": "The default separator for String#split."
+      },
+      {
+        "key": "$.",
+        "val": "The current input line number of the last file that was read."
+      },
+      {
+        "key": "$<",
+        "val": "The virtual concatenation file of the files given on command line (or from $stdin if no files were given)."
+      },
+      {
+        "key": "$>",
+        "val": "The default output for print, printf. $stdout by default."
+      },
+      {
+        "key": "$_",
+        "val": "The last input line of string by gets or readline."
+      },
+      {
+        "key": "$0",
+        "val": "Contains the name of the script being executed. May be assignable."
+      },
+      {
+        "key": "$*",
+        "val": "Command line arguments given for the script sans args."
+      },
+      {
+        "key": "$$",
+        "val": "The process number of the Ruby running this script."
+      },
+      {
+        "key": "$?",
+        "val": "The status of the last executed child process.  This value is thread-local."
+      },
+      {
+        "key": "$:",
+        "val": "Load path for scripts and binary modules by load or require."
+      },
+      {
+        "key": "$\"",
+        "val": "The array contains the module names loaded by require."
+      }
+    ],
+    "Long Variables": [
+      {
+        "key": "$DEBUG",
+        "val": "The debug flag, which is set by the -d switch.  Enabling debug output prints each exception raised to $stderr (but not its backtrace).  Setting this to a true value enables debug output as if -d were given on the command line.  Setting this to a false value disables debug output."
+      },
+      {
+        "key": "$LOADED_FEATURES",
+        "val": "The alias to the $\"."
+      },
+      {
+        "key": "$FILENAME",
+        "val": "Current input file from $<. Same as $<.filename."
+      },
+      {
+        "key": "$LOAD_PATH",
+        "val": "The alias to the $:."
+      },
+      {
+        "key": "$stderr",
+        "val": "The current standard error output."
+      },
+      {
+        "key": "$stdin",
+        "val": "The current standard input."
+      },
+      {
+        "key": "$stdout",
+        "val": "The current standard output."
+      },
+      {
+        "key": "$VERBOSE",
+        "val": "The verbose flag, which is set by the -w or -v switch.  Setting this to a true value enables warnings as if -w or -v were given on the command line.  Setting this to nil disables warnings, including from Kernel#warn."
+      }
+    ],
+    "Command Line Switches": [
+      {
+        "key": "$-0",
+        "val": "The alias to $/."
+      },
+      {
+        "key": "$-a",
+        "val": "True if option -a is set. Read-only variable."
+      },
+      {
+        "key": "$-d",
+        "val": "The alias of $DEBUG.  See $DEBUG above for further discussion."
+      },
+      {
+        "key": "$-F",
+        "val": "The alias to $;."
+      },
+      {
+        "key": "$-i",
+        "val": "In in-place-edit mode, this variable holds the extension, otherwise nil."
+      },
+      {
+        "key": "$-I",
+        "val": "The alias to $:."
+      },
+      {
+        "key": "$-l",
+        "val": "True if option -l is set. Read-only variable."
+      },
+      {
+        "key": "$-p",
+        "val": "True if option -p is set. Read-only variable."
+      },
+      {
+        "key": "$-v",
+        "val": "An alias of $VERBOSE.  See $VERBOSE above for further discussion."
+      },
+      {
+        "key": "$-w",
+        "val": "An alias of $VERBOSE.  See $VERBOSE above for further discussion."
+      }
+    ],
+    "Global Constants": [
+      {
+        "key": "TRUE",
+        "val": "The typical true value."
+      },
+      {
+        "key": "FALSE",
+        "val": "The false itself."
+      },
+      {
+        "key": "NIL",
+        "val": "The nil itself."
+      },
+      {
+        "key": "STDIN",
+        "val": "The standard input. The default value for $stdin."
+      },
+      {
+        "key": "STDOUT",
+        "val": "The standard output. The default value for $stdout."
+      },
+      {
+        "key": "STDERR",
+        "val": "The standard error output. The default value for $stderr."
+      },
+      {
+        "key": "ENV",
+        "val": "The hash contains current environment variables."
+      },
+      {
+        "key": "ARGF",
+        "val": "The alias to the $<."
+      },
+      {
+        "key": "ARGV",
+        "val": "The alias to the $*."
+      },
+      {
+        "key": "DATA",
+        "val": "The file object of the script, pointing just after __END__."
+      },
+      {
+        "key": "RUBY_VERSION",
+        "val": "The ruby version string (VERSION was deprecated)."
+      },
+      {
+        "key": "RUBY_RELEASE_DATE",
+        "val": "The release date string."
+      },
+      {
+        "key": "RUBY_PLATFORM",
+        "val": "The platform identifier."
+      }
+    ]
+  }
+}

--- a/share/goodie/cheat_sheets/json/ruby-globals.json
+++ b/share/goodie/cheat_sheets/json/ruby-globals.json
@@ -75,7 +75,7 @@
         "val": "Default split pattern for String#split, nil by default"
       },
       {
-        "key": "$",
+        "key": "$.",
         "val": "Current input line number of the last file that was read"
       },
       {

--- a/share/goodie/cheat_sheets/json/ruby-globals.json
+++ b/share/goodie/cheat_sheets/json/ruby-globals.json
@@ -24,75 +24,75 @@
     "Short Variables": [
       {
         "key": "$!",
-        "val": "The exception information message set by 'raise'."
+        "val": "Last raised exception."
       },
       {
         "key": "$@",
-        "val": "Array of backtrace of the last exception thrown."
+        "val": "Backtrace array of the last raised exception."
       },
       {
         "key": "$&",
-        "val": "The string matched by the last successful match."
+        "val": "Last successfully matched string."
       },
       {
         "key": "$`",
-        "val": "The string to the left  of the last successful match."
+        "val": "String to the left  of the last successful match."
       },
       {
         "key": "$'",
-        "val": "The string to the right of the last successful match."
+        "val": "String to the right of the last successful match."
       },
       {
         "key": "$+",
-        "val": "The highest group matched by the last successful match."
+        "val": "Highest group matched by the last successful match."
       },
       {
         "key": "$1",
-        "val": "The Nth group of the last successful match. May be > 1."
+        "val": "Nth group of the last successful match, may be > 1."
       },
       {
         "key": "$~",
-        "val": "The information about the last match in the current scope."
+        "val": "Match data from the last match in the current scope."
       },
       {
         "key": "$=",
-        "val": "The flag for case insensitive, nil by default."
+        "val": "Case insensitive flag, nil by default, ineffective."
       },
       {
         "key": "$/",
-        "val": "The input record separator, newline by default."
+        "val": "Input record separator, newline by default."
       },
       {
         "key": "$\\",
-        "val": "The output record separator for the print and IO#write. Default is nil."
+        "val": "Output record separator for print and IO#write, nil by default."
       },
       {
         "key": "$,",
-        "val": "The output field separator for the print and Array#join."
+        "val": "Output field separator for print and Array#join, nil by default."
       },
       {
         "key": "$;",
-        "val": "The default separator for String#split."
+        "val": "Default split pattern for String#split, nil by default."
       },
       {
         "key": "$.",
-        "val": "The current input line number of the last file that was read."
+        "val": "Current input line number of the last file that was read."
       },
       {
         "key": "$<",
-        "val": "The virtual concatenation file of the files given on command line (or from $stdin if no files were given)."
+        "val": "Virtual concatenation file of files from command line or $stdin."
       },
       {
         "key": "$>",
-        "val": "The default output for print, printf. $stdout by default."
+        "val": "Default output for print and printf, $stdout by default."
       },
       {
         "key": "$_",
-        "val": "The last input line of string by gets or readline."
+        "val": "Last input line of string by gets or readline."
       },
       {
         "key": "$0",
-        "val": "Contains the name of the script being executed. May be assignable."
+        "val": "Name of the script being executed, may be assignable."
       },
       {
         "key": "$*",
@@ -100,11 +100,11 @@
       },
       {
         "key": "$$",
-        "val": "The process number of the Ruby running this script."
+        "val": "Process number of the Ruby running this script."
       },
       {
         "key": "$?",
-        "val": "The status of the last executed child process.  This value is thread-local."
+        "val": "Status of the last executed child process, thread-local."
       },
       {
         "key": "$:",
@@ -112,137 +112,137 @@
       },
       {
         "key": "$\"",
-        "val": "The array contains the module names loaded by require."
+        "val": "Array of module names loaded by require."
       }
     ],
     "Long Variables": [
       {
         "key": "$DEBUG",
-        "val": "The debug flag, which is set by the -d switch.  Enabling debug output prints each exception raised to $stderr (but not its backtrace).  Setting this to a true value enables debug output as if -d were given on the command line.  Setting this to a false value disables debug output."
+        "val": "Debug flag, set by -d switch, enables printing of each exception raised to $stderr (but not its backtrace) when true."
       },
       {
         "key": "$LOADED_FEATURES",
-        "val": "The alias to the $\"."
+        "val": "Alias of $\"."
       },
       {
         "key": "$FILENAME",
-        "val": "Current input file from $<. Same as $<.filename."
+        "val": "Current input file from $<, same as $<.filename."
       },
       {
         "key": "$LOAD_PATH",
-        "val": "The alias to the $:."
+        "val": "Alias of $:."
       },
       {
         "key": "$stderr",
-        "val": "The current standard error output."
+        "val": "Current standard error output."
       },
       {
         "key": "$stdin",
-        "val": "The current standard input."
+        "val": "Current standard input."
       },
       {
         "key": "$stdout",
-        "val": "The current standard output."
+        "val": "Current standard output."
       },
       {
         "key": "$VERBOSE",
-        "val": "The verbose flag, which is set by the -w or -v switch.  Setting this to a true value enables warnings as if -w or -v were given on the command line.  Setting this to nil disables warnings, including from Kernel#warn."
+        "val": "Verbose flag, set by -w or -v switch, enables warnings when true."
       }
     ],
     "Command Line Switches": [
       {
         "key": "$-0",
-        "val": "The alias to $/."
+        "val": "Alias of input record separator $/."
       },
       {
         "key": "$-a",
-        "val": "True if option -a is set. Read-only variable."
+        "val": "Autosplit mode flag, read-only."
       },
       {
         "key": "$-d",
-        "val": "The alias of $DEBUG.  See $DEBUG above for further discussion."
+        "val": "Alias of $DEBUG."
       },
       {
         "key": "$-F",
-        "val": "The alias to $;."
+        "val": "Alias of split pattern $;."
       },
       {
         "key": "$-i",
-        "val": "In in-place-edit mode, this variable holds the extension, otherwise nil."
+        "val": "Extension for in-place-edit mode, otherwise nil."
       },
       {
         "key": "$-I",
-        "val": "The alias to $:."
+        "val": "Alias of load path $:."
       },
       {
         "key": "$-l",
-        "val": "True if option -l is set. Read-only variable."
+        "val": "Line ending processing mode flag, read-only."
       },
       {
         "key": "$-p",
-        "val": "True if option -p is set. Read-only variable."
+        "val": "Print loop flag, read-only."
       },
       {
         "key": "$-v",
-        "val": "An alias of $VERBOSE.  See $VERBOSE above for further discussion."
+        "val": "Alias of $VERBOSE."
       },
       {
         "key": "$-w",
-        "val": "An alias of $VERBOSE.  See $VERBOSE above for further discussion."
+        "val": "Alias of $VERBOSE."
       }
     ],
     "Global Constants": [
       {
         "key": "TRUE",
-        "val": "The typical true value."
+        "val": "Value of true, the singleton instance of TrueClass."
       },
       {
         "key": "FALSE",
-        "val": "The false itself."
+        "val": "Value of false, the singleton instance of FalseClass."
       },
       {
         "key": "NIL",
-        "val": "The nil itself."
+        "val": "Value of nil, the singleton instance of NilClass."
       },
       {
         "key": "STDIN",
-        "val": "The standard input. The default value for $stdin."
+        "val": "Standard input, default value for $stdin."
       },
       {
         "key": "STDOUT",
-        "val": "The standard output. The default value for $stdout."
+        "val": "Standard output, default value for $stdout."
       },
       {
         "key": "STDERR",
-        "val": "The standard error output. The default value for $stderr."
+        "val": "Standard error output, default value for $stderr."
       },
       {
         "key": "ENV",
-        "val": "The hash contains current environment variables."
+        "val": "Hash of current environment variables."
       },
       {
         "key": "ARGF",
-        "val": "The alias to the $<."
+        "val": "Alias of virtual input file $<."
       },
       {
         "key": "ARGV",
-        "val": "The alias to the $*."
+        "val": "Alias of command line arguments $*."
       },
       {
         "key": "DATA",
-        "val": "The file object of the script, pointing just after __END__."
+        "val": "Script file object, pointing just after __END__."
       },
       {
         "key": "RUBY_VERSION",
-        "val": "The ruby version string (VERSION was deprecated)."
+        "val": "Version string."
       },
       {
         "key": "RUBY_RELEASE_DATE",
-        "val": "The release date string."
+        "val": "Release date string."
       },
       {
         "key": "RUBY_PLATFORM",
-        "val": "The platform identifier."
+        "val": "Platform identifier string."
       }
     ]
   }


### PR DESCRIPTION
**What does your Instant Answer do?**
Displays a list of [Ruby](https://www.ruby-lang.org/en/)'s global variables and constants in response to cheat sheet searches like *ruby globals*, *ruby global constants*, *ruby global variables*.

**What is the data source for your Instant Answer? (Provide a link if possible)**
The list items are copied verbatim from the [Ruby source][] at [doc/globals.rdoc][].  This document is rendered at http://docs.ruby-lang.org/en/trunk/globals_rdoc.html, which I've used as the answer `sourceUrl` as it is more readable than the raw rdoc markup.

The source lists variables and constants.  I added sections to break the list of variables up; without the addition of a **Long Variables** section there is a lot of whitespace to the right of the one- and two-character variables.

[Ruby source]: https://github.com/ruby/ruby
[doc/globals.rdoc]: https://github.com/ruby/ruby/blob/trunk/doc/globals.rdoc

**Why did you choose this data source?**
This is a document from the Ruby project itself, so should be close to the truth.  I chose http://docs.ruby-lang.org as a reference as it is under the official Ruby domain.

**Are there any other alternative (better) data sources?**
The same data is presented at http://ruby-doc.org/core/doc/globals_rdoc.html, and other Ruby documentation servers.  I wasn't able to find a source that uses SSL.

Ryan Davis lists pre-defined variables as part of [Ruby QuickRef][].

[Ruby QuickRef]: http://www.zenspider.com/Languages/Ruby/QuickRef.html#pre-defined-variables

**Which communities will this Instant Answer be especially useful for? (gamers, book lovers, etc)**
Programmers

**Is this Instant Answer connected to a DuckDuckHack Instant Answer idea?**
No

**Are you having any problems? Do you need our help with anything?**
I ran `duckpan server` locally, it took me a while to work out that I needed to restart the server to pick up the new JSON file and aliases, though other changes are loaded while the server is running.  I know now to do this, but it would be helpful if the server was restarted automatically when needed, or printed a warning suggesting so.

**Where did you hear about DuckDuckHack? (For first time contributors)**
I've used the search engine for years, and have gradually become aware of the community around it.  I started hearing about Quack & Hack about a month ago, which I hope to get involved in.

**What does the Instant Answer look like? (Provide a screenshot for new or updated Instant Answers)**
![screen shot 2015-12-13 at 12 02 24](https://cloud.githubusercontent.com/assets/6856120/11766888/fd2a417c-a191-11e5-8d2d-510ebe752e4d.png)

---
https://duck.co/ia/view/ruby_globals_cheat_sheet