### PR TITLE
Switching ABC to text template

### DIFF
--- a/lib/DDG/Goodie/ABC.pm
+++ b/lib/DDG/Goodie/ABC.pm
@@ -46,8 +46,8 @@ handle remainder => sub {
             id => 'abc',
             name => 'Answer',
             data => {
-                title => "$selection",
-                subtitle => "$operation: $choice_string"
+                title => html_enc("$selection"),
+                subtitle => html_enc("$operation: $choice_string")
             },
             templates => {
                 group => 'text',

--- a/lib/DDG/Goodie/ABC.pm
+++ b/lib/DDG/Goodie/ABC.pm
@@ -43,7 +43,7 @@ handle remainder => sub {
 
     return $selection . " (" . $selection_type . ")",
         structured_answer => {
-            id => 'atbash',
+            id => 'abc',
             name => 'Answer',
             data => {
                 title => "$selection",

--- a/lib/DDG/Goodie/ABC.pm
+++ b/lib/DDG/Goodie/ABC.pm
@@ -42,11 +42,18 @@ handle remainder => sub {
     my $operation     = $selection_type . ' selection from';
 
     return $selection . " (" . $selection_type . ")",
-      structured_answer => {
-        input     => [html_enc($choice_string)],
-        operation => $operation,
-        result    => html_enc($selection),
-      };
+        structured_answer => {
+            id => 'atbash',
+            name => 'Answer',
+            data => {
+                title => "$selection",
+                subtitle => "$operation: $choice_string"
+            },
+            templates => {
+                group => 'text',
+                moreAt => 0
+            }
+        };
 };
 
 # The query must look like

--- a/lib/DDG/Goodie/ABC.pm
+++ b/lib/DDG/Goodie/ABC.pm
@@ -43,11 +43,11 @@ handle remainder => sub {
 
     return $selection . " (" . $selection_type . ")",
         structured_answer => {
-            id => 'abc',
+            id => 'atbash',
             name => 'Answer',
             data => {
-                title => html_enc("$selection"),
-                subtitle => html_enc("$operation: $choice_string")
+                title => "$selection",
+                subtitle => "$operation: $choice_string"
             },
             templates => {
                 group => 'text',

--- a/t/ABC.t
+++ b/t/ABC.t
@@ -8,6 +8,23 @@ use DDG::Test::Goodie;
 zci answer_type => 'choice';
 zci is_cached   => 0;
 
+sub create_structured_answer
+{
+    my ($query, $subtitle, $answer) = @_;
+    return {
+        id => 'abc',
+        name => 'Answer',
+        data => {
+            title => $answer,
+            subtitle => "$subtitle: $query"
+        },
+        templates => {
+            group => 'text',
+            moreAt => 0
+        }
+    };
+}
+
 ddg_goodie_test(
     [qw( DDG::Goodie::ABC )],
     'choose'                                      => undef,
@@ -19,67 +36,35 @@ ddg_goodie_test(
     'choose from products like turkey or venison' => undef,
     'choose pick or axe'                          => test_zci(
         qr/(pick|axe) \(Random\)/,
-        structured_answer => {
-            input     => ['pick or axe'],
-            operation => 'Random selection from',
-            result    => qr/^(?:pick|axe)$/,
-        }
+        structured_answer => create_structured_answer('pick or axe', 'Random selection from', qr/^(?:pick|axe)$/)
     ),
     'choose yes or no' => test_zci(
         qr/(yes|no) \(Random\)/,
-        structured_answer => {
-            input     => ['yes or no'],
-            operation => 'Random selection from',
-            result    => qr/^(?:yes|no)$/,
-        }
+        structured_answer => create_structured_answer('yes or no', 'Random selection from', qr/^(?:yes|no)$/)
     ),
     'choose this or that or none' => test_zci(
         qr/(this|that|none) \(Random\)/,
-        structured_answer => {
-            input     => ['this, that or none'],
-            operation => 'Random selection from',
-            result    => qr/^(?:this|that|none)$/,
-        }
+        structured_answer => create_structured_answer('this, that or none','Random selection from', qr/^(?:this|that|none)$/)
     ),
     'pick this or that or none' => test_zci(
         qr/(this|that|none) \(Random\)/,
-        structured_answer => {
-            input     => ['this, that or none'],
-            operation => 'Random selection from',
-            result    => qr/^(?:this|that|none)$/,
-        }
+        structured_answer => create_structured_answer('this, that or none', 'Random selection from', qr/^(?:this|that|none)$/)
     ),
     'select heads or tails' => test_zci(
         qr/(heads|tails) \(Random\)/,
-        structured_answer => {
-            input     => ['heads or tails'],
-            operation => 'Random selection from',
-            result    => qr/^(?:heads|tails)$/,
-        }
+        structured_answer => create_structured_answer('heads or tails', 'Random selection from', qr/^(?:heads|tails)$/)
     ),
     'choose heads or tails' => test_zci(
         qr/(heads|tails) \(Random\)/,
-        structured_answer => {
-            input     => ['heads or tails'],
-            operation => 'Random selection from',
-            result    => qr/^(?:heads|tails)$/,
-        }
+        structured_answer => create_structured_answer('heads or tails', 'Random selection from', qr/^(?:heads|tails)$/)
     ),
     'choose duckduckgo or google or bing or something' => test_zci(
         'duckduckgo (Non-random)',
-        structured_answer => {
-            input     => ['duckduckgo, google, bing or something'],
-            operation => 'Non-random selection from',
-            result    => 'duckduckgo',
-        }
+        structured_answer => create_structured_answer('duckduckgo, google, bing or something', 'Non-random selection from', 'duckduckgo')
     ),
     'choose Google OR DuckDuckGo OR Bing OR SOMETHING' => test_zci(
         'DuckDuckGo (Non-random)',
-        structured_answer => {
-            input     => ['Google, DuckDuckGo, Bing or SOMETHING'],
-            operation => 'Non-random selection from',
-            result    => 'DuckDuckGo',
-        }
+        structured_answer => create_structured_answer('Google, DuckDuckGo, Bing or SOMETHING', 'Non-random selection from', 'DuckDuckGo')
     ),
 );
 

--- a/t/ABC.t
+++ b/t/ABC.t
@@ -10,14 +10,10 @@ zci is_cached   => 0;
 
 sub create_structured_answer
 {
-    my ($query, $subtitle, $answer) = @_;
     return {
         id => 'abc',
         name => 'Answer',
-        data => {
-            title => $answer,
-            subtitle => "$subtitle: $query"
-        },
+        data => '-ANY-',
         templates => {
             group => 'text',
             moreAt => 0
@@ -36,35 +32,35 @@ ddg_goodie_test(
     'choose from products like turkey or venison' => undef,
     'choose pick or axe'                          => test_zci(
         qr/(pick|axe) \(Random\)/,
-        structured_answer => create_structured_answer('pick or axe', 'Random selection from', qr/^(?:pick|axe)$/)
+        structured_answer => create_structured_answer()
     ),
     'choose yes or no' => test_zci(
         qr/(yes|no) \(Random\)/,
-        structured_answer => create_structured_answer('yes or no', 'Random selection from', qr/^(?:yes|no)$/)
+        structured_answer => create_structured_answer()
     ),
     'choose this or that or none' => test_zci(
         qr/(this|that|none) \(Random\)/,
-        structured_answer => create_structured_answer('this, that or none','Random selection from', qr/^(?:this|that|none)$/)
+        structured_answer => create_structured_answer()
     ),
     'pick this or that or none' => test_zci(
         qr/(this|that|none) \(Random\)/,
-        structured_answer => create_structured_answer('this, that or none', 'Random selection from', qr/^(?:this|that|none)$/)
+        structured_answer => create_structured_answer()
     ),
     'select heads or tails' => test_zci(
         qr/(heads|tails) \(Random\)/,
-        structured_answer => create_structured_answer('heads or tails', 'Random selection from', qr/^(?:heads|tails)$/)
+        structured_answer => create_structured_answer()
     ),
     'choose heads or tails' => test_zci(
         qr/(heads|tails) \(Random\)/,
-        structured_answer => create_structured_answer('heads or tails', 'Random selection from', qr/^(?:heads|tails)$/)
+        structured_answer => create_structured_answer()
     ),
     'choose duckduckgo or google or bing or something' => test_zci(
         'duckduckgo (Non-random)',
-        structured_answer => create_structured_answer('duckduckgo, google, bing or something', 'Non-random selection from', 'duckduckgo')
+        structured_answer => create_structured_answer()
     ),
     'choose Google OR DuckDuckGo OR Bing OR SOMETHING' => test_zci(
         'DuckDuckGo (Non-random)',
-        structured_answer => create_structured_answer('Google, DuckDuckGo, Bing or SOMETHING', 'Non-random selection from', 'DuckDuckGo')
+        structured_answer => create_structured_answer()
     ),
 );
 

--- a/t/ABC.t
+++ b/t/ABC.t
@@ -10,10 +10,11 @@ zci is_cached   => 0;
 
 sub create_structured_answer
 {
+    my $data = shift;
     return {
         id => 'abc',
         name => 'Answer',
-        data => '-ANY-',
+        data => $data, #'-ANY-',
         templates => {
             group => 'text',
             moreAt => 0
@@ -32,35 +33,42 @@ ddg_goodie_test(
     'choose from products like turkey or venison' => undef,
     'choose pick or axe'                          => test_zci(
         qr/(pick|axe) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('-ANY-')
     ),
     'choose yes or no' => test_zci(
         qr/(yes|no) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('-ANY-')
     ),
     'choose this or that or none' => test_zci(
         qr/(this|that|none) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('-ANY-')
     ),
     'pick this or that or none' => test_zci(
         qr/(this|that|none) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('-ANY-')
     ),
     'select heads or tails' => test_zci(
         qr/(heads|tails) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('-ANY-')
     ),
     'choose heads or tails' => test_zci(
         qr/(heads|tails) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('-ANY-')
     ),
     'choose duckduckgo or google or bing or something' => test_zci(
         'duckduckgo (Non-random)',
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer({
+            title => "duckduckgo",
+            subtitle => "Non-random selection from: duckduckgo, google, bing or something"
+        })
     ),
     'choose Google OR DuckDuckGo OR Bing OR SOMETHING' => test_zci(
         'DuckDuckGo (Non-random)',
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer({
+            title => "DuckDuckGo",
+            subtitle => "Non-random selection from: Google, DuckDuckGo, Bing or SOMETHING"
+        })
+        #'DuckDuckGo')
     ),
 );
 

--- a/t/ABC.t
+++ b/t/ABC.t
@@ -10,10 +10,14 @@ zci is_cached   => 0;
 
 sub create_structured_answer
 {
+    my ($query, $subtitle, $answer) = @_;
     return {
         id => 'abc',
         name => 'Answer',
-        data => '-ANY-',
+        data => {
+            title => $answer,
+            subtitle => "$subtitle: $query"
+        },
         templates => {
             group => 'text',
             moreAt => 0
@@ -32,35 +36,35 @@ ddg_goodie_test(
     'choose from products like turkey or venison' => undef,
     'choose pick or axe'                          => test_zci(
         qr/(pick|axe) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('pick or axe', 'Random selection from', qr/^(?:pick|axe)$/)
     ),
     'choose yes or no' => test_zci(
         qr/(yes|no) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('yes or no', 'Random selection from', qr/^(?:yes|no)$/)
     ),
     'choose this or that or none' => test_zci(
         qr/(this|that|none) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('this, that or none','Random selection from', qr/^(?:this|that|none)$/)
     ),
     'pick this or that or none' => test_zci(
         qr/(this|that|none) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('this, that or none', 'Random selection from', qr/^(?:this|that|none)$/)
     ),
     'select heads or tails' => test_zci(
         qr/(heads|tails) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('heads or tails', 'Random selection from', qr/^(?:heads|tails)$/)
     ),
     'choose heads or tails' => test_zci(
         qr/(heads|tails) \(Random\)/,
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('heads or tails', 'Random selection from', qr/^(?:heads|tails)$/)
     ),
     'choose duckduckgo or google or bing or something' => test_zci(
         'duckduckgo (Non-random)',
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('duckduckgo, google, bing or something', 'Non-random selection from', 'duckduckgo')
     ),
     'choose Google OR DuckDuckGo OR Bing OR SOMETHING' => test_zci(
         'DuckDuckGo (Non-random)',
-        structured_answer => create_structured_answer()
+        structured_answer => create_structured_answer('Google, DuckDuckGo, Bing or SOMETHING', 'Non-random selection from', 'DuckDuckGo')
     ),
 );
 

--- a/t/ABC.t
+++ b/t/ABC.t
@@ -68,7 +68,6 @@ ddg_goodie_test(
             title => "DuckDuckGo",
             subtitle => "Non-random selection from: Google, DuckDuckGo, Bing or SOMETHING"
         })
-        #'DuckDuckGo')
     ),
 );
 


### PR DESCRIPTION
Lo,

This one's still using the structured answer so I've converted it to the full template.

There are some slight issues with the tests here, the existing `-ANY-` mechanism doesn't work too well for this, as ideally all components of the `structured_answer` would be asserted and then only the random component could be asserted against a regex (something like : https://github.com/duckduckgo/zeroclickinfo-goodies/commit/4ef7c85ce66f15bb62cfdf474bc029a029818b30) 

https://duck.co/ia/view/abc