### PR TITLE
PigLatin: Update to use templates

### DIFF
--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -12,6 +12,7 @@ zci is_cached   => 1;
 
 handle remainder => sub {
     my $in = shift;
+    return unless $in;
 
     my $out = piglatin($in);
 

--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -42,7 +42,7 @@ handle query_raw => sub {
         name => 'Answer',
         data => {
             title    => "$result",
-            subtitle => "Translate $action Pig Latin: $to_translate",
+            subtitle => html_enc("Translate $action Pig Latin: $to_translate"),
         },
         templates => {
             group  => 'text',

--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -10,21 +10,38 @@ triggers any => 'pig latin', 'piglatin';
 zci answer_type => "translation";
 zci is_cached   => 1;
 
-handle query_raw => sub {
+my $piglatin = qr/pig ?latin/i;
+my $actions = qr/(?<action>to|from|in)/i;
+my $additional_forms = qr/(?:what is|how (?:(?:do|would) (?:you|I)| to) say)/i;
+
+sub get_action {
     my $query = shift;
-    $query =~ s/\s*(?<action>to|from|in)\s*pig ?latin\s*$//i;
-    $+{'action'} // ($query =~ s/^\s*(?<action>to|from|in)?+\s*pig ?latin\s*//i or return);
-    return unless $query;
+    $query =~ s/(^\s+|\s+$)//g;
+    $query =~ s/[!.]$//;
+    $query =~ s/^$additional_forms\s*+(.+?)\s*+(?<action>in)\s*$piglatin\s*[?]?$/$1/i;
+    $+{'action'} // ($query =~ s/^translate\s*+(.+?)\s*+(?<action>from|to)\s*$piglatin$/$1/i);
+    $+{'action'} // ($query =~ s/\s*$actions\s*$piglatin$//i);
+    $+{'action'} // ($query =~ s/^$actions?+\s*$piglatin\s*//i or return);
+    return if $query eq '';
     my $action = lc ($+{'action'} // 'to');
     $action = 'to' if $action eq 'in';
-    my $result = $action eq 'to' ? to_piglatin($query) : from_piglatin($query);
+    return ($query, $action);
+}
+
+handle query_raw => sub {
+    my $query = shift;
+    my ($to_translate, $action) = get_action $query or return;
+    return if $to_translate eq '';
+    my $result = $action eq 'to'
+        ? to_piglatin($to_translate)
+        : from_piglatin($to_translate);
 
     return $result, structured_answer => {
         id   => 'pig_latin',
         name => 'Answer',
         data => {
             title    => "$result",
-            subtitle => "Translate $action Pig Latin: $query",
+            subtitle => "Translate $action Pig Latin: $to_translate",
         },
         templates => {
             group  => 'text',

--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -13,7 +13,7 @@ zci is_cached   => 1;
 handle query_raw => sub {
     my $query = shift;
     $query =~ s/\s*(?<action>to|from|in)\s*pig ?latin\s*$//i;
-    $query =~ s/^\s*(?<action>to|from|in)?+\s*pig ?latin\s*//i unless $+{'action'};
+    $+{'action'} // ($query =~ s/^\s*(?<action>to|from|in)?+\s*pig ?latin\s*//i or return);
     return unless $query;
     my $action = lc ($+{'action'} // 'to');
     $action = 'to' if $action eq 'in';

--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -35,6 +35,7 @@ handle query_raw => sub {
     my $result = $action eq 'to'
         ? to_piglatin($to_translate)
         : from_piglatin($to_translate);
+    return if $result eq $to_translate;
 
     return $result, structured_answer => {
         id   => 'pig_latin',

--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -11,16 +11,21 @@ zci answer_type => "translation";
 zci is_cached   => 1;
 
 handle remainder => sub {
-    my $in = shift;
-    return unless $in;
+    my $query = shift;
+    return unless $query;
 
-    my $out = piglatin($in);
-
-    return "Pig Latin: " . $out,
-      structured_answer => {
-        input     => [html_enc($in)],
-        operation => 'Translate to Pig Latin',
-        result    => html_enc($out)
+    my $result = piglatin($query);
+    return $result, structured_answer => {
+        id   => 'pig_latin',
+        name => 'Answer',
+        data => {
+            title    => "$result",
+            subtitle => "Translate to Pig Latin: $query",
+        },
+        templates => {
+            group  => 'text',
+            moreAt => 0,
+        },
       };
 };
 

--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -28,7 +28,7 @@ sub get_action {
     return ($query, $action);
 }
 
-handle query_raw => sub {
+handle query => sub {
     my $query = shift;
     my ($to_translate, $action) = get_action $query or return;
     return if $to_translate eq '';

--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -23,7 +23,7 @@ sub get_action {
     $+{'action'} // ($query =~ s/\s*$actions\s*$piglatin$//i);
     $+{'action'} // ($query =~ s/^$actions?+\s*$piglatin\s*//i or return);
     return if $query eq '';
-    my $action = lc ($+{'action'} // 'to');
+    my $action = lc ($+{'action'} // return);
     $action = 'to' if $action eq 'in';
     return ($query, $action);
 }

--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -3,24 +3,28 @@ package DDG::Goodie::PigLatin;
 
 use strict;
 use DDG::Goodie;
-use Lingua::PigLatin 'piglatin';
+use Lingua::PigLatin::Bidirectional;
 
-triggers startend => 'pig latin', 'piglatin';
+triggers any => 'pig latin', 'piglatin';
 
 zci answer_type => "translation";
 zci is_cached   => 1;
 
-handle remainder => sub {
+handle query_raw => sub {
     my $query = shift;
+    $query =~ s/\s*(?<action>to|from|in)\s*pig ?latin\s*$//i;
+    $query =~ s/^\s*(?<action>to|from|in)?+\s*pig ?latin\s*//i unless $+{'action'};
     return unless $query;
+    my $action = lc ($+{'action'} // 'to');
+    $action = 'to' if $action eq 'in';
+    my $result = $action eq 'to' ? to_piglatin($query) : from_piglatin($query);
 
-    my $result = piglatin($query);
     return $result, structured_answer => {
         id   => 'pig_latin',
         name => 'Answer',
         data => {
             title    => "$result",
-            subtitle => "Translate to Pig Latin: $query",
+            subtitle => "Translate $action Pig Latin: $query",
         },
         templates => {
             group  => 'text',

--- a/lib/DDG/Goodie/PigLatin.pm
+++ b/lib/DDG/Goodie/PigLatin.pm
@@ -41,7 +41,7 @@ handle query_raw => sub {
         id   => 'pig_latin',
         name => 'Answer',
         data => {
-            title    => "$result",
+            title    => html_enc("$result"),
             subtitle => html_enc("Translate $action Pig Latin: $to_translate"),
         },
         templates => {

--- a/t/PigLatin.t
+++ b/t/PigLatin.t
@@ -28,19 +28,31 @@ sub build_test { test_zci(build_structured_answer(@_)) }
 
 ddg_goodie_test(
     [qw( DDG::Goodie::PigLatin )],
-    'pig latin will this work?'       => build_test('illway isthay orkway?', 'to', 'will this work?'),
-    'piglatin i love duckduckgo'      => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
-    'pig latin i love duckduckgo'     => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
-    'What is this? in piglatin'       => build_test('Atwhay isway isthay?', 'to', 'What is this?'),
-    'in piglatin foo'                 => build_test('oofay', 'to', 'foo'),
-    'from pigLatiN oofay'             => build_test('foo', 'from', 'oofay'),
-    'piglatin in piglatin'            => build_test('iglatinpay', 'to', 'piglatin'),
-    'iglatinpay from piglatin'        => build_test('piglatin', 'from', 'iglatinpay'),
-    'pig latin'                       => undef,
-    'piglatin'                        => undef,
-    'what is piglatin?'               => undef,
-    'from piglatin in piglatin'       => build_test('romfay iglatinpay', 'to', 'from piglatin'),
-    'romfay iglatinpay from piglatin' => build_test('from piglatin', 'from', 'romfay iglatinpay'),
+    # Basic forms
+    'pig latin will this work?'   => build_test('illway isthay orkway?', 'to', 'will this work?'),
+    'piglatin i love duckduckgo'  => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
+    'pig latin i love duckduckgo' => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
+    'in piglatin foo'             => build_test('oofay', 'to', 'foo'),
+    'from pigLatiN oofay'         => build_test('foo', 'from', 'oofay'),
+    'piglatin in piglatin'        => build_test('iglatinpay', 'to', 'piglatin'),
+    'iglatinpay from piglatin'    => build_test('piglatin', 'from', 'iglatinpay'),
+    # Additional forms
+    'from piglatin in piglatin'                 => build_test('romfay iglatinpay', 'to', 'from piglatin'),
+    'romfay iglatinpay from piglatin'           => build_test('from piglatin', 'from', 'romfay iglatinpay'),
+    'how do you say I am awesome in piglatin?'  => build_test('Iway amway awesomeway', 'to', 'I am awesome'),
+    'what is piglatin in piglatin?'             => build_test('iglatinpay', 'to', 'piglatin'),
+    'translate hello to piglatin.'              => build_test('ellohay', 'to', 'hello'),
+    'translate ellohay from piglatin'           => build_test('hello', 'from', 'ellohay'),
+    'How would I say What is this? in piglatin' => build_test('Atwhay isway isthay?', 'to', 'What is this?'),
+    'What is piglatin to piglatin'              => build_test('Atwhay isway iglatinpay', 'to', 'What is piglatin'),
+    'translate foo in piglatin'                 => build_test('ranslatetay oofay', 'to', 'translate foo'),
+    'translate to piglatin'                     => build_test('ranslatetay', 'to', 'translate'),
+    'what is in piglatin'                       => build_test('atwhay isway', 'to', 'what is'),
+    # Non-matchers
+    'pig latin'            => undef,
+    'piglatin'             => undef,
+    'what is piglatin?'    => undef,
+    'what is in piglatin?' => undef,
 );
 
 done_testing;

--- a/t/PigLatin.t
+++ b/t/PigLatin.t
@@ -8,34 +8,31 @@ use DDG::Test::Goodie;
 zci answer_type => 'translation';
 zci is_cached   => 1;
 
+sub build_structured_answer {
+    my ($expected_result, $expected_formatted_input) = @_;
+    return $expected_result, structured_answer => {
+        id   => 'pig_latin',
+        name => 'Answer',
+        data => {
+            title    => "$expected_result",
+            subtitle => "Translate to Pig Latin: $expected_formatted_input",
+        },
+        templates => {
+            group  => 'text',
+            moreAt => 0,
+        },
+    };
+}
+
+sub build_test { test_zci(build_structured_answer(@_)) }
+
 ddg_goodie_test(
     [qw( DDG::Goodie::PigLatin )],
-    'pig latin will this work?' => test_zci(
-        'Pig Latin: illway isthay orkway?',
-        structured_answer => {
-            input     => ['will this work?'],
-            operation => 'Translate to Pig Latin',
-            result    => 'illway isthay orkway?'
-        }
-    ),
-    'piglatin i love duckduckgo' => test_zci(
-        'Pig Latin: iway ovelay uckduckgoday',
-        structured_answer => {
-            input     => ['i love duckduckgo'],
-            operation => 'Translate to Pig Latin',
-            result    => 'iway ovelay uckduckgoday'
-        }
-    ),
-    'pig latin i love duckduckgo' => test_zci(
-        'Pig Latin: iway ovelay uckduckgoday',
-        structured_answer => {
-            input     => ['i love duckduckgo'],
-            operation => 'Translate to Pig Latin',
-            result    => 'iway ovelay uckduckgoday'
-        }
-    ),
-    'pig latin' => undef,
-    'piglatin'  => undef,
+    'pig latin will this work?'   => build_test('illway isthay orkway?', 'will this work?'),
+    'piglatin i love duckduckgo'  => build_test('iway ovelay uckduckgoday', 'i love duckduckgo'),
+    'pig latin i love duckduckgo' => build_test('iway ovelay uckduckgoday', 'i love duckduckgo'),
+    'pig latin'                   => undef,
+    'piglatin'                    => undef,
 );
 
 done_testing;

--- a/t/PigLatin.t
+++ b/t/PigLatin.t
@@ -29,13 +29,11 @@ sub build_test { test_zci(build_structured_answer(@_)) }
 ddg_goodie_test(
     [qw( DDG::Goodie::PigLatin )],
     # Basic forms
-    'pig latin will this work?'   => build_test('illway isthay orkway?', 'to', 'will this work?'),
-    'piglatin i love duckduckgo'  => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
-    'pig latin i love duckduckgo' => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
-    'in piglatin foo'             => build_test('oofay', 'to', 'foo'),
-    'from pigLatiN oofay'         => build_test('foo', 'from', 'oofay'),
-    'piglatin in piglatin'        => build_test('iglatinpay', 'to', 'piglatin'),
-    'iglatinpay from piglatin'    => build_test('piglatin', 'from', 'iglatinpay'),
+    'in pig latin i love duckduckgo' => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
+    'in piglatin foo'                => build_test('oofay', 'to', 'foo'),
+    'from pigLatiN oofay'            => build_test('foo', 'from', 'oofay'),
+    'piglatin in piglatin'           => build_test('iglatinpay', 'to', 'piglatin'),
+    'iglatinpay from piglatin'       => build_test('piglatin', 'from', 'iglatinpay'),
     # Additional forms
     'from piglatin in piglatin'                 => build_test('romfay iglatinpay', 'to', 'from piglatin'),
     'romfay iglatinpay from piglatin'           => build_test('from piglatin', 'from', 'romfay iglatinpay'),
@@ -49,11 +47,13 @@ ddg_goodie_test(
     'translate to piglatin'                     => build_test('ranslatetay', 'to', 'translate'),
     'what is in piglatin'                       => build_test('atwhay isway', 'to', 'what is'),
     # Non-matchers
-    'pig latin'            => undef,
-    'piglatin'             => undef,
-    'what is piglatin?'    => undef,
-    'what is in piglatin?' => undef,
-    'piglatin 0'           => undef,
+    'piglatin i love duckduckgo' => undef,
+    'pig latin will this work?'  => undef,
+    'pig latin'                  => undef,
+    'piglatin'                   => undef,
+    'what is piglatin?'          => undef,
+    'what is in piglatin?'       => undef,
+    'piglatin 0'                 => undef,
 );
 
 done_testing;

--- a/t/PigLatin.t
+++ b/t/PigLatin.t
@@ -53,6 +53,7 @@ ddg_goodie_test(
     'piglatin'             => undef,
     'what is piglatin?'    => undef,
     'what is in piglatin?' => undef,
+    'piglatin 0'           => undef,
 );
 
 done_testing;

--- a/t/PigLatin.t
+++ b/t/PigLatin.t
@@ -28,16 +28,19 @@ sub build_test { test_zci(build_structured_answer(@_)) }
 
 ddg_goodie_test(
     [qw( DDG::Goodie::PigLatin )],
-    'pig latin will this work?'   => build_test('illway isthay orkway?', 'to', 'will this work?'),
-    'piglatin i love duckduckgo'  => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
-    'pig latin i love duckduckgo' => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
-    'What is this? in piglatin'   => build_test('Atwhay isway isthay?', 'to', 'What is this?'),
-    'in piglatin foo'             => build_test('oofay', 'to', 'foo'),
-    'from pigLatiN oofay'         => build_test('foo', 'from', 'oofay'),
-    'piglatin in piglatin'        => build_test('iglatinpay', 'to', 'piglatin'),
-    'iglatinpay from piglatin'    => build_test('piglatin', 'from', 'iglatinpay'),
-    'pig latin'                   => undef,
-    'piglatin'                    => undef,
+    'pig latin will this work?'       => build_test('illway isthay orkway?', 'to', 'will this work?'),
+    'piglatin i love duckduckgo'      => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
+    'pig latin i love duckduckgo'     => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
+    'What is this? in piglatin'       => build_test('Atwhay isway isthay?', 'to', 'What is this?'),
+    'in piglatin foo'                 => build_test('oofay', 'to', 'foo'),
+    'from pigLatiN oofay'             => build_test('foo', 'from', 'oofay'),
+    'piglatin in piglatin'            => build_test('iglatinpay', 'to', 'piglatin'),
+    'iglatinpay from piglatin'        => build_test('piglatin', 'from', 'iglatinpay'),
+    'pig latin'                       => undef,
+    'piglatin'                        => undef,
+    'what is piglatin?'               => undef,
+    'from piglatin in piglatin'       => build_test('romfay iglatinpay', 'to', 'from piglatin'),
+    'romfay iglatinpay from piglatin' => build_test('from piglatin', 'from', 'romfay iglatinpay'),
 );
 
 done_testing;

--- a/t/PigLatin.t
+++ b/t/PigLatin.t
@@ -9,13 +9,13 @@ zci answer_type => 'translation';
 zci is_cached   => 1;
 
 sub build_structured_answer {
-    my ($expected_result, $expected_formatted_input) = @_;
+    my ($expected_result, $expected_action, $expected_formatted_input) = @_;
     return $expected_result, structured_answer => {
         id   => 'pig_latin',
         name => 'Answer',
         data => {
             title    => "$expected_result",
-            subtitle => "Translate to Pig Latin: $expected_formatted_input",
+            subtitle => "Translate $expected_action Pig Latin: $expected_formatted_input",
         },
         templates => {
             group  => 'text',
@@ -28,9 +28,14 @@ sub build_test { test_zci(build_structured_answer(@_)) }
 
 ddg_goodie_test(
     [qw( DDG::Goodie::PigLatin )],
-    'pig latin will this work?'   => build_test('illway isthay orkway?', 'will this work?'),
-    'piglatin i love duckduckgo'  => build_test('iway ovelay uckduckgoday', 'i love duckduckgo'),
-    'pig latin i love duckduckgo' => build_test('iway ovelay uckduckgoday', 'i love duckduckgo'),
+    'pig latin will this work?'   => build_test('illway isthay orkway?', 'to', 'will this work?'),
+    'piglatin i love duckduckgo'  => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
+    'pig latin i love duckduckgo' => build_test('iway ovelay uckduckgoday', 'to', 'i love duckduckgo'),
+    'What is this? in piglatin'   => build_test('Atwhay isway isthay?', 'to', 'What is this?'),
+    'in piglatin foo'             => build_test('oofay', 'to', 'foo'),
+    'from pigLatiN oofay'         => build_test('foo', 'from', 'oofay'),
+    'piglatin in piglatin'        => build_test('iglatinpay', 'to', 'piglatin'),
+    'iglatinpay from piglatin'    => build_test('piglatin', 'from', 'iglatinpay'),
     'pig latin'                   => undef,
     'piglatin'                    => undef,
 );

--- a/t/PigLatin.t
+++ b/t/PigLatin.t
@@ -34,6 +34,8 @@ ddg_goodie_test(
             result    => 'iway ovelay uckduckgoday'
         }
     ),
+    'pig latin' => undef,
+    'piglatin'  => undef,
 );
 
 done_testing;


### PR DESCRIPTION
Updates the [PigLatin IA](https://duck.co/ia/view/pig_latin) to using the `text` text answer template.

Also Fixes #1969 with a simple trigger check.

-----
IA Page: https://duck.co/ia/view/pig_latin