### PR TITLE
Minecraft: Fixes #1949

### DIFF
--- a/lib/DDG/Goodie/Minecraft.pm
+++ b/lib/DDG/Goodie/Minecraft.pm
@@ -29,7 +29,7 @@ my $json = share('crafting-guide.json')->slurp;
 #my $json = share('crafting-guide.json')->slurp(iomode => '<:encoding(UTF-8)'); # descriptions contain unicode
 my $decoded = decode_json($json);
 my %recipes = map{ lc $_->{'name'} => $_ } (@{ $decoded->{'items'} });
-my @recipe_names = keys %recipes;
+my @recipe_names = sort { length($b) <=> length($a) } keys %recipes;
 
 # Extra words: Words that could be a part of the query, but not part of a recipe.
 my @extra_words = ('a','an','in','crafting','recipe','how to make','how to craft','how do I make','how do I craft');

--- a/lib/DDG/Goodie/Minecraft.pm
+++ b/lib/DDG/Goodie/Minecraft.pm
@@ -24,6 +24,9 @@ triggers startend => "minecraft";
 
 # Fetch and store recipes in a hash.
 my $json = share('crafting-guide.json')->slurp;
+## following throws error when testing:
+## malformed UTF-8 character in JSON string, at character offset 504 (before "\x{fffd} crafting gr...")
+#my $json = share('crafting-guide.json')->slurp(iomode => '<:encoding(UTF-8)'); # descriptions contain unicode
 my $decoded = decode_json($json);
 my %recipes = map{ lc $_->{'name'} => $_ } (@{ $decoded->{'items'} });
 my @recipe_names = keys %recipes;

--- a/t/Minecraft.t
+++ b/t/Minecraft.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-
+use utf8;
 use Test::More;
 use DDG::Test::Goodie;
 use URI::Escape;
@@ -23,6 +23,37 @@ ddg_goodie_test(
             "Sticks",
             "Used for climbing walls. You can climb either horizontally or vertically. To climb safely, you can sneak while climbing (hold shift).",
             "http://www.minecraftxl.com/images/wiki/recipes/ladder-crafting.png",
+        )
+    ),
+    'how to make a ladder crafting minecraft' =>
+    test_zci(
+        'Minecraft Ladder ingredients: Sticks.',
+        make_structured_answer(
+            "Ladder",
+            "Sticks",
+            "Used for climbing walls. You can climb either horizontally or vertically. To climb safely, you can sneak while climbing (hold shift).",
+            "http://www.minecraftxl.com/images/wiki/recipes/ladder-crafting.png",
+        )
+    ),
+    'crafting table minecraft' =>
+    test_zci(
+        'Minecraft Crafting Table ingredients: Wooden Plank.',
+        make_structured_answer(
+            "Crafting Table",
+            "Wooden Plank",
+            "When placed on the ground, it provides use of the 3×3 crafting grid.",
+            "http://www.minecraftxl.com/images/wiki/recipes/crafting-table-crafting.png",
+        )
+    ),
+
+    'how to make a crafting table minecraft' =>
+    test_zci(
+        'Minecraft Crafting Table ingredients: Wooden Plank.',
+        make_structured_answer(
+            "Crafting Table",
+            "Wooden Plank",
+            "When placed on the ground, it provides use of the 3×3 crafting grid.",
+            "http://www.minecraftxl.com/images/wiki/recipes/crafting-table-crafting.png",
         )
     ),
 

--- a/t/Minecraft.t
+++ b/t/Minecraft.t
@@ -77,6 +77,8 @@ ddg_goodie_test(
     'how do i craft a cheeseburger in minecraft' => undef,
     'minecraft download' => undef,
     'cool texture packs for minecraft' => undef,
+    'minecraft cake design' => undef,
+    'minecraft cake guide' => undef,
 );
 
 sub make_structured_answer {


### PR DESCRIPTION
Logic for triggers and recipe lookup has changed. Loop through all recipe names looking for exact match in query string; then remove all 'extra' words allowed in query. Continue if no remaining words in query.

Added a couple of 'negative' trigger tests; all existing tests still pass.

Fixes #1949 

IA Page: http://duck.co/ia/view/minecraft