### PR TITLE
Fix #1836 Regex trigger needs anchors to limit triggering

### DIFF
--- a/lib/DDG/Goodie/LaserShip.pm
+++ b/lib/DDG/Goodie/LaserShip.pm
@@ -15,7 +15,7 @@ category 'ids';
 topics 'special_interest';
 attribution github => [ 'https://github.com/duckduckgo', 'duckduckgo'];
 
-triggers query_nowhitespace_nodash => qr/(l[a-z]\d{8})/i;
+triggers query_nowhitespace_nodash => qr/(^l[a-z]\d{8}$)/i;
 
 handle query_nowhitespace_nodash => sub {
     return $1, heading => "Lasership Shipment Tracking", html => qq(Track this shipment at <a href="http://lasership.com/track/$1">Lasership</a>.) if $1;

--- a/t/LaserShip.t
+++ b/t/LaserShip.t
@@ -20,6 +20,7 @@ ddg_goodie_test(
         	heading => 'Lasership Shipment Tracking',
         	html => qq(Track this shipment at <a href="http://lasership.com/track/LL12345678">Lasership</a>.)
         ),
+        '1LS12345678999999999' => undef
 );
 
 done_testing;


### PR DESCRIPTION
Fixes #1836. Updated regex to include anchors so it will not match on strings such as "1LS12345678999999" but will still match on "LS12345678"