### PR TITLE
HTTP Status Codes: Fixed values for multiple codes.

### DIFF
--- a/share/goodie/cheat_sheets/json/http-status-codes.json
+++ b/share/goodie/cheat_sheets/json/http-status-codes.json
@@ -39,7 +39,7 @@
             "val": "Created",
             "key": "201"
         }, {
-            "val": "Successful",
+            "val": "Accepted",
             "key": "202"
         }, {
             "val": "Non-authorative information",
@@ -189,46 +189,46 @@
             "key": "499"
         }],
         "HTTP Server Error Codes (5xx)": [{
-             "val": "Bad Request",
+             "val": "Internal Server Error",
             "key": "500"
         }, {
-            "val": "Unauthorized",
+            "val": "Not Implemented",
             "key": "501"
         }, {
-            "val": "Payment Required",
+            "val": "Bad Gateway",
             "key": "502"
         }, {
-            "val": "Forbidden",
+            "val": "Service Unavailable",
             "key": "503"
         }, {
-            "val": "Not Found",
+            "val": "Gateway Timeout",
             "key": "504"
         }, {
-            "val": "Method Not Allowed",
+            "val": "HTTP Version Not Supported",
             "key": "505"
         }, {
-            "val": "Not Acceptable",
+            "val": "Variant Also Negotiates",
             "key": "506"
         }, {
-            "val": "Proxy Authentication Required",
+            "val": "Insufficient Storage",
             "key": "507"
         }, {
-            "val": "Request Timeout",
+            "val": "Loop Detected",
             "key": "508"
         }, {
-             "val": "Conflict",
+             "val": "Bandwidth Exceeded",
             "key": "509"
         }, {
-            "val": "Gone",
+            "val": "Not Extended",
             "key": "510"
         }, {
-            "val": "Length Required",
+            "val": "Network Authentication Required",
             "key": "511"
         }, {
-            "val": "Precondition Failed",
+            "val": "Network Read Timeout",
             "key": "598"
         }, {
-            "val": "Request Entity Too Large",
+            "val": "Network Connect Timeout ",
             "key": "599"
         }]
 


### PR DESCRIPTION
Changed the value for the status code 202 and codes 500 to 599.

It appears like a lot of the 5XX codes were copied incorrectly from 4XX codes.

Sources are from the following URL's.
http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
https://en.wikipedia.org/wiki/List_of_HTTP_status_codes

