### PR TITLE
Unicode: Added 'emoji' trigger word

### DIFF
--- a/lib/DDG/Goodie/Unicode.pm
+++ b/lib/DDG/Goodie/Unicode.pm
@@ -22,7 +22,7 @@ use constant {
     CODEPOINT_RE => qr/^ \s* (?:U \+|\\(?:u|x{(?=.*}))) (?<codepoint> [a-f0-9]{4,6})}? \s* $/xi,
     NAME_RE      => qr/^ (?<name> [A-Z][A-Z\s]+) $/xi,
     CHAR_RE      => qr/^ \s* (?<char> .) \s* $/x,
-    UNICODE_RE   => qr/^ (?:unicode|utf-(?:8|16|32)) \s+ (.+) $/xi,
+    UNICODE_RE   => qr/^ (?:unicode|emoji|utf-(?:8|16|32)) \s+ (.+) $/xi,
     CODEPOINT    => 1,
     NAME         => 2,
     CHAR         => 3,

--- a/t/Unicode.t
+++ b/t/Unicode.t
@@ -32,6 +32,9 @@ ddg_goodie_test(
         # Lookup by name, "utf-32 custard"
         "utf-32 custard" => test_zci("\x{1F36E} U+1F36E CUSTARD, decimal: 127854, HTML: &#127854;, UTF-8: 0xF0 0x9F 0x8D 0xAE, block: Miscellaneous Symbols And Pictographs"),
 
+        # Lookup by name, "emoji rocket"
+        "emoji rocket" => test_zci("\x{1F680} U+1F680 ROCKET, decimal: 128640, HTML: &#128640;, UTF-8: 0xF0 0x9F 0x9A 0x80, block: Transport And Map Symbols"),
+
         # Lookup by character, "unicode à"
         "unicode \x{263B}" => test_zci("\x{263B} U+263B BLACK SMILING FACE, decimal: 9787, HTML: &#9787;, UTF-8: 0xE2 0x98 0xBB, block: Miscellaneous Symbols"),
 


### PR DESCRIPTION
Eventually we may have a dedicated emoji IA with better UI but for now this should help people find emojis faster.

<img width="350" alt="emoji-ia" src="https://cloud.githubusercontent.com/assets/94173/11958581/f428e692-a90b-11e5-8619-be70575103ee.png">

Suggested on Twitter: https://twitter.com/sthmcleod/status/679319872980037632

-----
IA Page: https://duck.co/ia/view/unicode