### PR TITLE
Added 'kairali' trigger word

### DIFF
--- a/share/goodie/cheat_sheets/json/language/malayalam.json
+++ b/share/goodie/cheat_sheets/json/language/malayalam.json
@@ -7,8 +7,15 @@
       "sourceUrl" : "http://www.pravasimalayalam.com/index.shtml"
    },
    "aliases": [
-       "malayalam phrases", "english to malayalam",
-       "basic malayalam phrases", "basic malayalam"
+       "malayalam phrases",
+       "english to malayalam",
+       "basic malayalam phrases",
+       "basic malayalam",
+       "kairali",
+       "kairali phrases",
+       "english to kairali",
+       "basic kairali phrases",
+       "basic kairali"
    ],
    "template_type": "language",
    "section_order" : [


### PR DESCRIPTION
[According to Wikipedia](https://en.wikipedia.org/wiki/Malayalam), Malayalam is sometimes referred to as Kairali so added that as a trigger.