### PR TITLE
URLEncode: Fixes #1932

### DIFF
--- a/lib/DDG/Goodie/URLDecode.pm
+++ b/lib/DDG/Goodie/URLDecode.pm
@@ -2,7 +2,7 @@ package DDG::Goodie::URLDecode;
 # ABSTRACT: Displays the decoded URL for a percent encoded uri
 
 use DDG::Goodie;
-use URI::Escape::XS qw(decodeURIComponent);
+use URI::Escape::XS qw(uri_unescape);
 use warnings;
 use strict;
 
@@ -35,7 +35,7 @@ handle query_raw => sub {
     s/(^\s+)|(\s+$)//;
 
     my $in      = $_;
-    my $decoded = decodeURIComponent($in);
+    my $decoded = uri_unescape($in);
 
     if ($decoded =~ /^\s+$/) {
         $decoded =~ s/\r/CReturn/;

--- a/lib/DDG/Goodie/URLDecode.pm
+++ b/lib/DDG/Goodie/URLDecode.pm
@@ -45,13 +45,20 @@ handle query_raw => sub {
     }
 
     my $text = "URL Decoded: $decoded";
+    my $subtitle = "URL decode: $in";
 
-    return $text,
-      structured_answer => {
-        input     => [html_enc($in)],
-        operation => 'URL decode',
-        result    => html_enc($decoded)
-      };
+    return $text, structured_answer => {
+        id => 'url_decode',
+        name => 'Answer',
+        data => {
+            title => $decoded,
+            subtitle => $subtitle
+        },
+        templates => {
+            group => 'text',
+            moreAt => 0
+        }
+    };
 };
 
 1;

--- a/lib/DDG/Goodie/URLEncode.pm
+++ b/lib/DDG/Goodie/URLEncode.pm
@@ -2,7 +2,7 @@ package DDG::Goodie::URLEncode;
 # ABSTRACT: Displays the percent-encoded url.
 
 use DDG::Goodie;
-use URI::Escape::XS qw(encodeURIComponent);
+use URI::Escape qw(uri_escape);
 use warnings;
 use strict;
 
@@ -29,7 +29,7 @@ handle remainder => sub {
 
     return unless $in;
 
-    my $encoded_url = encodeURIComponent($in);
+    my $encoded_url = uri_escape($in);
 
     my $text = "Percent-encoded URL: $encoded_url";
 

--- a/lib/DDG/Goodie/URLEncode.pm
+++ b/lib/DDG/Goodie/URLEncode.pm
@@ -36,13 +36,20 @@ handle remainder => sub {
     my $encoded_url = uri_escape($in);
 
     my $text = "Percent-encoded URL: $encoded_url";
+    my $subtitle = "URL percent-encode: $in";
 
-    return $text,
-      structured_answer => {
-        input     => [html_enc($in)],
-        operation => 'URL percent-encode',
-        result    => html_enc($encoded_url),
-      };
+    return $text, structured_answer => {
+        id => 'url_encode',
+        name => 'Answer',
+        data => {
+            title => $encoded_url,
+            subtitle => $subtitle
+        },
+        templates => {
+            group => 'text',
+            moreAt => 0
+        }
+    };
 };
 
 1;

--- a/lib/DDG/Goodie/URLEncode.pm
+++ b/lib/DDG/Goodie/URLEncode.pm
@@ -2,7 +2,7 @@ package DDG::Goodie::URLEncode;
 # ABSTRACT: Displays the percent-encoded url.
 
 use DDG::Goodie;
-use URI::Escape qw(uri_escape);
+use URI::Escape::XS qw(uri_escape);
 use warnings;
 use strict;
 
@@ -28,6 +28,10 @@ handle remainder => sub {
     my $in = $_;
 
     return unless $in;
+
+	## URI::Escape::XS::uri_escape expects a byte string, so downgrade our string
+	## https://metacpan.org/pod/URI::Escape::XS#uri_escape
+	utf8::downgrade($in);
 
     my $encoded_url = uri_escape($in);
 

--- a/lib/DDG/Goodie/URLEncode.pm
+++ b/lib/DDG/Goodie/URLEncode.pm
@@ -29,9 +29,9 @@ handle remainder => sub {
 
     return unless $in;
 
-	## URI::Escape::XS::uri_escape expects a byte string, so downgrade our string
-	## https://metacpan.org/pod/URI::Escape::XS#uri_escape
-	utf8::downgrade($in);
+    ## URI::Escape::XS::uri_escape expects a byte string, so downgrade our string
+    ## https://metacpan.org/pod/URI::Escape::XS#uri_escape
+    utf8::downgrade($in);
 
     my $encoded_url = uri_escape($in);
 

--- a/t/URLDecode.t
+++ b/t/URLDecode.t
@@ -107,7 +107,7 @@ ddg_goodie_test(
         structured_answer => {
             input     => ['%E4%F6%FC'],
             operation => 'URL decode',
-            result    => 'äöü'
+            result    => '&auml;&ouml;&uuml;'
         }
     ),
     '%20' => test_zci(

--- a/t/URLDecode.t
+++ b/t/URLDecode.t
@@ -9,115 +9,55 @@ use DDG::Test::Goodie;
 zci answer_type => 'decoded_url';
 zci is_cached   => 1;
 
+sub build_answer {
+    my ($answer, $sub) = @_;
+    $sub = '' unless $sub;
+
+    return sprintf("URL Decoded: %s",$answer) , structured_answer => {
+        id => 'url_decode',
+        name => 'Answer',
+        data => {
+            title => $answer,
+            subtitle => "URL decode: $sub"
+        },
+        templates => {
+            group => 'text',
+            moreAt => 0
+        }
+    }
+}
+
 ddg_goodie_test(
     [qw(DDG::Goodie::URLDecode)],
 
     # Primary example queries
-    'url decode https%3A%2F%2Fduckduckgo.com%2F' => test_zci(
-        "URL Decoded: https://duckduckgo.com/",
-        structured_answer => {
-            input     => ['https%3A%2F%2Fduckduckgo.com%2F'],
-            operation => 'URL decode',
-            result    => 'https://duckduckgo.com/'
-        }
-    ),
-    'decode url xkcd.com%2Fblag' => test_zci(
-        "URL Decoded: xkcd.com/blag",
-        structured_answer => {
-            input     => ['xkcd.com%2Fblag'],
-            operation => 'URL decode',
-            result    => 'xkcd.com/blag'
-        }
-    ),
+    'url decode https%3A%2F%2Fduckduckgo.com%2F' => test_zci(build_answer('https://duckduckgo.com/', 'https%3A%2F%2Fduckduckgo.com%2F')),
+
+    'decode url xkcd.com%2Fblag' => test_zci(build_answer('xkcd.com/blag', 'xkcd.com%2Fblag')),
+
     # Secondary example queries
-    'http%3A%2F%2Farstechnica.com%2F url unescape' => test_zci(
-        "URL Decoded: http://arstechnica.com/",
-        structured_answer => {
-            input     => ['http%3A%2F%2Farstechnica.com%2F'],
-            operation => 'URL decode',
-            result    => 'http://arstechnica.com/'
-        }
-    ),
-    'linux.com%2Ftour%2F unescape url' => test_zci(
-        "URL Decoded: linux.com/tour/",
-        structured_answer => {
-            input     => ['linux.com%2Ftour%2F'],
-            operation => 'URL decode',
-            result    => 'linux.com/tour/'
-        }
-    ),
-    'urldecode www.xkcd.com%2Fa-webcomic-of-romance%2Bmath%2Bsarcasm%2Blanguage' => test_zci(
-        "URL Decoded: www.xkcd.com/a-webcomic-of-romance+math+sarcasm+language",
-        structured_answer => {
-            input     => ['www.xkcd.com%2Fa-webcomic-of-romance%2Bmath%2Bsarcasm%2Blanguage'],
-            operation => 'URL decode',
-            result    => 'www.xkcd.com/a-webcomic-of-romance+math+sarcasm+language'
-        }
-    ),
-    'unescapeurl https%3A%2F%2Fexample.com%2Fzero%23clickinfo%5E%3Cgoodies%3E%3Bspice%3Afathead-%5C' => test_zci(
-        'URL Decoded: https://example.com/zero#clickinfo^<goodies>;spice:fathead-\\',
-        structured_answer => {
-            input     => ['https%3A%2F%2Fexample.com%2Fzero%23clickinfo%5E%3Cgoodies%3E%3Bspice%3Afathead-%5C'],
-            operation => 'URL decode',
-            result    => 'https://example.com/zero#clickinfo^&lt;goodies&gt;;spice:fathead-\\'
-        }
-    ),
-    'urlunescape https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22' => test_zci(
-        qq`URL Decoded: https://example.org/the answer to "[life], (the universe) .and. <everything>"`,
-        structured_answer => {
-            input     => ['https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22'],
-            operation => 'URL decode',
-            result    => 'https://example.org/the answer to &quot;[life], (the universe) .and. &lt;everything&gt;&quot;'
-        }
-    ),
-    'https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22' => test_zci(
-        qq`URL Decoded: https://example.org/the answer to "[life], (the universe) .and. <everything>"`,
-        structured_answer => {
-            input     => ['https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22'],
-            operation => 'URL decode',
-            result    => 'https://example.org/the answer to &quot;[life], (the universe) .and. &lt;everything&gt;&quot;'
-        }
-    ),
-    'www.heroku.com%2F%7Brawwr!%40%23%24%25%5E%26*()%2B%3D__%7D unescapeurl' => test_zci(
-        'URL Decoded: www.heroku.com/{rawwr!@#$%^&*()+=__}',
-        structured_answer => {
-            input     => ['www.heroku.com%2F%7Brawwr!%40%23%24%25%5E%26*()%2B%3D__%7D'],
-            operation => 'URL decode',
-            result    => 'www.heroku.com/{rawwr!@#$%^&amp;*()+=__}'
-        }
-    ),
-    'urldecode %3Cscript%3Ealert(1)%3C%2Fscript%3E' => test_zci(
-        "URL Decoded: <script>alert(1)</script>",
-        structured_answer => {
-            input     => ['%3Cscript%3Ealert(1)%3C%2Fscript%3E'],
-            operation => 'URL decode',
-            result    => '&lt;script&gt;alert(1)&lt;/script&gt;'
-        }
-    ),
-    'https%3A%2F%2Fduckduckgo.com%2F' => test_zci(
-        "URL Decoded: https://duckduckgo.com/",
-        structured_answer => {
-            input     => ['https%3A%2F%2Fduckduckgo.com%2F'],
-            operation => 'URL decode',
-            result    => 'https://duckduckgo.com/'
-        }
-    ),
-    '%E4%F6%FC' => test_zci(
-        "URL Decoded: äöü",
-        structured_answer => {
-            input     => ['%E4%F6%FC'],
-            operation => 'URL decode',
-            result    => '&auml;&ouml;&uuml;'
-        }
-    ),
-    '%20' => test_zci(
-        'URL Decoded: Space',
-        structured_answer => {
-            input     => ['%20'],
-            operation => 'URL decode',
-            result    => 'Space'
-        }
-    ),
+    'http%3A%2F%2Farstechnica.com%2F url unescape' => test_zci(build_answer('http://arstechnica.com/', 'http%3A%2F%2Farstechnica.com%2F')),
+
+    'linux.com%2Ftour%2F unescape url' => test_zci(build_answer('linux.com/tour/', 'linux.com%2Ftour%2F')),
+
+    'urldecode www.xkcd.com%2Fa-webcomic-of-romance%2Bmath%2Bsarcasm%2Blanguage' => test_zci(build_answer('www.xkcd.com/a-webcomic-of-romance+math+sarcasm+language', 'www.xkcd.com%2Fa-webcomic-of-romance%2Bmath%2Bsarcasm%2Blanguage')),
+
+    'unescapeurl https%3A%2F%2Fexample.com%2Fzero%23clickinfo%5E%3Cgoodies%3E%3Bspice%3Afathead-%5C' => test_zci(build_answer('https://example.com/zero#clickinfo^<goodies>;spice:fathead-\\', 'https%3A%2F%2Fexample.com%2Fzero%23clickinfo%5E%3Cgoodies%3E%3Bspice%3Afathead-%5C')),
+
+    'urlunescape https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22' => test_zci(build_answer('https://example.org/the answer to "[life], (the universe) .and. <everything>"', 'https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22')),
+
+    'https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22' => test_zci(build_answer('https://example.org/the answer to "[life], (the universe) .and. <everything>"', 'https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22')),
+
+    'www.heroku.com%2F%7Brawwr!%40%23%24%25%5E%26*()%2B%3D__%7D unescapeurl' => test_zci(build_answer('www.heroku.com/{rawwr!@#$%^&*()+=__}', 'www.heroku.com%2F%7Brawwr!%40%23%24%25%5E%26*()%2B%3D__%7D')),
+
+    'urldecode %3Cscript%3Ealert(1)%3C%2Fscript%3E' => test_zci(build_answer('<script>alert(1)</script>', '%3Cscript%3Ealert(1)%3C%2Fscript%3E')),
+
+    'https%3A%2F%2Fduckduckgo.com%2F' => test_zci(build_answer('https://duckduckgo.com/', 'https%3A%2F%2Fduckduckgo.com%2F')),
+
+    '%E4%F6%FC' => test_zci(build_answer('äöü', '%E4%F6%FC')),
+
+    '%20' => test_zci(build_answer('Space', '%20')),
+
     'hello there unescapeurl' => undef,
     '38% of 100 GBP'          => undef,
     'url decode tool'         => undef,

--- a/t/URLDecode.t
+++ b/t/URLDecode.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use utf8;
 use Test::More;
 use DDG::Test::Goodie;
 
@@ -99,6 +100,14 @@ ddg_goodie_test(
             input     => ['https%3A%2F%2Fduckduckgo.com%2F'],
             operation => 'URL decode',
             result    => 'https://duckduckgo.com/'
+        }
+    ),
+    '%E4%F6%FC' => test_zci(
+        "URL Decoded: äöü",
+        structured_answer => {
+            input     => ['%E4%F6%FC'],
+            operation => 'URL decode',
+            result    => 'äöü'
         }
     ),
     '%20' => test_zci(

--- a/t/URLEncode.t
+++ b/t/URLEncode.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use utf8;
 use Test::More;
 use DDG::Test::Goodie;
 
@@ -68,20 +69,29 @@ ddg_goodie_test(
     ),
 
     'urlescape https://example.org/the answer to "[life], (the universe) .and. <everything>"' => test_zci(
-        "Percent-encoded URL: https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22",
+        "Percent-encoded URL: https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20%28the%20universe%29%20.and.%20%3Ceverything%3E%22",
         structured_answer => {
             input     => ['https://example.org/the answer to &quot;[life], (the universe) .and. &lt;everything&gt;&quot;'],
             operation => 'URL percent-encode',
-            result    => 'https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22'
+            result    => 'https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20%28the%20universe%29%20.and.%20%3Ceverything%3E%22'
         }
     ),
 
     'www.heroku.com/{rawwr!@#$%^&*()+=__} escapeurl' => test_zci(
-        "Percent-encoded URL: www.heroku.com%2F%7Brawwr!%40%23%24%25%5E%26*()%2B%3D__%7D",
+        "Percent-encoded URL: www.heroku.com%2F%7Brawwr%21%40%23%24%25%5E%26%2A%28%29%2B%3D__%7D",
         structured_answer => {
             input     => ['www.heroku.com/{rawwr!@#$%^&amp;*()+=__}'],
             operation => 'URL percent-encode',
-            result    => 'www.heroku.com%2F%7Brawwr!%40%23%24%25%5E%26*()%2B%3D__%7D',
+            result    => 'www.heroku.com%2F%7Brawwr%21%40%23%24%25%5E%26%2A%28%29%2B%3D__%7D',
+        }
+    ),
+
+    'äöü escapeurl' => test_zci(
+        "Percent-encoded URL: %E4%F6%FC",
+        structured_answer => {
+            input     => ['äöü'],
+            operation => 'URL percent-encode',
+            result    => '%E4%F6%FC',
         }
     ),
 

--- a/t/URLEncode.t
+++ b/t/URLEncode.t
@@ -69,27 +69,27 @@ ddg_goodie_test(
     ),
 
     'urlescape https://example.org/the answer to "[life], (the universe) .and. <everything>"' => test_zci(
-        "Percent-encoded URL: https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20%28the%20universe%29%20.and.%20%3Ceverything%3E%22",
+        "Percent-encoded URL: https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22",
         structured_answer => {
             input     => ['https://example.org/the answer to &quot;[life], (the universe) .and. &lt;everything&gt;&quot;'],
             operation => 'URL percent-encode',
-            result    => 'https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20%28the%20universe%29%20.and.%20%3Ceverything%3E%22'
+            result    => 'https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22'
         }
     ),
 
     'www.heroku.com/{rawwr!@#$%^&*()+=__} escapeurl' => test_zci(
-        "Percent-encoded URL: www.heroku.com%2F%7Brawwr%21%40%23%24%25%5E%26%2A%28%29%2B%3D__%7D",
+        "Percent-encoded URL: www.heroku.com%2F%7Brawwr!%40%23%24%25%5E%26*()%2B%3D__%7D",
         structured_answer => {
             input     => ['www.heroku.com/{rawwr!@#$%^&amp;*()+=__}'],
             operation => 'URL percent-encode',
-            result    => 'www.heroku.com%2F%7Brawwr%21%40%23%24%25%5E%26%2A%28%29%2B%3D__%7D',
+            result    => 'www.heroku.com%2F%7Brawwr!%40%23%24%25%5E%26*()%2B%3D__%7D',
         }
     ),
 
     'äöü escapeurl' => test_zci(
         "Percent-encoded URL: %E4%F6%FC",
         structured_answer => {
-            input     => ['äöü'],
+            input     => ['&auml;&ouml;&uuml;'],
             operation => 'URL percent-encode',
             result    => '%E4%F6%FC',
         }

--- a/t/URLEncode.t
+++ b/t/URLEncode.t
@@ -9,100 +9,48 @@ use DDG::Test::Goodie;
 zci answer_type => 'encoded_url';
 zci is_cached   => 1;
 
+sub build_answer {
+    my ($answer, $sub) = @_;
+    $sub = '' unless $sub;
+
+    return sprintf("Percent-encoded URL: %s",$answer) , structured_answer => {
+        id => 'url_encode',
+        name => 'Answer',
+        data => {
+            title => $answer,
+            subtitle => "URL percent-encode: $sub"
+        },
+        templates => {
+            group => 'text',
+            moreAt => 0
+        }
+    }
+}
+
 ddg_goodie_test(
     [qw(DDG::Goodie::URLEncode)],
 
     # Primary example queries
-    'url encode https://duckduckgo.com/' => test_zci(
-        "Percent-encoded URL: https%3A%2F%2Fduckduckgo.com%2F",
-        structured_answer => {
-            input     => ['https://duckduckgo.com/'],
-            operation => 'URL percent-encode',
-            result    => 'https%3A%2F%2Fduckduckgo.com%2F'
-        }
-    ),
+    'url encode https://duckduckgo.com/' => test_zci(build_answer('https%3A%2F%2Fduckduckgo.com%2F', 'https://duckduckgo.com/')),
 
-    'encode url xkcd.com/blag' => test_zci(
-        "Percent-encoded URL: xkcd.com%2Fblag",
-        structured_answer => {
-            input     => ['xkcd.com/blag'],
-            operation => 'URL percent-encode',
-            result    => 'xkcd.com%2Fblag'
-        }
-    ),
+    'encode url xkcd.com/blag' => test_zci(build_answer('xkcd.com%2Fblag', 'xkcd.com/blag')),
 
     # Secondary example queries
-    'http://arstechnica.com/ url escape' => test_zci(
-        "Percent-encoded URL: http%3A%2F%2Farstechnica.com%2F",
-        structured_answer => {
-            input     => ['http://arstechnica.com/'],
-            operation => 'URL percent-encode',
-            result    => 'http%3A%2F%2Farstechnica.com%2F'
-        }
-    ),
+    'http://arstechnica.com/ url escape' => test_zci(build_answer('http%3A%2F%2Farstechnica.com%2F', 'http://arstechnica.com/')),
 
-    'apple.com/mac/ escape url' => test_zci(
-        "Percent-encoded URL: apple.com%2Fmac%2F",
-        structured_answer => {
-            input     => ['apple.com/mac/'],
-            operation => 'URL percent-encode',
-            result    => 'apple.com%2Fmac%2F',
-        }
-    ),
+    'apple.com/mac/ escape url' => test_zci(build_answer('apple.com%2Fmac%2F', 'apple.com/mac/')),
 
-    'urlencode www.xkcd.com/a-webcomic-of-romance+math+sarcasm+language' => test_zci(
-        "Percent-encoded URL: www.xkcd.com%2Fa-webcomic-of-romance%2Bmath%2Bsarcasm%2Blanguage",
-        structured_answer => {
-            input     => ['www.xkcd.com/a-webcomic-of-romance+math+sarcasm+language'],
-            operation => 'URL percent-encode',
-            result    => 'www.xkcd.com%2Fa-webcomic-of-romance%2Bmath%2Bsarcasm%2Blanguage'
-        }
-    ),
+    'urlencode www.xkcd.com/a-webcomic-of-romance+math+sarcasm+language' => test_zci(build_answer('www.xkcd.com%2Fa-webcomic-of-romance%2Bmath%2Bsarcasm%2Blanguage', 'www.xkcd.com/a-webcomic-of-romance+math+sarcasm+language')),
 
-    'https://example.com/zero#clickinfo^<goodies>;spice:fathead-\ encodeurl' => test_zci(
-        "Percent-encoded URL: https%3A%2F%2Fexample.com%2Fzero%23clickinfo%5E%3Cgoodies%3E%3Bspice%3Afathead-%5C",
-        structured_answer => {
-            input     => ['https://example.com/zero#clickinfo^&lt;goodies&gt;;spice:fathead-\\'],
-            operation => 'URL percent-encode',
-            result    => 'https%3A%2F%2Fexample.com%2Fzero%23clickinfo%5E%3Cgoodies%3E%3Bspice%3Afathead-%5C'
-        }
-    ),
+    'https://example.com/zero#clickinfo^<goodies>;spice:fathead-\ encodeurl' => test_zci(build_answer('https%3A%2F%2Fexample.com%2Fzero%23clickinfo%5E%3Cgoodies%3E%3Bspice%3Afathead-%5C', 'https://example.com/zero#clickinfo^<goodies>;spice:fathead-\\')),
 
-    'urlescape https://example.org/the answer to "[life], (the universe) .and. <everything>"' => test_zci(
-        "Percent-encoded URL: https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22",
-        structured_answer => {
-            input     => ['https://example.org/the answer to &quot;[life], (the universe) .and. &lt;everything&gt;&quot;'],
-            operation => 'URL percent-encode',
-            result    => 'https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22'
-        }
-    ),
+    'urlescape https://example.org/the answer to "[life], (the universe) .and. <everything>"' => test_zci(build_answer('https%3A%2F%2Fexample.org%2Fthe%20answer%20to%20%22%5Blife%5D%2C%20(the%20universe)%20.and.%20%3Ceverything%3E%22', 'https://example.org/the answer to "[life], (the universe) .and. <everything>"')),
 
-    'www.heroku.com/{rawwr!@#$%^&*()+=__} escapeurl' => test_zci(
-        "Percent-encoded URL: www.heroku.com%2F%7Brawwr!%40%23%24%25%5E%26*()%2B%3D__%7D",
-        structured_answer => {
-            input     => ['www.heroku.com/{rawwr!@#$%^&amp;*()+=__}'],
-            operation => 'URL percent-encode',
-            result    => 'www.heroku.com%2F%7Brawwr!%40%23%24%25%5E%26*()%2B%3D__%7D',
-        }
-    ),
+    'www.heroku.com/{rawwr!@#$%^&*()+=__} escapeurl' => test_zci(build_answer('www.heroku.com%2F%7Brawwr!%40%23%24%25%5E%26*()%2B%3D__%7D', 'www.heroku.com/{rawwr!@#$%^&*()+=__}')),
 
-    'äöü escapeurl' => test_zci(
-        "Percent-encoded URL: %E4%F6%FC",
-        structured_answer => {
-            input     => ['&auml;&ouml;&uuml;'],
-            operation => 'URL percent-encode',
-            result    => '%E4%F6%FC',
-        }
-    ),
+    'äöü escapeurl' => test_zci(build_answer('%E4%F6%FC', 'äöü')),
 
-    'hello there escapeurl' => test_zci(
-        "Percent-encoded URL: hello%20there",
-        structured_answer => {
-            input     => ['hello there'],
-            operation => 'URL percent-encode',
-            result    => 'hello%20there'
-        }
-    ),
+    'hello there escapeurl' => test_zci(build_answer('hello%20there', 'hello there')),
 );
 
 done_testing;


### PR DESCRIPTION
IA for URLEncode was not handling UTF8 correctly, so round-trip values for URLEncode/URLDecode didn't match. Changed from `en|decodeURIComponent` to `uri_(un)escape` to handle unicode characters. `URI::Escape::XS::uri_escape` expects a byte string, so downgrade the string before encoding.

Tests are comparing HTML entities rather than raw utf8 characters since IA isn't using templated answers. 

IA Page: https://duck.co/ia/view/urlencode