### PR TITLE
added alias to firefox.json

### DIFF
--- a/share/goodie/cheat_sheets/json/firefox.json
+++ b/share/goodie/cheat_sheets/json/firefox.json
@@ -6,6 +6,9 @@
         "sourceName":"Mozilla Firefox",
         "sourceUrl":"https://support.mozilla.org/en-US/kb/keyboard-shortcuts-perform-firefox-tasks-quickly"
     },
+  "aliases": [
+    "mozilla firefox"
+  ],
     "template_type": "keyboard",
     "section_order":[
         "Navigation",


### PR DESCRIPTION
added alias to firefox.json as it is not triggering on the query:
https://duckduckgo.com/?q=mozilla+firefox+cheatsheet 