### PR TITLE
Conversions: "Convert The Future Into The Present"

### DIFF
--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -71,14 +71,14 @@ handle query_lc => sub {
     
     # hack - convert "oz" to "fl oz" if "ml" contained in query
     s/(oz|ounces)/fl oz/ if(/ml/ && not /fl oz/);
-warn("LINE 74");    
+#warn("LINE 74");    
     # guard the query from spurious matches
     return unless $_ =~ /$guard/;
-warn("LINE 77");    
+#warn("LINE 77");    
     my @matches = ($+{'left_unit'}, $+{'right_unit'});
     return if ("" ne $+{'left_num'} && "" ne $+{'right_num'});
     my $factor = $+{'left_num'};
-warn("LINE 81");
+#warn("LINE 81");
     # Compare factors of both units to ensure proper order when ambiguous
     # also, check the <connecting_word> of regex for possible user intentions 
     my @factor1 = (); # conversion factors, not left_num or right_num values
@@ -109,7 +109,7 @@ warn("LINE 81");
         }
     }
 
-warn("LINE 112");
+#warn("LINE 112");
     # if the query is in the format <unit> in <num> <unit> we need to flip
     # also if it's like "how many cm in metre"; the "1" is implicitly metre so also flip
     # But if the second unit is plural, assume we want the the implicit one on the first
@@ -127,7 +127,7 @@ warn("LINE 112");
         @matches = ($matches[1], $matches[0]);
     }
     $factor = 1 if ($factor =~ qr/^(a[n]?)?$/);
-warn("LINE 130");
+#warn("LINE 130");
     my $styler = number_style_for($factor);
     return unless $styler;
 
@@ -137,9 +137,9 @@ warn("LINE 130");
         'to_unit' => $matches[1],
     });
 
-warn("LINE 139");
+#warn("LINE 139");
     return if !$result->{'result'};
-warn("LINE 141");
+#warn("LINE 141");
     my $formatted_result = sprintf("%.${precision}f", $result->{'result'});
 
     # if $result = 1.00000 .. 000n, where n <> 0 then $result != 1 and throws off pluralization, so:
@@ -192,7 +192,7 @@ sub looks_plural {
 sub convert_temperatures {
     my ($from, $to, $in_temperature) = @_;
 
-    warn("'$from' '$to' '$in_temperature'\n");
+    #warn("'$from' '$to' '$in_temperature'\n");
 
     my $kelvin;
     # Convert to SI (Kelvin)
@@ -236,11 +236,11 @@ sub get_matches {
 sub convert {
     my ($conversion) = @_;
     my @matches = get_matches($conversion->{'from_unit'}, $conversion->{'to_unit'});
-warn("line 239 ---  ".dump($conversion));
+#warn("line 239 ---  ".dump($conversion));
     return if $conversion->{'factor'} < 0 && !($matches[0]->{'can_be_negative'}); 
     # matches must be of the same type (e.g., can't convert mass to length):
     return if ($matches[0]->{'type'} ne $matches[1]->{'type'});
-warn("line 243");
+#warn("line 243");
     my $result;
     # run the conversion:
     # temperatures don't have 1:1 conversions, so they get special treatment:
@@ -249,7 +249,7 @@ warn("line 243");
     }
     else {
         $result = $conversion->{'factor'} * ($matches[1]->{'factor'} / $matches[0]->{'factor'});
-    }warn("line 252");
+    }#warn("line 252");
     return {
         "result" => $result,
         "from_unit" => $matches[0]->{'unit'},

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -69,7 +69,7 @@ handle query_lc => sub {
     $_ =~ s/'/feet/;
 
     # hack support for "degrees" prefix on temperatures
-    $_ =~ s/ degree[s]? (celsius|fahrenheit)/ $1/;
+    $_ =~ s/ degree[s]? (celsius|fahrenheit|rankine)/ $1/;
     
     # hack - convert "oz" to "fl oz" if "ml" contained in query
     s/\b(oz|ounces)/fl oz/ if(/(ml|cup[s]?)/ && not /fl oz/);

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -85,7 +85,7 @@ handle query_lc => sub {
     # also, check the <connecting_word> of regex for possible user intentions 
     my @factor1 = (); # conversion factors, not left_num or right_num values
     my @factor2 = ();
-	    
+        
     # gets factors for comparison
     foreach my $type (@types) {
         if($+{'left_unit'} eq $type->{'unit'}) {

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -9,7 +9,7 @@ use Math::Round qw/nearest/;
 use bignum;
 use utf8;
 use YAML qw(Load);
-
+use Data::Dump qw(dump);
 name                      'Conversions';
 description               'convert between various units of measurement';
 category                  'calculations';
@@ -71,14 +71,14 @@ handle query_lc => sub {
     
     # hack - convert "oz" to "fl oz" if "ml" contained in query
     s/(oz|ounces)/fl oz/ if(/ml/ && not /fl oz/);
-    
+warn("LINE 74");    
     # guard the query from spurious matches
     return unless $_ =~ /$guard/;
-    
+warn("LINE 77");    
     my @matches = ($+{'left_unit'}, $+{'right_unit'});
     return if ("" ne $+{'left_num'} && "" ne $+{'right_num'});
     my $factor = $+{'left_num'};
-
+warn("LINE 81");
     # Compare factors of both units to ensure proper order when ambiguous
     # also, check the <connecting_word> of regex for possible user intentions 
     my @factor1 = (); # conversion factors, not left_num or right_num values
@@ -109,7 +109,7 @@ handle query_lc => sub {
         }
     }
 
-
+warn("LINE 112");
     # if the query is in the format <unit> in <num> <unit> we need to flip
     # also if it's like "how many cm in metre"; the "1" is implicitly metre so also flip
     # But if the second unit is plural, assume we want the the implicit one on the first
@@ -127,7 +127,7 @@ handle query_lc => sub {
         @matches = ($matches[1], $matches[0]);
     }
     $factor = 1 if ($factor =~ qr/^(a[n]?)?$/);
-
+warn("LINE 130");
     my $styler = number_style_for($factor);
     return unless $styler;
 
@@ -136,9 +136,10 @@ handle query_lc => sub {
         'from_unit' => $matches[0],
         'to_unit' => $matches[1],
     });
-    
-    return if !$result->{'result'};
 
+warn("LINE 139");
+    return if !$result->{'result'};
+warn("LINE 141");
     my $formatted_result = sprintf("%.${precision}f", $result->{'result'});
 
     # if $result = 1.00000 .. 000n, where n <> 0 then $result != 1 and throws off pluralization, so:
@@ -191,6 +192,8 @@ sub looks_plural {
 sub convert_temperatures {
     my ($from, $to, $in_temperature) = @_;
 
+    warn("'$from' '$to' '$in_temperature'\n");
+
     my $kelvin;
     # Convert to SI (Kelvin)
     if    ($from =~ /^f(?:ahrenheit)?$/i) { $kelvin = ($in_temperature + 459.67) * 5/9; }
@@ -233,11 +236,11 @@ sub get_matches {
 sub convert {
     my ($conversion) = @_;
     my @matches = get_matches($conversion->{'from_unit'}, $conversion->{'to_unit'});
-    
-    return if $conversion->{'factor'} < 0 && !($matches[0]->{'can_be_negative'} && $matches[1]->{'can_be_negative'}); 
+warn("line 239 ---  ".dump($conversion));
+    return if $conversion->{'factor'} < 0 && !($matches[0]->{'can_be_negative'}); 
     # matches must be of the same type (e.g., can't convert mass to length):
     return if ($matches[0]->{'type'} ne $matches[1]->{'type'});
-
+warn("line 243");
     my $result;
     # run the conversion:
     # temperatures don't have 1:1 conversions, so they get special treatment:
@@ -246,7 +249,7 @@ sub convert {
     }
     else {
         $result = $conversion->{'factor'} * ($matches[1]->{'factor'} / $matches[0]->{'factor'});
-    }
+    }warn("line 252");
     return {
         "result" => $result,
         "from_unit" => $matches[0]->{'unit'},

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -39,7 +39,7 @@ triggers any => @triggers;
 
 # match longest possible key (some keys are sub-keys of other keys):
 my $keys = join '|', reverse sort { length($a) <=> length($b) } @units;
-my $question_prefix = qr/(?<prefix>convert|what (?:is|are|does)|how (?:much|many|long) (?:is|are)?|(?:number of))?/;
+my $question_prefix = qr/(?<prefix>convert|what (?:is|are|does)|how (?:much|many|long) (?:is|are)?|(?:number of)|(?:how to convert))?/;
 
 # guards and matches regex
 my $factor_re = join('|', ('a', 'an', number_style_regex()));

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -72,7 +72,7 @@ handle query_lc => sub {
     $_ =~ s/ degrees (celsius|fahrenheit)/ $1/;
     
     # hack - convert "oz" to "fl oz" if "ml" contained in query
-    s/(oz|ounces)/fl oz/ if(/ml/ && not /fl oz/);
+    s/\b(oz|ounces)/fl oz/ if(/(ml|cup[s]?)/ && not /fl oz/);
     
     # guard the query from spurious matches
     return unless $_ =~ /$guard/;

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -7,8 +7,7 @@ with 'DDG::GoodieRole::NumberStyler';
 
 use Math::Round qw/nearest/;
 use bignum;
-use Convert::Pluggable;
-use utf8;
+use YAML qw(Load);
 
 name                      'Conversions';
 description               'convert between various units of measurement';
@@ -24,13 +23,9 @@ attribution                github  => 'https://github.com/elohmrow',
 zci answer_type => 'conversions';
 zci is_cached   => 1;
 
-# build the keys:
-# unit types available for conversion
-my $c = new Convert::Pluggable();
-my @types = @{$c->get_units()};
+my @types = Load(scalar share('ratios.yml')->slurp);
 
 my @units = ();
-
 foreach my $type (@types) {
     push(@units, $type->{'unit'});
     push(@units, @{$type->{'aliases'}});
@@ -59,15 +54,11 @@ my %plural_exceptions = (
     'electrical horsepower'  => 'electrical horsepower',
     'pounds force'           => 'pounds force',
 );
-
 my %singular_exceptions = reverse %plural_exceptions;
 
-my %temperature_aliases = (
-    'celsius'    => '°C',
-    'fahrenheit' => '°F',
-    'rankine'    => '°R',
-    'kelvin'     => 'K',
-);
+# fix precision and rounding:
+my $precision = 3;
+my $nearest = '.' . ('0' x ($precision-1)) . '1';
 
 handle query_lc => sub {
     # hack around issues with feet and inches for now
@@ -79,25 +70,19 @@ handle query_lc => sub {
     
     # hack - convert "oz" to "fl oz" if "ml" contained in query
     s/(oz|ounces)/fl oz/ if(/ml/ && not /fl oz/);
-
+    
     # guard the query from spurious matches
     return unless $_ =~ /$guard/;
-   
+    
     my @matches = ($+{'left_unit'}, $+{'right_unit'});
     return if ("" ne $+{'left_num'} && "" ne $+{'right_num'});
     my $factor = $+{'left_num'};
-    
- 
 
-    # if the query is in the format <unit> in <num> <unit> we need to flip
-    # also if it's like "how many cm in metre"; the "1" is implicitly metre so also flip
-    # But if the second unit is plural, assume we want the the implicit one on the first 
-    # It's always ambiguous when they are both countless and plural, so shouldn't be too bad.
     # Compare factors of both units to ensure proper order when ambiguous
     # also, check the <connecting_word> of regex for possible user intentions 
     my @factor1 = (); # conversion factors, not left_num or right_num values
     my @factor2 = ();
-    
+	    
     # gets factors for comparison
     foreach my $type (@types) {
         if($+{'left_unit'} eq $type->{'unit'}) {
@@ -123,6 +108,11 @@ handle query_lc => sub {
         }
     }
 
+
+    # if the query is in the format <unit> in <num> <unit> we need to flip
+    # also if it's like "how many cm in metre"; the "1" is implicitly metre so also flip
+    # But if the second unit is plural, assume we want the the implicit one on the first
+    # It's always ambiguous when they are both countless and plural, so shouldn't be too bad.
     if (
         "" ne $+{'right_num'}
         || (   "" eq $+{'left_num'}
@@ -136,59 +126,49 @@ handle query_lc => sub {
         @matches = ($matches[1], $matches[0]);
     }
     $factor = 1 if ($factor =~ qr/^(a[n]?)?$/);
-    
-    # fix precision and rounding:
-    my $precision = 3;
-    my $nearest = '.' . ('0' x ($precision-1)) . '1';
 
     my $styler = number_style_for($factor);
     return unless $styler;
 
-    my $result = $c->convert( {
+    my $result = convert({
         'factor' => $styler->for_computation($factor),
         'from_unit' => $matches[0],
         'to_unit' => $matches[1],
-        'precision' => $precision,
-    } );
+    });
     
     return if !$result->{'result'};
 
-    my $f_result;
+    my $formatted_result = sprintf("%.${precision}f", $result->{'result'});
 
     # if $result = 1.00000 .. 000n, where n <> 0 then $result != 1 and throws off pluralization, so:
     $result->{'result'} = nearest($nearest, $result->{'result'});
 
     if ($result->{'result'} == 0 || length($result->{'result'}) > 2*$precision + 1) {
-        if ($result->{'result'} == 0) {
-            # rounding error
-            $result = $c->convert( {
-                'factor' => $styler->for_computation($factor),
-                'from_unit' => $matches[0],
-                'to_unit' => $matches[1],
-                'precision' => $precision,
-            } );
-        }
+        # rounding error
+        $result = convert({
+            'factor' => $styler->for_computation($factor),
+            'from_unit' => $matches[0],
+            'to_unit' => $matches[1],
+        });
 
         # We only display it in exponent form if it's above a certain number.
         # We also want to display numbers from 0 to 1 in exponent form.
-        if($result->{'result'} > 1_000_000 || $result->{'result'} < 1) {
-            $f_result = (sprintf "%.${precision}g", $result->{'result'});
-        } else {
-            $f_result = (sprintf "%.${precision}f", $result->{'result'});
+        if($result->{'result'} > 1_000_000 || abs($result->{'result'}) < 1) {
+            $formatted_result = (sprintf "%.${precision}g", $result->{'result'});
         }
     }
 
     # handle pluralisation of units
     # however temperature is never plural and does require "degrees" to be prepended
-    if ($result->{'type_1'} ne 'temperature') {
+    if ($result->{'type'} eq 'temperature') {
+        $result->{'from_unit'} = ($factor == 1 ? "degree" : "degrees") . " $result->{'from_unit'}" if ($result->{'from_unit'} ne "kelvin");
+        $result->{'to_unit'}   = ($result->{'result'} == 1 ? "degree" : "degrees") . " $result->{'to_unit'}" if ($result->{'to_unit'}   ne "kelvin");
+    } else {
         $result->{'from_unit'} = set_unit_pluralisation($result->{'from_unit'}, $factor);
         $result->{'to_unit'}   = set_unit_pluralisation($result->{'to_unit'},   $result->{'result'});
-    } else {
-        $result->{'from_unit'} = $temperature_aliases{$result->{'from_unit'}};
-        $result->{'to_unit'} = $temperature_aliases{$result->{'to_unit'}};
     }
 
-    $result->{'result'} = defined($f_result) ? $f_result : sprintf("%.${precision}f", $result->{'result'});
+    $result->{'result'} = $formatted_result;
     $result->{'result'} =~ s/\.0{$precision}$//;
     $result->{'result'} = $styler->for_display($result->{'result'});
 
@@ -197,31 +177,102 @@ handle query_lc => sub {
     return $factor . " $result->{'from_unit'} = $result->{'result'} $result->{'to_unit'}",
       structured_answer => {
         input     => [$styler->with_html($factor) . ' ' . $result->{'from_unit'}],
-        operation => 'Convert',
+        operation => 'convert',
         result    => $styler->with_html($result->{'result'}) . ' ' . $result->{'to_unit'},
       };
 };
 
+sub looks_plural {
+    my ($unit) = @_;
+    my @unit_letters = split //, $unit;
+    return exists $singular_exceptions{$unit} || $unit_letters[-1] eq 's';
+}
+sub convert_temperatures {
+    my ($from, $to, $factor) = @_;
+    # ##
+    # F  = (C * 1.8) + 32            # celsius to fahrenheit
+    # F  = 1.8 * (K - 273.15) + 32   # kelvin  to fahrenheit
+    # F  = R - 459.67                # rankine to fahrenheit
+    # F  = (Ra * 2.25) + 32          # reaumur to fahrenheit
+    #
+    # C  = (F - 32) * 0.555          # fahrenheit to celsius
+    # K  = (F + 459.67) * 0.555      # fahrenheit to kelvin
+    # R  = F + 459.67                # fahrenheit to rankine
+    # Ra = (F - 32) * 0.444          # fahrenheit to reaumur
+    # ##
+   
+    # convert $from to fahrenheit:
+    if    ($from =~ /fahrenheit|f/i) { $factor = $factor;                           }
+    elsif ($from =~ /celsius|c/i)    { $factor = ($factor * (9 / 5)) + 32;          }
+    elsif ($from =~ /kelvin|k/i)     { $factor = (9 / 5) * ($factor - 273.15) + 32; }
+    elsif ($from =~ /rankine|r/i)    { $factor = $factor - 459.67;                  }
+    else                             { $factor = ($factor * (9 / 4)) + 32;          } 
+    
+    # convert fahrenheit $to:
+    if    ($to   =~ /fahrenheit|f/i) { $factor = $factor;                           }
+    elsif ($to   =~ /celsius|c/i)    { $factor = ($factor - 32) * (5 / 9);          }
+    elsif ($to   =~ /kelvin|k/i)     { $factor = ($factor + 459.67) * (5 / 9);      }
+    elsif ($to   =~ /rankine|r/i)    { $factor = $factor + 459.67;                  }
+    else                             { $factor = ($factor - 32) * (4 / 9);          }
+
+    return $factor;
+}
+sub get_matches {
+    my @input_matches = @_;
+
+    my @output_matches = ();
+    foreach my $match (@input_matches) {
+        foreach my $type (@types) {
+            if (lc $match eq $type->{'unit'} || grep { $_ eq lc $match } @{$type->{'aliases'}}) {
+                push(@output_matches,{
+                    type => $type->{'type'},
+                    factor => $type->{'factor'},
+                    unit => $type->{'unit'},
+                    can_be_negative => $type->{'can_be_negative'} || '0'
+                });
+            }
+        }
+    }
+    return if scalar(@output_matches) != 2;
+    return @output_matches;
+}
+sub convert {
+    my ($conversion) = @_;
+    my @matches = get_matches($conversion->{'from_unit'}, $conversion->{'to_unit'});
+    
+    return if $conversion->{'factor'} < 0 && !($matches[0]->{'can_be_negative'} && $matches[1]->{'can_be_negative'}); 
+    # matches must be of the same type (e.g., can't convert mass to length):
+    return if ($matches[0]->{'type'} ne $matches[1]->{'type'});
+
+    my $result;
+    # run the conversion:
+    # temperatures don't have 1:1 conversions, so they get special treatment:
+    if ($matches[0]->{'type'} eq 'temperature') {
+        $result = convert_temperatures($matches[0]->{'unit'}, $matches[1]->{'unit'}, $conversion->{'factor'})
+    }
+    else {
+        $result = $conversion->{'factor'} * ($matches[1]->{'factor'} / $matches[0]->{'factor'});
+    }
+    return {
+        "result" => $result,
+        "from_unit" => $matches[0]->{'unit'},
+        "to_unit" => $matches[1]->{'unit'},
+        "type"  => $matches[0]->{'type'}
+    };
+}
 sub set_unit_pluralisation {
     my ($unit, $count) = @_;
-    my $proper_unit = $unit;    # By default, we'll leave it unchanged.
+    my $proper_unit = $unit;
 
     my $already_plural = looks_plural($unit);
 
-    if ($count == 1 && $already_plural) {
+    if ($already_plural && $count == 1) {
         $proper_unit = $singular_exceptions{$unit} || substr($unit, 0, -1);
-    } elsif ($count != 1 && !$already_plural) {
+    } elsif (!$already_plural && $count != 1) {
         $proper_unit = $plural_exceptions{$unit} || $unit . 's';
     }
 
     return $proper_unit;
-}
-
-sub looks_plural {
-    my $unit = shift;
-
-    my @unit_letters = split //, $unit;
-    return exists $singular_exceptions{$unit} || $unit_letters[-1] eq 's';
 }
 
 1;

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -8,7 +8,7 @@ with 'DDG::GoodieRole::NumberStyler';
 use Math::Round qw/nearest/;
 use bignum;
 use utf8;
-use YAML qw(Load);
+use YAML::XS 'LoadFile';
 
 name                      'Conversions';
 description               'convert between various units of measurement';
@@ -24,7 +24,7 @@ attribution                github  => 'https://github.com/elohmrow',
 zci answer_type => 'conversions';
 zci is_cached   => 1;
 
-my @types = Load(scalar share('ratios.yml')->slurp);
+my @types = LoadFile(share('ratios.yml'));
 
 my @units = ();
 foreach my $type (@types) {
@@ -33,7 +33,9 @@ foreach my $type (@types) {
 }
 
 # build triggers based on available conversion units:
-triggers any => map { lc $_ } @units;
+my @triggers = map { lc $_ } @units;
+
+triggers any => @triggers;
 
 # match longest possible key (some keys are sub-keys of other keys):
 my $keys = join '|', reverse sort { length($a) <=> length($b) } @units;

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -9,7 +9,7 @@ use Math::Round qw/nearest/;
 use bignum;
 use utf8;
 use YAML qw(Load);
-use Data::Dump qw(dump);
+
 name                      'Conversions';
 description               'convert between various units of measurement';
 category                  'calculations';
@@ -71,14 +71,14 @@ handle query_lc => sub {
     
     # hack - convert "oz" to "fl oz" if "ml" contained in query
     s/(oz|ounces)/fl oz/ if(/ml/ && not /fl oz/);
-#warn("LINE 74");    
+    
     # guard the query from spurious matches
     return unless $_ =~ /$guard/;
-#warn("LINE 77");    
+    
     my @matches = ($+{'left_unit'}, $+{'right_unit'});
     return if ("" ne $+{'left_num'} && "" ne $+{'right_num'});
     my $factor = $+{'left_num'};
-#warn("LINE 81");
+
     # Compare factors of both units to ensure proper order when ambiguous
     # also, check the <connecting_word> of regex for possible user intentions 
     my @factor1 = (); # conversion factors, not left_num or right_num values
@@ -109,7 +109,6 @@ handle query_lc => sub {
         }
     }
 
-#warn("LINE 112");
     # if the query is in the format <unit> in <num> <unit> we need to flip
     # also if it's like "how many cm in metre"; the "1" is implicitly metre so also flip
     # But if the second unit is plural, assume we want the the implicit one on the first
@@ -127,7 +126,7 @@ handle query_lc => sub {
         @matches = ($matches[1], $matches[0]);
     }
     $factor = 1 if ($factor =~ qr/^(a[n]?)?$/);
-#warn("LINE 130");
+
     my $styler = number_style_for($factor);
     return unless $styler;
     
@@ -137,9 +136,9 @@ handle query_lc => sub {
         'to_unit' => $matches[1],
     });
 
-#warn("LINE 139 ". dump($result));
+
     return unless defined $result->{'result'};
-#warn("LINE 141");
+
     my $formatted_result = sprintf("%.${precision}f", $result->{'result'});
 
     # if $result = 1.00000 .. 000n, where n <> 0 then $result != 1 and throws off pluralization, so:
@@ -192,8 +191,6 @@ sub looks_plural {
 sub convert_temperatures {
     my ($from, $to, $in_temperature) = @_;
 
-    #warn("'$from' '$to' '$in_temperature'\n");
-
     my $kelvin;
     # Convert to SI (Kelvin)
     if    ($from =~ /^f(?:ahrenheit)?$/i) { $kelvin = ($in_temperature + 459.67) * 5/9; }
@@ -236,11 +233,11 @@ sub get_matches {
 sub convert {
     my ($conversion) = @_;
     my @matches = get_matches($conversion->{'from_unit'}, $conversion->{'to_unit'});
-#warn("line 239 ---  ".dump($conversion));
+
     return if $conversion->{'factor'} < 0 && !($matches[0]->{'can_be_negative'}); 
     # matches must be of the same type (e.g., can't convert mass to length):
     return if ($matches[0]->{'type'} ne $matches[1]->{'type'});
-#warn("line 243");
+
     my $result;
     # run the conversion:
     # temperatures don't have 1:1 conversions, so they get special treatment:
@@ -249,7 +246,7 @@ sub convert {
     }
     else {
         $result = $conversion->{'factor'} * ($matches[1]->{'factor'} / $matches[0]->{'factor'});
-    }#warn("line 252");
+    }
     return {
         "result" => $result,
         "from_unit" => $matches[0]->{'unit'},

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -69,7 +69,7 @@ handle query_lc => sub {
     $_ =~ s/'/feet/;
 
     # hack support for "degrees" prefix on temperatures
-    $_ =~ s/ degrees (celsius|fahrenheit)/ $1/;
+    $_ =~ s/ degree[s]? (celsius|fahrenheit)/ $1/;
     
     # hack - convert "oz" to "fl oz" if "ml" contained in query
     s/\b(oz|ounces)/fl oz/ if(/(ml|cup[s]?)/ && not /fl oz/);

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -130,15 +130,15 @@ handle query_lc => sub {
 #warn("LINE 130");
     my $styler = number_style_for($factor);
     return unless $styler;
-
+    
     my $result = convert({
         'factor' => $styler->for_computation($factor),
         'from_unit' => $matches[0],
         'to_unit' => $matches[1],
     });
 
-#warn("LINE 139");
-    return if !$result->{'result'};
+#warn("LINE 139 ". dump($result));
+    return unless defined $result->{'result'};
 #warn("LINE 141");
     my $formatted_result = sprintf("%.${precision}f", $result->{'result'});
 

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -7,6 +7,7 @@ with 'DDG::GoodieRole::NumberStyler';
 
 use Math::Round qw/nearest/;
 use bignum;
+use utf8;
 use YAML qw(Load);
 
 name                      'Conversions';

--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -505,6 +505,14 @@ type: volume
 unit: us fluid ounce
 ---
 aliases:
+  - us cups
+  - cups
+  - cup
+factor: 4.2267528
+type: volume
+unit: us cup
+---
+aliases:
   - days
   - dy
   - dys

--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -1,0 +1,1264 @@
+---
+aliases:
+  - tonne
+  - t
+  - mt
+  - te
+  - metric tons
+  - tonnes
+  - ts
+  - mts
+  - tes
+factor: 1
+type: mass
+unit: metric ton
+---
+aliases:
+  - oz
+  - ounces
+  - ozs
+factor: 35274
+type: mass
+unit: ounce
+---
+aliases:
+  - lb
+  - lbm
+  - pound mass
+  - pounds
+  - lbs
+  - lbms
+  - pounds mass
+factor: 2204.62
+type: mass
+unit: pound
+---
+aliases:
+  - st
+  - stones
+  - sts
+factor: 157.473
+type: mass
+unit: stone
+---
+aliases:
+  - weight ton
+  - imperial ton
+  - long tons
+  - weight tons
+  - imperial tons
+factor: 0.984207
+type: mass
+unit: long ton
+---
+aliases:
+  - mcg
+  - micrograms
+  - mcgs
+factor: 1000000000000
+type: mass
+unit: microgram
+---
+aliases:
+  - kg
+  - kilo
+  - kilogramme
+  - kilograms
+  - kgs
+  - kilos
+  - kilogrammes
+factor: 1000
+type: mass
+unit: kilogram
+---
+aliases:
+  - g
+  - gm
+  - gramme
+  - grams
+  - gs
+  - gms
+  - grammes
+factor: 1000000
+type: mass
+unit: gram
+---
+aliases:
+  - mg
+  - milligrams
+  - mgs
+factor: 1000000000
+type: mass
+unit: milligram
+---
+aliases:
+  - short ton
+  - short tons
+  - tons
+factor: 1.10231
+type: mass
+unit: ton
+---
+aliases:
+  - meters
+  - metre
+  - metres
+  - m
+factor: 1
+type: length
+unit: meter
+---
+aliases:
+  - kilometers
+  - kilometre
+  - kilometres
+  - km
+  - kms
+  - klick
+  - klicks
+factor: 0.001
+type: length
+unit: kilometer
+---
+aliases:
+  - centimeters
+  - centimetre
+  - centimetres
+  - cm
+  - cms
+factor: 100
+type: length
+unit: centimeter
+---
+aliases:
+  - millimeters
+  - millimetre
+  - millimetres
+  - mm
+  - mms
+factor: 1000
+type: length
+unit: millimeter
+---
+aliases:
+  - miles
+  - mi
+  - statute mile
+  - statute miles
+  - land mile
+  - land miles
+factor: 0.000621371192237334
+type: length
+unit: mile
+---
+aliases:
+  - yards
+  - yd
+  - yds
+  - yrds
+factor: 1.0936133
+type: length
+unit: yard
+---
+aliases:
+  - feet
+  - ft
+  - international foot
+  - international feet
+  - survey foot
+  - survey feet
+factor: 3.28084
+type: length
+unit: foot
+---
+aliases:
+  - inches
+  - in
+  - ins
+factor: 39.3701
+type: length
+unit: inch
+---
+aliases:
+  - nautical miles
+  - n
+  - ns
+  - nm
+  - nms
+  - nmi
+  - nmis
+factor: 0.000539957
+type: length
+unit: nautical mile
+---
+aliases:
+  - furlongs
+factor: 0.00497096953789867
+type: length
+unit: furlong
+---
+aliases:
+  - gunter's chains
+  - chains
+factor: 0.0497096953789867
+type: length
+unit: chain
+---
+aliases:
+  - gunter's links
+  - links
+factor: 4.97096953789867
+type: length
+unit: link
+---
+aliases:
+  - rods
+factor: 0.198838781515947
+type: length
+unit: rod
+---
+aliases:
+  - fathoms
+  - ftm
+  - ftms
+factor: 0.539611824837685
+type: length
+unit: fathom
+---
+aliases:
+  - leagues
+factor: 0.000207123730745778
+type: length
+unit: league
+---
+aliases:
+  - cables
+factor: 0.00539611824837685
+type: length
+unit: cable
+---
+aliases:
+  - light years
+  - ly
+  - lys
+factor: 1.05700083402462e-16
+type: length
+unit: light year
+---
+aliases:
+  - parsecs
+  - pc
+  - pcs
+factor: 3.24077923047971e-17
+type: length
+unit: parsec
+---
+aliases:
+  - astronomical units
+  - au
+  - aus
+factor: 6.68458712226845e-12
+type: length
+unit: astronomical unit
+---
+aliases:
+  - hectares
+  - ha
+factor: 1
+type: area
+unit: hectare
+---
+aliases:
+  - acres
+factor: 2.4710439
+type: area
+unit: acre
+---
+aliases:
+  - square meters
+  - metre^2
+  - meter^2
+  - metres^2
+  - meters^2
+  - square metre
+  - square metres
+  - m^2
+  - m²
+factor: 10000
+type: area
+unit: square meter
+---
+aliases:
+  - square kilometers
+  - square kilometre
+  - square kilometres
+  - km^2
+  - km²
+factor: 0.01
+type: area
+unit: square kilometer
+---
+aliases:
+  - square centimeters
+  - square centimetre
+  - square centimetres
+  - cm^2
+  - cm²
+factor: 100000000
+type: area
+unit: square centimeter
+---
+aliases:
+  - square millimeters
+  - square millimetre
+  - square millimetres
+  - mm^2
+  - mm²
+factor: 10000000000
+type: area
+unit: square millimeter
+---
+aliases:
+  - square miles
+  - sq mi
+  - square statute mile
+  - square statute miles
+  - square land mile
+  - square land miles
+  - miles^2
+  - miles²
+factor: 0.00386102160083284
+type: area
+unit: square mile
+---
+aliases:
+  - square yards
+  - yard^2
+  - yard²
+  - yards²
+  - yards^2
+  - yd^2
+  - yd²
+  - yrd^2
+  - yrd²
+factor: 11959.9
+type: area
+unit: square yard
+---
+aliases:
+  - square feet
+  - feet^2
+  - feet²
+  - foot^2
+  - foot²
+  - ft²
+  - ft^2
+factor: 107639.1
+type: area
+unit: square foot
+---
+aliases:
+  - square inches
+  - inch^2
+  - inches^2
+  - squinch
+  - in^2
+  - in²
+factor: 15500031
+type: area
+unit: square inch
+---
+aliases:
+  - liter
+  - litres
+  - liters
+  - l
+  - litter
+  - litters
+factor: 1
+type: volume
+unit: litre
+---
+aliases:
+  - milliliter
+  - millilitres
+  - milliliters
+  - ml
+factor: 1000
+type: volume
+unit: millilitre
+---
+aliases:
+  - metre^3
+  - meter^3
+  - metres^3
+  - meters^3
+  - m^3
+  - m³
+factor: 0.001
+type: volume
+unit: cubic metre
+---
+aliases:
+  - centimetre^3
+  - centimeter^3
+  - centimetres^3
+  - centimeters^3
+  - cm^3
+  - cm³
+factor: 1000
+type: volume
+unit: cubic centimetre
+---
+aliases:
+  - millimetre^3
+  - millimeter^3
+  - millimetres^3
+  - millimeters^3
+  - mm^3
+  - mm³
+factor: 1000000
+type: volume
+unit: cubic millimetre
+---
+aliases:
+  - liquid pints
+  - us pints
+  - us liquid pint
+  - us liquid pints
+factor: 2.11337641886519
+type: volume
+unit: liquid pint
+---
+aliases:
+  - dry pints
+factor: 1.81616596853771
+type: volume
+unit: dry pint
+---
+aliases:
+  - pints
+  - pint
+  - imperial pints
+  - uk pint
+  - british pint
+  - pts
+factor: 1.7597539863927
+type: volume
+unit: imperial pint
+---
+aliases:
+  - imperial gallon
+  - uk gallon
+  - british gallon
+  - british gallons
+  - uk gallons
+factor: 0.219969248299088
+type: volume
+unit: imperial gallon
+---
+aliases:
+  - fluid gallon
+  - us fluid gallon
+  - fluid gallons
+  - us gallons
+  - gallon
+  - gallons
+factor: 0.264172052358148
+type: volume
+unit: us gallon
+---
+aliases:
+  - liquid quart
+  - us quart
+  - us quarts
+  - quarts
+  - liquid quarts
+factor: 1.05668820943259
+type: volume
+unit: quart
+---
+aliases:
+  - imperial quarts
+  - british quarts
+  - british quart
+factor: 7.03901594557081
+type: volume
+unit: imperial quart
+---
+aliases:
+  - imperial fluid ounces
+  - imperial fl oz
+  - imperial fluid oz
+factor: 28.1560637822832
+type: volume
+unit: imperial fluid ounce
+---
+aliases:
+  - us fluid ounces
+  - us fl oz
+  - fl oz
+  - fl. oz
+  - fluid oz
+factor: 33.814022701843
+type: volume
+unit: us fluid ounce
+---
+aliases:
+  - days
+  - dy
+  - dys
+  - d
+factor: 1
+type: duration
+unit: day
+---
+aliases:
+  - seconds
+  - sec
+  - s
+factor: 86400
+type: duration
+unit: second
+---
+aliases:
+  - milliseconds
+  - millisec
+  - millisecs
+  - ms
+factor: 86400000
+type: duration
+unit: millisecond
+---
+aliases:
+  - microseconds
+  - microsec
+  - microsecs
+  - us
+factor: 86400000000
+type: duration
+unit: microsecond
+---
+aliases:
+  - nanoseconds
+  - nanosec
+  - nanosecs
+  - ns
+factor: 86400000000000
+type: duration
+unit: nanosecond
+---
+aliases:
+  - minutes
+  - min
+  - mins
+factor: 1440
+type: duration
+unit: minute
+---
+aliases:
+  - hours
+  - hr
+  - hrs
+  - h
+factor: 24
+type: duration
+unit: hour
+---
+aliases:
+  - weeks
+  - wks
+  - wk
+factor: 0.142857142857143
+type: duration
+unit: week
+---
+aliases: []
+factor: 0.0714285714285714
+type: duration
+unit: fortnight
+---
+aliases:
+  - months
+  - mons
+  - mns
+  - mn
+factor: 0.0328767123287671
+type: duration
+unit: month
+---
+aliases:
+  - years
+  - yr
+  - yrs
+factor: 0.00273972602739726
+type: duration
+unit: year
+---
+aliases:
+  - leap years
+  - leapyear
+  - leapyr
+  - leapyrs
+factor: 0.00273224043715847
+type: duration
+unit: leap year
+---
+aliases:
+  - pascals
+  - pa
+  - pas
+factor: 1
+type: pressure
+unit: pascal
+---
+aliases:
+  - kilopascals
+  - kpa
+  - kpas
+factor: 0.001
+type: pressure
+unit: kilopascal
+---
+aliases:
+  - megapascals
+  - megapa
+  - megapas
+factor: 1e-06
+type: pressure
+unit: megapascal
+---
+aliases:
+  - gigapascals
+  - gpa
+  - gpas
+factor: 1e-09
+type: pressure
+unit: gigapascal
+---
+aliases:
+  - bars
+  - pa
+  - pas
+factor: 1e-05
+type: pressure
+unit: bar
+---
+aliases:
+  - atmospheres
+  - atm
+  - atms
+factor: 9.86923266716013e-06
+type: pressure
+unit: atmosphere
+---
+aliases:
+  - psis
+  - psi
+  - lbs/inch^2
+  - p.s.i.
+  - p.s.i
+factor: 0.000145036839357197
+type: pressure
+unit: pounds per square inch
+---
+aliases:
+  - joules
+  - j
+  - js
+factor: 1
+type: energy
+unit: joule
+---
+aliases:
+  - watt second
+  - watt seconds
+  - ws
+factor: 1
+type: energy
+unit: watt-second
+---
+aliases:
+  - watt hour
+  - watt hours
+  - wh
+factor: 0.000277777777777778
+type: energy
+unit: watt-hour
+---
+aliases:
+  - kilowatt hour
+  - kilowatt hours
+  - kwh
+factor: 2.77777777777778e-07
+type: energy
+unit: kilowatt-hour
+---
+aliases:
+  - ergon
+  - ergs
+  - ergons
+factor: 1e-07
+type: energy
+unit: erg
+---
+aliases:
+  - electronvolt
+  - electron volts
+  - ev
+  - evs
+factor: 6.2415096e+18
+type: energy
+unit: electron volt
+---
+aliases:
+  - small calories
+  - thermochemical gram calories
+  - chemical calorie
+  - chemical calories
+factor: 0.239005736137667
+type: energy
+unit: thermochemical gram calorie
+---
+aliases:
+  - large calories
+  - food calorie
+  - food calories
+  - kcals
+  - kcal
+factor: 0.000239005736137667
+type: energy
+unit: large calorie
+---
+aliases:
+  - british thermal units
+  - btu
+  - btus
+factor: 0.000948316737790422
+type: energy
+unit: british thermal unit
+---
+aliases:
+  - tnt equivilent
+  - tonnes of tnt
+  - tnt
+  - tons of tnt
+factor: 2.39005736137667e-10
+type: energy
+unit: ton of TNT
+---
+aliases:
+  - watts
+  - w
+factor: 1
+type: power
+unit: watt
+---
+aliases:
+  - kilowatts
+  - kw
+factor: 0.001
+type: power
+unit: kilowatt
+---
+aliases:
+  - megawatts
+  - mw
+factor: 1e-06
+type: power
+unit: megawatt
+---
+aliases:
+  - gigawatts
+  - jiggawatts
+  - gw
+factor: 1e-09
+type: power
+unit: gigawatt
+---
+aliases:
+  - terawatts
+  - tw
+factor: 1e-12
+type: power
+unit: terawatt
+---
+aliases:
+  - petawatts
+  - pw
+factor: 1e-15
+type: power
+unit: petawatt
+---
+aliases:
+  - milliwatts
+factor: 1000
+type: power
+unit: milliwatt
+---
+aliases:
+  - microwatts
+factor: 1000000
+type: power
+unit: microwatt
+---
+aliases:
+  - nanowatts
+  - nw
+factor: 1000000000
+type: power
+unit: nanowatt
+---
+aliases:
+  - picowatts
+  - pw
+factor: 1000000000000
+type: power
+unit: picowatt
+---
+aliases:
+  - metric horsepowers
+  - mhp
+  - hp
+  - ps
+  - cv
+  - hk
+  - ks
+  - ch
+factor: 0.0013596216173039
+type: power
+unit: metric horsepower
+---
+aliases:
+  - mechnical horsepower
+  - horsepower
+  - hp
+  - hp
+  - bhp
+factor: 0.00134102208959503
+type: power
+unit: horsepower
+---
+aliases:
+  - electical horsepowers
+  - hp
+  - hp
+factor: 0.00134048257372654
+type: power
+unit: electical horsepower
+---
+aliases:
+  - degrees
+  - deg
+  - degs
+factor: 1
+type: angle
+unit: degree
+---
+aliases:
+  - radians
+  - rad
+  - rads
+factor: 0.0174532925199433
+type: angle
+unit: radian
+---
+aliases:
+  - gradians
+  - grad
+  - grads
+  - gon
+  - gons
+  - grade
+  - grades
+factor: 1.11111111111111
+type: angle
+unit: gradian
+---
+aliases:
+  - quadrants
+  - quads
+  - quad
+factor: 0.0111111111111111
+type: angle
+unit: quadrant
+---
+aliases:
+  - semi circle
+  - semicircle
+  - semi circles
+  - semicircles
+  - semi-circles
+factor: 0.00555555555555556
+type: angle
+unit: semi-circle
+---
+aliases:
+  - revolutions
+  - circle
+  - circles
+  - revs
+factor: 0.00277777777777778
+type: angle
+unit: revolution
+---
+aliases:
+  - newtons
+  - n
+factor: 1
+type: force
+unit: newton
+---
+aliases:
+  - kilonewtons
+  - kn
+factor: 0.001
+type: force
+unit: kilonewton
+---
+aliases:
+  - meganewtons
+  - mn
+factor: 1e-06
+type: force
+unit: meganewton
+---
+aliases:
+  - giganewtons
+  - gn
+factor: 1e-09
+type: force
+unit: giganewton
+---
+aliases:
+  - dynes
+factor: 1e-05
+type: force
+unit: dyne
+---
+aliases:
+  - kilodynes
+factor: 0.01
+type: force
+unit: kilodyne
+---
+aliases:
+  - megadynes
+factor: 10
+type: force
+unit: megadyne
+---
+aliases:
+  - lbs force
+  - pounds force
+factor: 0.224808943099711
+type: force
+unit: pounds force
+---
+aliases:
+  - poundals
+  - pdl
+factor: 7.23301385120989
+type: force
+unit: poundal
+---
+aliases:
+  - f
+can_be_negative: 1
+factor: 1
+type: temperature
+unit: fahrenheit
+---
+aliases:
+  - c
+can_be_negative: 1
+factor: 1
+type: temperature
+unit: celsius
+---
+aliases:
+  - k
+factor: 1
+type: temperature
+unit: kelvin
+---
+aliases:
+  - r
+factor: 1
+type: temperature
+unit: rankine
+---
+aliases:
+  - re
+can_be_negative: 1
+factor: 1
+type: temperature
+unit: reaumur
+---
+aliases:
+  - bits
+factor: 1
+type: digital
+unit: bit
+---
+aliases:
+  - kbit
+  - kbits
+  - kilobits
+factor: 0.001
+type: digital
+unit: kilobit
+---
+aliases:
+  - mbit
+  - mbits
+  - megabits
+factor: 1e-06
+type: digital
+unit: megabit
+---
+aliases:
+  - gbit
+  - gigabits
+  - gbits
+factor: 1e-09
+type: digital
+unit: gigabit
+---
+aliases:
+  - tbit
+  - tbits
+  - terabits
+factor: 1e-12
+type: digital
+unit: terabit
+---
+aliases:
+  - pbit
+  - pbits
+  - petabits
+factor: 1e-15
+type: digital
+unit: petabit
+---
+aliases:
+  - ebit
+  - ebits
+  - exabits
+factor: 1e-18
+type: digital
+unit: exabit
+---
+aliases:
+  - zbit
+  - zbits
+  - zettabits
+factor: 1e-21
+type: digital
+unit: zettabit
+---
+aliases:
+  - ybit
+  - ybits
+  - yottabits
+factor: 1e-24
+type: digital
+unit: yottabit
+---
+aliases:
+  - kibit
+  - kibits
+  - kibibits
+factor: 0.0009765625
+type: digital
+unit: kibibit
+---
+aliases:
+  - mibit
+  - mibits
+  - mebibits
+factor: 9.5367431640625e-07
+type: digital
+unit: mebibit
+---
+aliases:
+  - gibit
+  - gibits
+  - gibibits
+factor: 9.31322574615479e-10
+type: digital
+unit: gibibit
+---
+aliases:
+  - tibit
+  - tibits
+  - tebibits
+factor: 9.09494701772928e-13
+type: digital
+unit: tebibit
+---
+aliases:
+  - pibit
+  - pibits
+  - pebibits
+factor: 8.88178419700125e-16
+type: digital
+unit: pebibit
+---
+aliases:
+  - eibit
+  - eibits
+  - exbibits
+factor: 8.67361737988404e-19
+type: digital
+unit: exbibit
+---
+aliases:
+  - zibit
+  - zibits
+  - zebibits
+factor: 8.470329472543e-22
+type: digital
+unit: zebibit
+---
+aliases:
+  - yibit
+  - yibits
+  - yobibits
+factor: 8.27180612553028e-25
+type: digital
+unit: yobibit
+---
+aliases:
+  - bytes
+factor: 0.125
+type: digital
+unit: byte
+---
+aliases:
+  - kb
+  - kbs
+  - kilobytes
+factor: 0.000125
+type: digital
+unit: kilobyte
+---
+aliases:
+  - mb
+  - mbs
+  - megabytes
+factor: 1.25e-07
+type: digital
+unit: megabyte
+---
+aliases:
+  - gb
+  - gbs
+  - gigabytes
+factor: 1.25e-10
+type: digital
+unit: gigabyte
+---
+aliases:
+  - tb
+  - tbs
+  - terabytes
+factor: 1.25e-13
+type: digital
+unit: terabyte
+---
+aliases:
+  - pb
+  - pbs
+  - petabytes
+factor: 1.25e-16
+type: digital
+unit: petabyte
+---
+aliases:
+  - eb
+  - ebs
+  - exabytes
+factor: 1.25e-19
+type: digital
+unit: exabyte
+---
+aliases:
+  - zb
+  - zbs
+  - zettabytes
+factor: 1.25e-22
+type: digital
+unit: zettabyte
+---
+aliases:
+  - yb
+  - ybs
+  - yottabytes
+factor: 1.25e-25
+type: digital
+unit: yottabyte
+---
+aliases:
+  - kib
+  - kibs
+  - kibibytes
+factor: 0.0001220703125
+type: digital
+unit: kibibyte
+---
+aliases:
+  - mib
+  - mibs
+  - mebibytes
+factor: 1.19209289550781e-07
+type: digital
+unit: mebibyte
+---
+aliases:
+  - gib
+  - gibs
+  - gibibytes
+factor: 1.16415321826935e-10
+type: digital
+unit: gibibyte
+---
+aliases:
+  - tib
+  - tibs
+  - tebibytes
+factor: 1.13686837721616e-13
+type: digital
+unit: tebibyte
+---
+aliases:
+  - pib
+  - pibs
+  - pebibytes
+factor: 1.11022302462516e-16
+type: digital
+unit: pebibyte
+---
+aliases:
+  - eib
+  - eibs
+  - exbibytes
+factor: 1.0842021724855e-19
+type: digital
+unit: exbibyte
+---
+aliases:
+  - zib
+  - zibs
+  - zebibytes
+factor: 1.05879118406788e-22
+type: digital
+unit: zebibyte
+---
+aliases:
+  - yib
+  - yibs
+  - yobibytes
+factor: 1.03397576569129e-25
+type: digital
+unit: yobibyte

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -868,7 +868,7 @@ ddg_goodie_test(
     ),
     '1 acres in square kilometers' => test_zci(
         '1 acre = 0.004 square kilometers',
-		structured_answer => {
+        structured_answer => {
             input     => ['1 acre'],
             operation => 'convert',
             result    => '0.004 square kilometers'
@@ -876,7 +876,7 @@ ddg_goodie_test(
     ),
     '1 acres in square meters' => test_zci(
         '1 acre = 4,046.873 square meters',
-		structured_answer => {
+        structured_answer => {
             input     => ['1 acre'],
             operation => 'convert',
             result    => '4,046.873 square meters'

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -1564,6 +1564,16 @@ ddg_goodie_test(
         }
     ),
     
+    #Question format:
+    'How to convert meters to inches' => test_zci(
+        '1 meter = 39.370 inches',
+        structured_answer => {
+            input => ['1 meter'],
+            operation => 'convert',
+            result => '39.370 inches'
+        }
+    ),
+    
     # Intentionally untriggered
     '5 inches in 5 meters'            => undef,
     'convert 1 cm to 2 mm'            => undef,

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -463,6 +463,14 @@ ddg_goodie_test(
             result    => '1 revolution'
         }
     ),
+    '1 degree fahrenheit to celsius' => test_zci(
+        '1 degree fahrenheit = -17.222 degrees celsius',
+        structured_answer => {
+            input => ['1 degree fahrenheit'],
+            operation => 'convert',
+            result => '-17.222 degrees celsius'
+        }
+    ),
     '12 degrees Celsius to Fahrenheit' => test_zci(
         '12 degrees celsius = 53.600 degrees fahrenheit',
         structured_answer => {

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -17,7 +17,7 @@ ddg_goodie_test(
         '5 ounces = 141.747 grams',
         structured_answer => {
             input     => ['5 ounces'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '141.747 grams'
         }
     ),
@@ -25,7 +25,7 @@ ddg_goodie_test(
         '5 ounces = 141.747 grams',
         structured_answer => {
             input     => ['5 ounces'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '141.747 grams'
         }
     ),
@@ -33,7 +33,7 @@ ddg_goodie_test(
         '0.5 nautical miles = 0.926 kilometers',
         structured_answer => {
             input     => ['0.5 nautical miles'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.926 kilometers'
         }
     ),
@@ -42,7 +42,7 @@ ddg_goodie_test(
         '1 ton = 0.893 long tons',
         structured_answer => {
             input     => ['1 ton'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.893 long tons'
         }
     ),
@@ -50,7 +50,7 @@ ddg_goodie_test(
         '158 ounces = 9.875 pounds',
         structured_answer => {
             input     => ['158 ounces'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '9.875 pounds'
         }
     ),
@@ -58,7 +58,7 @@ ddg_goodie_test(
         '0.111 stone = 1.554 pounds',
         structured_answer => {
             input     => ['0.111 stone'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1.554 pounds'
         }
     ),
@@ -66,23 +66,23 @@ ddg_goodie_test(
         '5 feet = 60 inches',
         structured_answer => {
             input     => ['5 feet'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '60 inches'
         }
     ),
     'convert 5 kelvin to fahrenheit' => test_zci(
-        '5 K = -450.670 °F',
+        '5 kelvin = -450.670 degrees fahrenheit',
         structured_answer => {
-            input     => ['5 K'],
-            operation => 'Convert',
-            result    => "-450.670 °F"
+            input     => ['5 kelvin'],
+            operation => 'convert',
+            result    => "-450.670 degrees fahrenheit"
         }
     ),
     'light year to mm' => test_zci(
         '1 light year = 9.46 * 10^18 millimeters',
         structured_answer => {
             input     => ['1 light year'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '9.46 * 10<sup>18</sup> millimeters'
         }
     ),
@@ -90,7 +90,7 @@ ddg_goodie_test(
         '1 british thermal unit = 0.000293 kilowatt-hours',
         structured_answer => {
             input     => ['1 british thermal unit'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.000293 kilowatt-hours'
         }
     ),
@@ -98,23 +98,23 @@ ddg_goodie_test(
         '25 inches = 2.083 feet',
         structured_answer => {
             input     => ['25 inches'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '2.083 feet'
         }
     ),
     'convert 5 f to celsius' => test_zci(
-        '5 °F = -15 °C',
+        '5 degrees fahrenheit = -15 degrees celsius',
         structured_answer => {
-            input     => ['5 °F'],
-            operation => 'Convert',
-            result    => "-15 °C"
+            input     => ['5 degrees fahrenheit'],
+            operation => 'convert',
+            result    => "-15 degrees celsius"
         }
     ),
     'convert km to cm' => test_zci(
         '1 kilometer = 100,000 centimeters',
         structured_answer => {
             input     => ['1 kilometer'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '100,000 centimeters'
         }
     ),
@@ -122,7 +122,7 @@ ddg_goodie_test(
         '10 milliseconds = 0.010 seconds',
         structured_answer => {
             input     => ['10 milliseconds'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.010 seconds'
         }
     ),
@@ -130,7 +130,7 @@ ddg_goodie_test(
         '1 yottabyte = 0.827 yobibytes',
         structured_answer => {
             input     => ['1 yottabyte'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.827 yobibytes'
         }
     ),
@@ -138,7 +138,7 @@ ddg_goodie_test(
         '1 stone = 14 pounds',
         structured_answer => {
             input     => ['1 stone'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '14 pounds'
         }
     ),
@@ -146,7 +146,7 @@ ddg_goodie_test(
         '5 bytes = 40 bits',
         structured_answer => {
             input     => ['5 bytes'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '40 bits'
         }
     ),
@@ -155,7 +155,7 @@ ddg_goodie_test(
         '3 kilograms = 6.614 pounds',
         structured_answer => {
             input     => ['3 kilograms'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '6.614 pounds'
         }
     ),
@@ -163,7 +163,7 @@ ddg_goodie_test(
         '1.3 metric tons = 1.433 tons',
         structured_answer => {
             input     => ['1.3 metric tons'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1.433 tons'
         }
     ),
@@ -171,7 +171,7 @@ ddg_goodie_test(
         '2 tons = 1,814.372 kilograms',
         structured_answer => {
             input     => ['2 tons'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1,814.372 kilograms'
         }
     ),
@@ -179,7 +179,7 @@ ddg_goodie_test(
         '1 ton = 907.186 kilograms',
         structured_answer => {
             input     => ['1 ton'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '907.186 kilograms'
         }
     ),
@@ -187,7 +187,7 @@ ddg_goodie_test(
         '3.9 ounces = 110.563 grams',
         structured_answer => {
             input     => ['3.9 ounces'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '110.563 grams'
         }
     ),
@@ -195,7 +195,7 @@ ddg_goodie_test(
         '2 miles = 3.219 kilometers',
         structured_answer => {
             input     => ['2 miles'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '3.219 kilometers'
         }
     ),
@@ -203,7 +203,7 @@ ddg_goodie_test(
         '3 miles = 4.828 kilometers',
         structured_answer => {
             input     => ['3 miles'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '4.828 kilometers'
         }
     ),
@@ -211,7 +211,7 @@ ddg_goodie_test(
         '0.5 nautical miles = 0.926 kilometers',
         structured_answer => {
             input     => ['0.5 nautical miles'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.926 kilometers'
         }
     ),
@@ -219,7 +219,7 @@ ddg_goodie_test(
         '500 miles = 804,672 meters',
         structured_answer => {
             input     => ['500 miles'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '804,672 meters'
         }
     ),
@@ -227,7 +227,7 @@ ddg_goodie_test(
         '25 centimeters = 9.843 inches',
         structured_answer => {
             input     => ['25 centimeters'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '9.843 inches'
         }
     ),
@@ -235,7 +235,7 @@ ddg_goodie_test(
         '1,760 yards = 1 mile',
         structured_answer => {
             input     => ['1,760 yards'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1 mile'
         }
     ),
@@ -243,7 +243,7 @@ ddg_goodie_test(
         '3,520 yards = 2 miles',
         structured_answer => {
             input     => ['3,520 yards'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '2 miles'
         }
     ),
@@ -251,7 +251,7 @@ ddg_goodie_test(
         '30 centimeters = 11.811 inches',
         structured_answer => {
             input     => ['30 centimeters'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '11.811 inches'
         }
     ),
@@ -259,7 +259,7 @@ ddg_goodie_test(
         '36 months = 3 years',
         structured_answer => {
             input     => ['36 months'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '3 years'
         }
     ),
@@ -267,7 +267,7 @@ ddg_goodie_test(
         '43,200 seconds = 12 hours',
         structured_answer => {
             input     => ['43,200 seconds'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '12 hours'
         }
     ),
@@ -275,7 +275,7 @@ ddg_goodie_test(
         '4 hours = 240 minutes',
         structured_answer => {
             input     => ['4 hours'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '240 minutes'
         }
     ),
@@ -283,7 +283,7 @@ ddg_goodie_test(
         '1 bar = 100,000 pascals',
         structured_answer => {
             input     => ['1 bar'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '100,000 pascals'
         }
     ),
@@ -291,7 +291,7 @@ ddg_goodie_test(
         '1 kilopascal = 0.145 pounds per square inch',
         structured_answer => {
             input     => ['1 kilopascal'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.145 pounds per square inch'
         }
     ),
@@ -299,7 +299,7 @@ ddg_goodie_test(
         '1 atmosphere = 101.325 kilopascals',
         structured_answer => {
             input     => ['1 atmosphere'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '101.325 kilopascals'
         }
     ),
@@ -307,7 +307,7 @@ ddg_goodie_test(
         '5 yards = 0.005 kilometers',
         structured_answer => {
             input     => ['5 yards'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.005 kilometers'
         }
     ),
@@ -315,7 +315,7 @@ ddg_goodie_test(
         '12 inches = 30.480 centimeters',
         structured_answer => {
             input     => ['12 inches'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '30.480 centimeters'
         }
     ),
@@ -323,7 +323,7 @@ ddg_goodie_test(
         '42 kilowatt-hours = 1.51 * 10^8 joules',
         structured_answer => {
             input     => ['42 kilowatt-hours'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1.51 * 10<sup>8</sup> joules'
         }
     ),
@@ -331,7 +331,7 @@ ddg_goodie_test(
         '2,500 large calories = 0.003 tons of TNT',
         structured_answer => {
             input     => ['2,500 large calories'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.003 tons of TNT'
         }
     ),
@@ -339,7 +339,7 @@ ddg_goodie_test(
         '90 metric horsepower = 66,194.888 watts',
         structured_answer => {
             input     => ['90 metric horsepower'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '66,194.888 watts'
         }
     ),
@@ -347,7 +347,7 @@ ddg_goodie_test(
         '1 gigawatt = 1.34 * 10^6 horsepower',
         structured_answer => {
             input     => ['1 gigawatt'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1.34 * 10<sup>6</sup> horsepower'
         }
     ),
@@ -355,7 +355,7 @@ ddg_goodie_test(
         '180 degrees = 3.142 radians',
         structured_answer => {
             input     => ['180 degrees'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '3.142 radians'
         }
     ),
@@ -363,7 +363,7 @@ ddg_goodie_test(
         '270 degrees = 3 quadrants',
         structured_answer => {
             input     => ['270 degrees'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '3 quadrants'
         }
     ),
@@ -371,7 +371,7 @@ ddg_goodie_test(
         '180 degrees = 200 gradians',
         structured_answer => {
             input     => ['180 degrees'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '200 gradians'
         }
     ),
@@ -379,7 +379,7 @@ ddg_goodie_test(
         '45 newtons = 10.116 pounds force',
         structured_answer => {
             input     => ['45 newtons'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '10.116 pounds force'
         }
     ),
@@ -387,7 +387,7 @@ ddg_goodie_test(
         '8 poundals = 1.106 newtons',
         structured_answer => {
             input     => ['8 poundals'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1.106 newtons'
         }
     ),
@@ -395,7 +395,7 @@ ddg_goodie_test(
         '10 milligrams = 1.1 * 10^-8 tons',
         structured_answer => {
             input     => ['10 milligrams'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1.1 * 10<sup>-8</sup> tons'
         }
     ),
@@ -403,7 +403,7 @@ ddg_goodie_test(
         '10,000 minutes = 6 * 10^11 microseconds',
         structured_answer => {
             input     => ['10,000 minutes'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '6 * 10<sup>11</sup> microseconds'
         }
     ),
@@ -411,7 +411,7 @@ ddg_goodie_test(
         '5 gigabytes = 5,000 megabytes',
         structured_answer => {
             input     => ['5 gigabytes'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '5,000 megabytes'
         }
     ),
@@ -419,7 +419,7 @@ ddg_goodie_test(
         '0.013 megabytes = 104,000 bits',
         structured_answer => {
             input     => ['0.013 megabytes'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '104,000 bits'
         }
     ),
@@ -427,7 +427,7 @@ ddg_goodie_test(
         '0,013 megabytes = 104.000 bits',
         structured_answer => {
             input     => ['0,013 megabytes'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '104.000 bits'
         }
     ),
@@ -435,7 +435,7 @@ ddg_goodie_test(
         '1 exabyte = 888.178 pebibytes',
         structured_answer => {
             input     => ['1 exabyte'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '888.178 pebibytes'
         }
     ),
@@ -443,7 +443,7 @@ ddg_goodie_test(
         '16 years = 192 months',
         structured_answer => {
             input     => ['16 years'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '192 months'
         }
     ),
@@ -451,7 +451,7 @@ ddg_goodie_test(
         '1 year = 12 months',
         structured_answer => {
             input     => ['1 year'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '12 months'
         }
     ),
@@ -459,55 +459,55 @@ ddg_goodie_test(
         '360 degrees = 1 revolution',
         structured_answer => {
             input     => ['360 degrees'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1 revolution'
         }
     ),
     '12 degrees Celsius to Fahrenheit' => test_zci(
-        '12 °C = 53.600 °F',
+        '12 degrees celsius = 53.600 degrees fahrenheit',
         structured_answer => {
-            input     => ['12 °C'],
-            operation => 'Convert',
-            result    => "53.600 °F"
+            input     => ['12 degrees celsius'],
+            operation => 'convert',
+            result    => "53.600 degrees fahrenheit"
         }
     ),
     '1 degrees Fahrenheit to celsius' => test_zci(
-        '1 °F = -17.222 °C',
+        '1 degree fahrenheit = -17.222 degrees celsius',
         structured_answer => {
-            input     => ['1 °F'],
-            operation => 'Convert',
-            result    => "-17.222 °C"
+            input     => ['1 degree fahrenheit'],
+            operation => 'convert',
+            result    => "-17.222 degrees celsius"
         }
     ),
     '0 c in k' => test_zci(
-        '0 °C = 273.150 K',
+        '0 degrees celsius = 273.150 kelvin',
         structured_answer => {
-            input     => ['0 °C'],
-            operation => 'Convert',
-            result    => '273.150 K'
+            input     => ['0 degrees celsius'],
+            operation => 'convert',
+            result    => '273.150 kelvin'
         }
     ),
     '234 f to c' => test_zci(
-        '234 °F = 112.222 °C',
+        '234 degrees fahrenheit = 112.222 degrees celsius',
         structured_answer => {
-            input     => ['234 °F'],
-            operation => 'Convert',
-            result    => "112.222 °C"
+            input     => ['234 degrees fahrenheit'],
+            operation => 'convert',
+            result    => "112.222 degrees celsius"
         }
     ),
     '234 f to k' => test_zci(
-        '234 °F = 385.372 K',
+        '234 degrees fahrenheit = 385.372 kelvin',
         structured_answer => {
-            input     => ['234 °F'],
-            operation => 'Convert',
-            result    => '385.372 K'
+            input     => ['234 degrees fahrenheit'],
+            operation => 'convert',
+            result    => '385.372 kelvin'
         }
     ),
     'metres from 20 yards' => test_zci(
         '20 yards = 18.288 meters',
         structured_answer => {
             input     => ['20 yards'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '18.288 meters'
         }
     ),
@@ -515,7 +515,7 @@ ddg_goodie_test(
         '7 milligrams = 7,000 micrograms',
         structured_answer => {
             input     => ['7 milligrams'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '7,000 micrograms'
         }
     ),
@@ -523,7 +523,7 @@ ddg_goodie_test(
         '5 meters = 196.851 inches',
         structured_answer => {
             input     => ['5 meters'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '196.851 inches'
         }
     ),
@@ -531,7 +531,7 @@ ddg_goodie_test(
         '5 inches = 0.127 meters',
         structured_answer => {
             input     => ['5 inches'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.127 meters'
         }
     ),
@@ -539,7 +539,7 @@ ddg_goodie_test(
         '1 us gallon = 3,785.412 millilitres',
         structured_answer => {
             input     => ['1 us gallon'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '3,785.412 millilitres'
         }
     ),
@@ -547,7 +547,7 @@ ddg_goodie_test(
         '1 millilitre = 0.000264 us gallons',
         structured_answer => {
             input     => ['1 millilitre'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.000264 us gallons'
         }
     ),
@@ -555,7 +555,7 @@ ddg_goodie_test(
         '1 inch = 0.083 feet',
         structured_answer => {
             input     => ['1 inch'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.083 feet'
         }
     ),
@@ -563,7 +563,7 @@ ddg_goodie_test(
         '1 millilitre = 0.000264 us gallons',
         structured_answer => {
             input     => ['1 millilitre'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.000264 us gallons'
         }
     ),
@@ -571,7 +571,7 @@ ddg_goodie_test(
         '1 us gallon = 3,785.412 millilitres',
         structured_answer => {
             input     => ['1 us gallon'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '3,785.412 millilitres'
         }
     ),
@@ -579,7 +579,7 @@ ddg_goodie_test(
         '32 millilitres = 1.082 us fluid ounces',
         structured_answer => {
             input     => ['32 millilitres'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1.082 us fluid ounces'
         }
     ),
@@ -587,7 +587,7 @@ ddg_goodie_test(
         '100 us fluid ounces = 2,957.353 millilitres',
         structured_answer => {
             input     => ['100 us fluid ounces'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '2,957.353 millilitres'
         }
     ),
@@ -595,7 +595,7 @@ ddg_goodie_test(
         '100 millilitres = 3.381 us fluid ounces',
         structured_answer => {
             input     => ['100 millilitres'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '3.381 us fluid ounces'
         }
     ),
@@ -603,7 +603,7 @@ ddg_goodie_test(
         '75 millilitres = 2.536 us fluid ounces',
         structured_answer => {
             input     => ['75 millilitres'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '2.536 us fluid ounces'
         }
     ),
@@ -611,7 +611,7 @@ ddg_goodie_test(
         '1 millimeter = 0.039 inches',
         structured_answer => {
             input     => ['1 millimeter'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.039 inches'
         }
     ),
@@ -619,7 +619,7 @@ ddg_goodie_test(
         '1 inch = 25.400 millimeters',
         structured_answer => {
             input     => ['1 inch'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '25.400 millimeters'
         }
     ),
@@ -628,7 +628,7 @@ ddg_goodie_test(
         '3 * 10^60 degrees = 8.33 * 10^57 revolutions',
         structured_answer => {
             input     => ['3 * 10<sup>60</sup> degrees'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '8.33 * 10<sup>57</sup> revolutions'
         }
     ),
@@ -636,7 +636,7 @@ ddg_goodie_test(
         '4,1 * 10^5 newtons = 92.171,667 pounds force',
         structured_answer => {
             input     => ['4,1 * 10<sup>5</sup> newtons'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '92.171,667 pounds force'
         }
     ),
@@ -644,7 +644,7 @@ ddg_goodie_test(
         '4 * 10^5 newtons = 89,923.577 pounds force',
         structured_answer => {
             input     => ['4 * 10<sup>5</sup> newtons'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '89,923.577 pounds force'
         }
     ),
@@ -652,7 +652,7 @@ ddg_goodie_test(
         '5,0 gigabytes = 5.000 megabytes',
         structured_answer => {
             input     => ['5,0 gigabytes'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '5.000 megabytes'
         }
     ),
@@ -660,7 +660,7 @@ ddg_goodie_test(
         '3.5 * 10^-2 miles = 2,217.601 inches',
         structured_answer => {
             input     => ['3.5 * 10<sup>-2</sup> miles'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '2,217.601 inches'
         }
     ),
@@ -669,7 +669,7 @@ ddg_goodie_test(
         '100 square meters = 0.010 hectares',
         structured_answer => {
             input     => ['100 square meters'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.010 hectares'
         }
     ),
@@ -677,7 +677,7 @@ ddg_goodie_test(
         '0.0001 hectares = 1 square meter',
         structured_answer => {
             input     => ['0.0001 hectares'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1 square meter'
         }
     ),
@@ -685,7 +685,7 @@ ddg_goodie_test(
         '5 square miles = 1.29 * 10^7 square meters',
         structured_answer => {
             input     => ['5 square miles'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1.29 * 10<sup>7</sup> square meters'
         }
     ),
@@ -693,7 +693,7 @@ ddg_goodie_test(
         '1 imperial gallon = 4.546 litres',
         structured_answer => {
             input     => ['1 imperial gallon'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '4.546 litres'
         }
     ),
@@ -701,7 +701,7 @@ ddg_goodie_test(
         '0.001 litres = 1 millilitre',
         structured_answer => {
             input     => ['0.001 litres'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '1 millilitre'
         }
     ),
@@ -709,7 +709,7 @@ ddg_goodie_test(
         '1 hectare = 10,000 square meters',
         structured_answer => {
             input     => ['1 hectare'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '10,000 square meters'
         }
     ),
@@ -717,7 +717,7 @@ ddg_goodie_test(
         '1 acre = 0.004 square kilometers',
         structured_answer => {
             input     => ['1 acre'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.004 square kilometers'
         }
     ),
@@ -725,7 +725,7 @@ ddg_goodie_test(
         '1 acre = 4,046.873 square meters',
         structured_answer => {
             input     => ['1 acre'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '4,046.873 square meters'
         }
     ),
@@ -734,7 +734,7 @@ ddg_goodie_test(
         '1 inch = 2.540 centimeters',
         structured_answer => {
             input     => ['1 inch'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '2.540 centimeters'
         }
     ),
@@ -742,7 +742,7 @@ ddg_goodie_test(
         '10 yards = 9.144 meters',
         structured_answer => {
             input     => ['10 yards'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '9.144 meters'
         }
     ),
@@ -750,31 +750,31 @@ ddg_goodie_test(
         '42 days = 60,480 minutes',
         structured_answer => {
             input     => ['42 days'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '60,480 minutes'
         }
     ),
     'how much is 40 kelvin in celsius' => test_zci(
-        '40 K = -233.150 °C',
+        '40 kelvin = -233.150 degrees celsius',
         structured_answer => {
-            input     => ['40 K'],
-            operation => 'Convert',
-            result    => '-233.150 °C'
+            input     => ['40 kelvin'],
+            operation => 'convert',
+            result    => '-233.150 degrees celsius'
         }
     ),
     'how much is 40 kelvin in celsius?' => test_zci(
-        '40 K = -233.150 °C',
+        '40 kelvin = -233.150 degrees celsius',
         structured_answer => {
-            input     => ['40 K'],
-            operation => 'Convert',
-            result    => "-233.150 °C"
+            input     => ['40 kelvin'],
+            operation => 'convert',
+            result    => "-233.150 degrees celsius"
         }
     ),
     'how many metres in 10 of yard?' => test_zci(
         '10 yards = 9.144 meters',
         structured_answer => {
             input     => ['10 yards'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '9.144 meters'
         }
     ),
@@ -782,7 +782,7 @@ ddg_goodie_test(
         '10 yards = 9.144 meters',
         structured_answer => {
             input     => ['10 yards'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '9.144 meters'
         }
     ),
@@ -790,7 +790,7 @@ ddg_goodie_test(
         '1 kilogram = 2.205 pounds',
         structured_answer => {
             input     => ['1 kilogram'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '2.205 pounds'
         }
     ),
@@ -798,7 +798,7 @@ ddg_goodie_test(
         '1 kilogram = 2.205 pounds',
         structured_answer => {
             input     => ['1 kilogram'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '2.205 pounds'
         }
     ),
@@ -806,7 +806,7 @@ ddg_goodie_test(
         '1 pound = 0.454 kilograms',
         structured_answer => {
             input     => ['1 pound'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.454 kilograms'
         }
     ),
@@ -814,7 +814,7 @@ ddg_goodie_test(
         '1 meter = 100 centimeters',
         structured_answer => {
             input     => ['1 meter'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '100 centimeters'
         }
     ),
@@ -822,7 +822,7 @@ ddg_goodie_test(
         '1 centimeter = 0.010 meters',
         structured_answer => {
             input     => ['1 centimeter'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.010 meters'
         }
     ),
@@ -830,7 +830,7 @@ ddg_goodie_test(
         '1 inch = 2.540 centimeters',
         structured_answer => {
             input     => ['1 inch'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '2.540 centimeters'
         }
     ),
@@ -838,7 +838,7 @@ ddg_goodie_test(
         '1 litre = 0.264 us gallons',
         structured_answer => {
             input     => ['1 litre'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.264 us gallons'
         }
     ),
@@ -846,7 +846,7 @@ ddg_goodie_test(
         '1 us gallon = 3.785 litres',
         structured_answer => {
             input     => ['1 us gallon'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '3.785 litres'
         }
     ),
@@ -854,7 +854,7 @@ ddg_goodie_test(
         '1 litre = 0.264 us gallons',
         structured_answer => {
             input     => ['1 litre'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '0.264 us gallons'
         }
     ),
@@ -862,8 +862,24 @@ ddg_goodie_test(
         '100 meters = 10,000 centimeters',
         structured_answer => {
             input     => ['100 meters'],
-            operation => 'Convert',
+            operation => 'convert',
             result    => '10,000 centimeters'
+        }
+    ),
+    '1 acres in square kilometers' => test_zci(
+        '1 acre = 0.004 square kilometers',
+		structured_answer => {
+            input     => ['1 acre'],
+            operation => 'convert',
+            result    => '0.004 square kilometers'
+        }
+    ),
+    '1 acres in square meters' => test_zci(
+        '1 acre = 4,046.873 square meters',
+		structured_answer => {
+            input     => ['1 acre'],
+            operation => 'convert',
+            result    => '4,046.873 square meters'
         }
     ),
     # Intentionally untriggered

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -639,6 +639,14 @@ ddg_goodie_test(
             result => '1 quart'
         }
     ),
+    'how many ounces in a cup' => test_zci(
+        '1 us cup = 16 fluid ounces',
+        structured_answer => {
+            input => ['1 us cup'],
+            operation => 'convert',
+            result => '16 fluid ounces'
+        }
+    ),
     # Unusual number formats
     '3e60 degrees in revolutions' => test_zci(
         '3 * 10^60 degrees = 8.33 * 10^57 revolutions',

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -479,7 +479,7 @@ ddg_goodie_test(
             result    => "-17.222 degrees celsius"
         }
     ),
-    '0 c in k' => test_zci(
+    '0 c in kelvin' => test_zci(
         '0 degrees celsius = 273.150 kelvin',
         structured_answer => {
             input     => ['0 degrees celsius'],
@@ -495,7 +495,7 @@ ddg_goodie_test(
             result    => "112.222 degrees celsius"
         }
     ),
-    '234 f to k' => test_zci(
+    '234 f to kelvin' => test_zci(
         '234 degrees fahrenheit = 385.372 kelvin',
         structured_answer => {
             input     => ['234 degrees fahrenheit'],
@@ -883,19 +883,19 @@ ddg_goodie_test(
         }
     ),
     '-40 fahrenheit in celsius' => test_zci(
-        '-40 °F = -40 °C',
+        '-40 degrees fahrenheit = -40 degrees celsius',
         structured_answer => {
-            input => ['-40 °F'],
-            operation => 'Convert',
-            result => '-40 °C'
+            input => ['-40 degrees fahrenheit'],
+            operation => 'convert',
+            result => '-40 degrees celsius'
         }
     ),
     '-40 celsius in fahrenheit' => test_zci(
-        '-40 °C = -40 °F',
+        '-40 degrees celsius = -40 degrees fahrenheit',
         structured_answer => {
-            input => ['-40 °C'],
-            operation => 'Convert',
-            result => '-40 °F'
+            input => ['-40 degrees celsius'],
+            operation => 'convert',
+            result => '-40 degrees fahrenheit'
         }
     ),
     
@@ -903,676 +903,676 @@ ddg_goodie_test(
     # for computational accuracy rather than
     # parsing accuracy
     '10 fahrenheit in fahrenheit' => test_zci(
-        '10 °F = 10 °F',
+        '10 degrees fahrenheit = 10 degrees fahrenheit',
         structured_answer => {
-            input => ['10 °F'],
-            operation => 'Convert',
-            result => '10 °F'
+            input => ['10 degrees fahrenheit'],
+            operation => 'convert',
+            result => '10 degrees fahrenheit'
         }
     ),
     '10 celsius in fahrenheit' => test_zci(
-        '10 °C = 50 °F',
+        '10 degrees celsius = 50 degrees fahrenheit',
         structured_answer => {
-            input => ['10 °C'],
-            operation => 'Convert',
-            result => '50 °F'
+            input => ['10 degrees celsius'],
+            operation => 'convert',
+            result => '50 degrees fahrenheit'
         }
     ),
     '10 kelvin in fahrenheit' => test_zci(
-        '10 K = -441.670 °F',
+        '10 kelvin = -441.670 degrees fahrenheit',
         structured_answer => {
-            input => ['10 K'],
-            operation => 'Convert',
-            result => '-441.670 °F'
+            input => ['10 kelvin'],
+            operation => 'convert',
+            result => '-441.670 degrees fahrenheit'
         }
     ),
     '10 rankine in fahrenheit' => test_zci(
-        '10 °R = -449.670 °F',
+        '10 degrees rankine = -449.670 degrees fahrenheit',
         structured_answer => {
-            input => ['10 °R'],
-            operation => 'Convert',
-            result => '-449.670 °F'
+            input => ['10 degrees rankine'],
+            operation => 'convert',
+            result => '-449.670 degrees fahrenheit'
         }
     ),
     '1234 fahrenheit in fahrenheit' => test_zci(
-        '1,234 °F = 1,234 °F',
+        '1,234 degrees fahrenheit = 1,234 degrees fahrenheit',
         structured_answer => {
-            input => ['1,234 °F'],
-            operation => 'Convert',
-            result => '1,234 °F'
+            input => ['1,234 degrees fahrenheit'],
+            operation => 'convert',
+            result => '1,234 degrees fahrenheit'
         }
     ),
     '1234 celsius in fahrenheit' => test_zci(
-        '1,234 °C = 2,253.200 °F',
+        '1,234 degrees celsius = 2,253.200 degrees fahrenheit',
         structured_answer => {
-            input => ['1,234 °C'],
-            operation => 'Convert',
-            result => '2,253.200 °F'
+            input => ['1,234 degrees celsius'],
+            operation => 'convert',
+            result => '2,253.200 degrees fahrenheit'
         }
     ),
     '1234 kelvin in fahrenheit' => test_zci(
-        '1,234 K = 1,761.530 °F',
+        '1,234 kelvin = 1,761.530 degrees fahrenheit',
         structured_answer => {
-            input => ['1,234 K'],
-            operation => 'Convert',
-            result => '1,761.530 °F'
+            input => ['1,234 kelvin'],
+            operation => 'convert',
+            result => '1,761.530 degrees fahrenheit'
         }
     ),
     '1234 rankine in fahrenheit' => test_zci(
-        '1,234 °R = 774.330 °F',
+        '1,234 degrees rankine = 774.330 degrees fahrenheit',
         structured_answer => {
-            input => ['1,234 °R'],
-            operation => 'Convert',
-            result => '774.330 °F'
+            input => ['1,234 degrees rankine'],
+            operation => 'convert',
+            result => '774.330 degrees fahrenheit'
         }
     ),
     '-87 fahrenheit in fahrenheit' => test_zci(
-        '-87 °F = -87 °F',
+        '-87 degrees fahrenheit = -87 degrees fahrenheit',
         structured_answer => {
-            input => ['-87 °F'],
-            operation => 'Convert',
-            result => '-87 °F'
+            input => ['-87 degrees fahrenheit'],
+            operation => 'convert',
+            result => '-87 degrees fahrenheit'
         }
     ),
     '-87 celsius in fahrenheit' => test_zci(
-        '-87 °C = -124.600 °F',        
+        '-87 degrees celsius = -124.600 degrees fahrenheit',        
         structured_answer => {
-            input => ['-87 °C'],
-            operation => 'Convert',
-            result => '-124.600 °F'
+            input => ['-87 degrees celsius'],
+            operation => 'convert',
+            result => '-124.600 degrees fahrenheit'
         }
     ),
     '-87 kelvin in fahrenheit' => undef,
     '-87 rankine in fahrenheit' => undef,
     '-7 fahrenheit in fahrenheit' => test_zci(
-        '-7 °F = -7 °F',
+        '-7 degrees fahrenheit = -7 degrees fahrenheit',
         structured_answer => {
-            input => ['-7 °F'],
-            operation => 'Convert',
-            result => '-7 °F'
+            input => ['-7 degrees fahrenheit'],
+            operation => 'convert',
+            result => '-7 degrees fahrenheit'
         }
     ),
     '-7 celsius in fahrenheit' => test_zci(
-        '-7 °C = 19.400 °F',
+        '-7 degrees celsius = 19.400 degrees fahrenheit',
         structured_answer => {
-            input => ['-7 °C'],
-            operation => 'Convert',
-            result => '19.400 °F'
+            input => ['-7 degrees celsius'],
+            operation => 'convert',
+            result => '19.400 degrees fahrenheit'
         }
     ),
     '-7 kelvin in fahrenheit' => undef,
     '-7 rankine in fahrenheit' => undef,
     #TODO: look at this undef
     '0 fahrenheit in fahrenheit' => test_zci(
-        '0 °F = 0 °F',
+        '0 degrees fahrenheit = 0 degrees fahrenheit',
         structured_answer => {
-            input => ['0 °F'],
-            operation => 'Convert',
-            result => '0 °F'
+            input => ['0 degrees fahrenheit'],
+            operation => 'convert',
+            result => '0 degrees fahrenheit'
         }
     ),
     '0 celsius in fahrenheit' => test_zci(
-        '0 °C = 32 °F',
+        '0 degrees celsius = 32 degrees fahrenheit',
         structured_answer => {
-            input => ['0 °C'],
-            operation => 'Convert',
-            result => '32 °F'
+            input => ['0 degrees celsius'],
+            operation => 'convert',
+            result => '32 degrees fahrenheit'
         }
     ),
     '0 kelvin in fahrenheit' => test_zci(
-        '0 K = -459.670 °F',
+        '0 kelvin = -459.670 degrees fahrenheit',
         structured_answer => {
-            input => ['0 K'],
-            operation => 'Convert',
-            result => '-459.670 °F'
+            input => ['0 kelvin'],
+            operation => 'convert',
+            result => '-459.670 degrees fahrenheit'
         }
     ),
     '0 rankine in fahrenheit' => test_zci(
-        '0 °R = -459.670 °F',
+        '0 degrees rankine = -459.670 degrees fahrenheit',
         structured_answer => {
-            input => ['0 °R'],
-            operation => 'Convert',
-            result => '-459.670 °F'
+            input => ['0 degrees rankine'],
+            operation => 'convert',
+            result => '-459.670 degrees fahrenheit'
         }
     ),
     '10 fahrenheit in celsius' => test_zci(
-        '10 °F = -12.222 °C',
+        '10 degrees fahrenheit = -12.222 degrees celsius',
         structured_answer => {
-            input => ['10 °F'],
-            operation => 'Convert',
-            result => '-12.222 °C'
+            input => ['10 degrees fahrenheit'],
+            operation => 'convert',
+            result => '-12.222 degrees celsius'
         }
     ),
     '10 celsius in celsius' => test_zci(
-        '10 °C = 10 °C',
+        '10 degrees celsius = 10 degrees celsius',
         structured_answer => {
-            input => ['10 °C'],
-            operation => 'Convert',
-            result => '10 °C'
+            input => ['10 degrees celsius'],
+            operation => 'convert',
+            result => '10 degrees celsius'
         }
     ),
     '10 kelvin in celsius' => test_zci(
-        '10 K = -263.150 °C',
+        '10 kelvin = -263.150 degrees celsius',
         structured_answer => {
-            input => ['10 K'],
-            operation => 'Convert',
-            result => '-263.150 °C'
+            input => ['10 kelvin'],
+            operation => 'convert',
+            result => '-263.150 degrees celsius'
         }
     ),
     #TODO: investigate accuracy here
-    # according to WA: 267.6°C;
+    # according to WA: 267.6degrees celsius;
     # https://www.wolframalpha.com/input/?i=10R+in+C
     '10 rankine in celsius' => test_zci(
-        '10 °R = -268 °C',
+        '10 degrees rankine = -268 degrees celsius',
         structured_answer => {
-            input => ['10 °R'],
-            operation => 'Convert',
-            result => '-268 °C'
+            input => ['10 degrees rankine'],
+            operation => 'convert',
+            result => '-268 degrees celsius'
         }
     ),
     
     '1234 fahrenheit in celsius' => test_zci(
-        '1,234 °F = 667.778 °C',
+        '1,234 degrees fahrenheit = 667.778 degrees celsius',
         structured_answer => {
-            input => ['1,234 °F'],
-            operation => 'Convert',
-            result => '667.778 °C'
+            input => ['1,234 degrees fahrenheit'],
+            operation => 'convert',
+            result => '667.778 degrees celsius'
         }
     ),
     '1234 celsius in celsius' => test_zci(
-        '1,234 °C = 1,234 °C',
+        '1,234 degrees celsius = 1,234 degrees celsius',
         structured_answer => {
-            input => ['1,234 °C'],
-            operation => 'Convert',
-            result => '1,234 °C'
+            input => ['1,234 degrees celsius'],
+            operation => 'convert',
+            result => '1,234 degrees celsius'
         }
     ),
     '1234 kelvin in celsius' => test_zci(
-        '1,234 K = 960.850 °C',
+        '1,234 kelvin = 960.850 degrees celsius',
         structured_answer => {
-            input => ['1,234 K'],
-            operation => 'Convert',
-            result => '960.850 °C'
+            input => ['1,234 kelvin'],
+            operation => 'convert',
+            result => '960.850 degrees celsius'
         }
     ),
     '1234 rankine in celsius' => test_zci(
-        '1,234 °R = 412.406 °C',
+        '1,234 degrees rankine = 412.406 degrees celsius',
         structured_answer => {
-            input => ['1,234 °R'],
-            operation => 'Convert',
-            result => '412.406 °C'
+            input => ['1,234 degrees rankine'],
+            operation => 'convert',
+            result => '412.406 degrees celsius'
         }
     ),
     '-87 fahrenheit in celsius' => test_zci(
-        '-87 °F = -66.111 °C',
+        '-87 degrees fahrenheit = -66.111 degrees celsius',
         structured_answer => {
-            input => ['-87 °F'],
-            operation => 'Convert',
-            result => '-66.111 °C'
+            input => ['-87 degrees fahrenheit'],
+            operation => 'convert',
+            result => '-66.111 degrees celsius'
         }
     ),
     '-87 celsius in celsius' => test_zci(
-        '-87 °C = -87 °C',
+        '-87 degrees celsius = -87 degrees celsius',
         structured_answer => {
-            input => ['-87 °C'],
-            operation => 'Convert',
-            result => '-87 °C'
+            input => ['-87 degrees celsius'],
+            operation => 'convert',
+            result => '-87 degrees celsius'
         }
     ),
     '-87 kelvin in celsius' => undef,
     '-87 rankine in celsius' => undef,
     '-7 fahrenheit in celsius' => test_zci(
-        '-7 °F = -21.667 °C',
+        '-7 degrees fahrenheit = -21.667 degrees celsius',
         structured_answer => {
-            input => ['-7 °F'],
-            operation => 'Convert',
-            result => '-21.667 °C'
+            input => ['-7 degrees fahrenheit'],
+            operation => 'convert',
+            result => '-21.667 degrees celsius'
         }
     ),
     '-7 celsius in celsius' => test_zci(
-        '-7 °C = -7 °C',
+        '-7 degrees celsius = -7 degrees celsius',
         structured_answer => {
-            input => ['-7 °C'],
-            operation => 'Convert',
-            result => '-7 °C'
+            input => ['-7 degrees celsius'],
+            operation => 'convert',
+            result => '-7 degrees celsius'
         }
     ),
     '-7 kelvin in celsius' => undef,
     '-7 rankine in celsius' => undef,
     '0 fahrenheit in celsius' => test_zci(
-        '0 °F = -17.778 °C',
+        '0 degrees fahrenheit = -17.778 degrees celsius',
         structured_answer => {
-            input => ['0 °F'],
-            operation => 'Convert',
-            result => '-17.778 °C'
+            input => ['0 degrees fahrenheit'],
+            operation => 'convert',
+            result => '-17.778 degrees celsius'
         }
     ),
     #TODO: Also no answer here?
     '0 celsius in celsius' => test_zci(
-        '0 °C = 0 °C',
+        '0 degrees celsius = 0 degrees celsius',
         structured_answer => {
-            input => ['0 °C'],
-            operation => 'Convert',
-            result => '0 °C'
+            input => ['0 degrees celsius'],
+            operation => 'convert',
+            result => '0 degrees celsius'
         }
     ),
     '0 kelvin in celsius' => test_zci(
-        '0 K = -273.150 °C',
+        '0 kelvin = -273.150 degrees celsius',
         structured_answer => {
-            input => ['0 K'],
-            operation => 'Convert',
-            result => '-273.150 °C'
+            input => ['0 kelvin'],
+            operation => 'convert',
+            result => '-273.150 degrees celsius'
         }
     ),
     '0 rankine in celsius' => test_zci(
-        '0 °R = -273.150 °C',
+        '0 degrees rankine = -273.150 degrees celsius',
         structured_answer => {
-            input => ['0 °R'],
-            operation => 'Convert',
-            result => '-273.150 °C'
+            input => ['0 degrees rankine'],
+            operation => 'convert',
+            result => '-273.150 degrees celsius'
         }
     ),
     '10 fahrenheit in kelvin' => test_zci(
-        '10 °F = 260.928 K',
+        '10 degrees fahrenheit = 260.928 kelvin',
         structured_answer => {
-            input => ['10 °F'],
-            operation => 'Convert',
-            result => '260.928 K'
+            input => ['10 degrees fahrenheit'],
+            operation => 'convert',
+            result => '260.928 kelvin'
         }
     ),
     '10 celsius in kelvin' => test_zci(
-        '10 °C = 283.150 K',
+        '10 degrees celsius = 283.150 kelvin',
         structured_answer => {
-            input => ['10 °C'],
-            operation => 'Convert',
-            result => '283.150 K'
+            input => ['10 degrees celsius'],
+            operation => 'convert',
+            result => '283.150 kelvin'
         }
     ),
     '10 kelvin in kelvin' => test_zci(
-        '10 K = 10 K',
+        '10 kelvin = 10 kelvin',
         structured_answer => {
-            input => ['10 K'],
-            operation => 'Convert',
-            result => '10 K'
+            input => ['10 kelvin'],
+            operation => 'convert',
+            result => '10 kelvin'
         }
     ),
     '10 rankine in kelvin' => test_zci(
-        '10 °R = 5.556 K',
+        '10 degrees rankine = 5.556 kelvin',
         structured_answer => {
-            input => ['10 °R'],
-            operation => 'Convert',
-            result => '5.556 K'
+            input => ['10 degrees rankine'],
+            operation => 'convert',
+            result => '5.556 kelvin'
         }
     ),
     '1234 fahrenheit in kelvin' => test_zci(
-        '1,234 °F = 940.928 K',
+        '1,234 degrees fahrenheit = 940.928 kelvin',
         structured_answer => {
-            input => ['1,234 °F'],
-            operation => 'Convert',
-            result => '940.928 K'
+            input => ['1,234 degrees fahrenheit'],
+            operation => 'convert',
+            result => '940.928 kelvin'
         }
     ),
     '1234 celsius in kelvin' => test_zci(
-        '1,234 °C = 1,507.150 K',
+        '1,234 degrees celsius = 1,507.150 kelvin',
         structured_answer => {
-            input => ['1,234 °C'],
-            operation => 'Convert',
-            result => '1,507.150 K'
+            input => ['1,234 degrees celsius'],
+            operation => 'convert',
+            result => '1,507.150 kelvin'
         }
     ),
     '1234 kelvin in kelvin' => test_zci(
-        '1,234 K = 1,234 K',
+        '1,234 kelvin = 1,234 kelvin',
         structured_answer => {
-            input => ['1,234 K'],
-            operation => 'Convert',
-            result => '1,234 K'
+            input => ['1,234 kelvin'],
+            operation => 'convert',
+            result => '1,234 kelvin'
         }
     ),
     '1234 rankine in kelvin' => test_zci(
-        '1,234 °R = 685.556 K',
+        '1,234 degrees rankine = 685.556 kelvin',
         structured_answer => {
-            input => ['1,234 °R'],
-            operation => 'Convert',
-            result => '685.556 K'
+            input => ['1,234 degrees rankine'],
+            operation => 'convert',
+            result => '685.556 kelvin'
         }
     ),
     #TODO NOT TRIGGERING!!
     '-87 fahrenheit in kelvin' => test_zci(
-        '-87 °F = 212 K',
+        '-87 degrees fahrenheit = 212 kelvin',
         structured_answer => {
-            input => ['-87 °F'],
-            operation => 'Convert',
-            result => '212 K'
+            input => ['-87 degrees fahrenheit'],
+            operation => 'convert',
+            result => '212 kelvin'
         }
     ),
     '-87 celsius in kelvin' => test_zci(
-        '-87 °C = 193.150 K ',
+        '-87 degrees celsius = 193.150 K ',
         structured_answer => {
-            input => ['-87 °C'],
-            operation => 'Convert',
-            result => '193.150 K'
+            input => ['-87 degrees celsius'],
+            operation => 'convert',
+            result => '193.150 kelvin'
         }
     ),
     '-87 kelvin in kelvin' => undef,
     '-87 rankine in kelvin' => undef,
     #TODO NOT TRIGGERING!!
     '-7 fahrenheit in kelvin' => test_zci(
-        '-7 °F = 251.500 K',
+        '-7 degrees fahrenheit = 251.500 kelvin',
         structured_answer => {
-            input => ['-7 °F'],
-            operation => 'Convert',
-            result => '251.500 K'
+            input => ['-7 degrees fahrenheit'],
+            operation => 'convert',
+            result => '251.500 kelvin'
         }
     ),
     '-7 celsius in kelvin' => test_zci(
-        '-7 °C = 266.150 K',
+        '-7 degrees celsius = 266.150 kelvin',
         structured_answer => {
-            input => ['-7 °C'],
-            operation => 'Convert',
-            result => '266.150 K'
+            input => ['-7 degrees celsius'],
+            operation => 'convert',
+            result => '266.150 kelvin'
         }
     ),
     '-7 kelvin in kelvin' => undef,
     '-7 rankine in kelvin' => undef,
     '0 fahrenheit in kelvin' => test_zci(
-        '0 °F = 255.372 K',
+        '0 degrees fahrenheit = 255.372 kelvin',
         structured_answer => {
-            input => ['0 °F'],
-            operation => 'Convert',
-            result => '255.372 K'
+            input => ['0 degrees fahrenheit'],
+            operation => 'convert',
+            result => '255.372 kelvin'
         }
     ),
     '0 celsius in kelvin' => test_zci(
-        '0 °C = 273.150 K',
+        '0 degrees celsius = 273.150 kelvin',
         structured_answer => {
-            input => ['0 °C'],
-            operation => 'Convert',
-            result => '273.150 K'
+            input => ['0 degrees celsius'],
+            operation => 'convert',
+            result => '273.150 kelvin'
         }
     ),
     #FAILING:
     '0 kelvin in kelvin' => test_zci(
-        '0 K = 0 K',
+        '0 kelvin = 0 kelvin',
         structured_answer => {
-            input => ['0 K'],
-            operation => 'Convert',
-            result => '0 K'
+            input => ['0 kelvin'],
+            operation => 'convert',
+            result => '0 kelvin'
         }
     ),
     # doesn't trigger:
     '0 rankine in kelvin' => test_zci(
-        '0 rankine = 0 K',
+        '0 rankine = 0 kelvin',
         structured_answer => {
-            input => ['0 °R'],
-            operation => 'Convert',
-            result => '0 K'
+            input => ['0 degrees rankine'],
+            operation => 'convert',
+            result => '0 kelvin'
         }
     ),
     
     '10 fahrenheit in rankine' => test_zci(
-        '10 °F = 469.670 °R',
+        '10 degrees fahrenheit = 469.670 degrees rankine',
         structured_answer => {
-            input => ['10 °F'],
-            operation => 'Convert',
-            result => '469.670 °R'
+            input => ['10 degrees fahrenheit'],
+            operation => 'convert',
+            result => '469.670 degrees rankine'
         }
     ),
     '10 celsius in rankine' => test_zci(
-        '10 °C = 509.670 °R',        
+        '10 degrees celsius = 509.670 degrees rankine',        
         structured_answer => {
-            input => ['10 °C'],
-            operation => 'Convert',
-            result => '509.670 °R'
+            input => ['10 degrees celsius'],
+            operation => 'convert',
+            result => '509.670 degrees rankine'
         }
     ),
     '10 kelvin in rankine' => test_zci(
-        '10 K = 18 °R',
+        '10 kelvin = 18 degrees rankine',
         structured_answer => {
-            input => ['10 K'],
-            operation => 'Convert',
-            result => '18 °R'
+            input => ['10 kelvin'],
+            operation => 'convert',
+            result => '18 degrees rankine'
         }
     ),
     '10 rankine in rankine' => test_zci(
-        '10 °R = 10 °R',
+        '10 degrees rankine = 10 degrees rankine',
         structured_answer => {
-            input => ['10 °R'],
-            operation => 'Convert',
-            result => '10 °R'
+            input => ['10 degrees rankine'],
+            operation => 'convert',
+            result => '10 degrees rankine'
         }
     ),
     '1234 fahrenheit in rankine' => test_zci(
-        '1,234 °F = 1,693.670 °R',
+        '1,234 degrees fahrenheit = 1,693.670 degrees rankine',
         structured_answer => {
-            input => ['1,234 °F'],
-            operation => 'Convert',
-            result => '1,693.670 °R'
+            input => ['1,234 degrees fahrenheit'],
+            operation => 'convert',
+            result => '1,693.670 degrees rankine'
         }
     ),
     '1234 celsius in rankine' => test_zci(
-        '1,234 °C = 2,712.870 °R',
+        '1,234 degrees celsius = 2,712.870 degrees rankine',
         structured_answer => {
-            input => ['1,234 °C'],
-            operation => 'Convert',
-            result => '2,712.870 °R'
+            input => ['1,234 degrees celsius'],
+            operation => 'convert',
+            result => '2,712.870 degrees rankine'
         }
     ),
     '1234 kelvin in rankine' => test_zci(
-        '1,234 K = 2,221.200 °R',
+        '1,234 kelvin = 2,221.200 degrees rankine',
         structured_answer => {
-            input => ['1,234 K'],
-            operation => 'Convert',
-            result => '2,221.200 °R'
+            input => ['1,234 kelvin'],
+            operation => 'convert',
+            result => '2,221.200 degrees rankine'
         }
     ),
     '1234 rankine in rankine' => test_zci(
-        '1,234 °R = 1,234 °R',
+        '1,234 degrees rankine = 1,234 degrees rankine',
         structured_answer => {
-            input => ['1,234 °R'],
-            operation => 'Convert',
-            result => '1,234 °R'
+            input => ['1,234 degrees rankine'],
+            operation => 'convert',
+            result => '1,234 degrees rankine'
         }
     ),
     #TOOD: FAILING, don't trigger correctly
     '-87 fahrenheit in rankine' => test_zci(
-        '-87 °F = 372.700 °R',
+        '-87 degrees fahrenheit = 372.700 degrees rankine',
         structured_answer => {
-            input => ['-87 °F'],
-            operation => 'Convert',
-            result => '372.700 °R'
+            input => ['-87 degrees fahrenheit'],
+            operation => 'convert',
+            result => '372.700 degrees rankine'
         }
     ),
     '-87 celsius in rankine' => test_zci(
-        '-87 °C = 335.100 °R',
+        '-87 degrees celsius = 335.100 degrees rankine',
         structured_answer => {
-            input => ['-87 °C'],
-            operation => 'Convert',
-            result => '335.100 °R'
+            input => ['-87 degrees celsius'],
+            operation => 'convert',
+            result => '335.100 degrees rankine'
         }
     ),
     '-87 kelvin in rankine' => undef,
     '-87 rankine in rankine' => undef,
     #TODO: Failing, don't trigger correctly
     '-7 fahrenheit in rankine' => test_zci(
-        '-7 °F = 452.700 °R',
+        '-7 degrees fahrenheit = 452.700 degrees rankine',
         structured_answer => {
-            input => ['-7 °F'],
-            operation => 'Convert',
-            result => '452.700 °R'
+            input => ['-7 degrees fahrenheit'],
+            operation => 'convert',
+            result => '452.700 degrees rankine'
         }
     ),
     '-7 celsius in rankine' => test_zci(
-        '-7 °C = 479.100 °R',
+        '-7 degrees celsius = 479.100 degrees rankine',
         structured_answer => {
-            input => ['-7 °C'],
-            operation => 'Convert',
-            result => '479.100 °R'
+            input => ['-7 degrees celsius'],
+            operation => 'convert',
+            result => '479.100 degrees rankine'
         }
     ),
     '-7 kelvin in rankine' => undef,
     '-7 rankine in rankine' => undef,
     '0 fahrenheit in rankine' => test_zci(
-        '0 °F = 459.670 °R',
+        '0 degrees fahrenheit = 459.670 degrees rankine',
         structured_answer => {
-            input => ['0 °F'],
-            operation => 'Convert',
-            result => '459.670 °R'
+            input => ['0 degrees fahrenheit'],
+            operation => 'convert',
+            result => '459.670 degrees rankine'
         }
     ),
     '0 celsius in rankine' => test_zci(
-        '0 °C = 491.670 °R',
+        '0 degrees celsius = 491.670 degrees rankine',
         structured_answer => {
-            input => ['0 °C'],
-            operation => 'Convert',
-            result => '491.670 °R'
+            input => ['0 degrees celsius'],
+            operation => 'convert',
+            result => '491.670 degrees rankine'
         }
     ),
     # FAILING: 0 != 0
     '0 kelvin in rankine' => test_zci(
-        '0 K = 0 °R',
+        '0 kelvin = 0 degrees rankine',
         structured_answer => {
-            input => ['0 K'],
-            operation => 'Convert',
-            result => '0 °R'
+            input => ['0 kelvin'],
+            operation => 'convert',
+            result => '0 degrees rankine'
         }
     ),
     # Doesn't Trigger
     '0 rankine in rankine' => test_zci(
-        '0 °R = 0 °R',
+        '0 degrees rankine = 0 degrees rankine',
         structured_answer => {
-            input => ['0 °R'],
-            operation => 'Convert',
-            result => '0 °R'
+            input => ['0 degrees rankine'],
+            operation => 'convert',
+            result => '0 degrees rankine'
         }
     ),
     
     
     '84856 fahrenheit in fahrenheit' => test_zci(
-        '84,856 °F = 84,856 °F',
+        '84,856 degrees fahrenheit = 84,856 degrees fahrenheit',
         structured_answer => {
-            input => ['84,856 °F'],
-            operation => 'Convert',
-            result => '84,856 °F'
+            input => ['84,856 degrees fahrenheit'],
+            operation => 'convert',
+            result => '84,856 degrees fahrenheit'
         }
     ),
     '84856 celsius in fahrenheit' => test_zci(
-        '84,856 °C = 152,772.800 °F',
+        '84,856 degrees celsius = 152,772.800 degrees fahrenheit',
         structured_answer => {
-            input => ['84,856 °C'],
-            operation => 'Convert',
-            result => '152,772.800 °F'
+            input => ['84,856 degrees celsius'],
+            operation => 'convert',
+            result => '152,772.800 degrees fahrenheit'
         }
     ),
     '84856 kelvin in fahrenheit' => test_zci(
-        '84,856 K = 152,281.130 °F',
+        '84,856 kelvin = 152,281.130 degrees fahrenheit',
         structured_answer => {
-            input => ['84,856 K'],
-            operation => 'Convert',
-            result => '152,281.130 °F'
+            input => ['84,856 kelvin'],
+            operation => 'convert',
+            result => '152,281.130 degrees fahrenheit'
         }
     ),
     '84856 rankine in fahrenheit' => test_zci(
-        '84,856 °R = 84,396.330 °F',
+        '84,856 degrees rankine = 84,396.330 degrees fahrenheit',
         structured_answer => {
-            input => ['84,856 °R'],
-            operation => 'Convert',
-            result => '84,396.330 °F'
+            input => ['84,856 degrees rankine'],
+            operation => 'convert',
+            result => '84,396.330 degrees fahrenheit'
         }
     ),
     '84856 fahrenheit in celsius' => test_zci(
-        '84,856 °F = 47,124.444 °C',
+        '84,856 degrees fahrenheit = 47,124.444 degrees celsius',
         structured_answer => {
-            input => ['84,856 °F'],
-            operation => 'Convert',
-            result => '47,124.444 °C'
+            input => ['84,856 degrees fahrenheit'],
+            operation => 'convert',
+            result => '47,124.444 degrees celsius'
         }
     ),
     '84856 celsius in celsius' => test_zci(
-        '84,856 °C = 84,856 °C',
+        '84,856 degrees celsius = 84,856 degrees celsius',
         structured_answer => {
-            input => ['84,856 °C'],
-            operation => 'Convert',
-            result => '84,856 °C'
+            input => ['84,856 degrees celsius'],
+            operation => 'convert',
+            result => '84,856 degrees celsius'
         }
     ),
     '84856 kelvin in celsius' => test_zci(
-        '84,856 K = 84,582.850 °C',
+        '84,856 kelvin = 84,582.850 degrees celsius',
         structured_answer => {
-            input => ['84,856 K'],
-            operation => 'Convert',
-            result => '84,582.850 °C'
+            input => ['84,856 kelvin'],
+            operation => 'convert',
+            result => '84,582.850 degrees celsius'
         }
     ),
     '84856 rankine in celsius' => test_zci(
-        '84,856 °R = 46,869.072 °C',
+        '84,856 degrees rankine = 46,869.072 degrees celsius',
         structured_answer => {
-            input => ['84,856 °R'],
-            operation => 'Convert',
-            result => '46,869.072 °C'
+            input => ['84,856 degrees rankine'],
+            operation => 'convert',
+            result => '46,869.072 degrees celsius'
         }
     ),
     '84856 fahrenheit in kelvin' => test_zci(
-        '84,856 °F = 47,397.594 K',
+        '84,856 degrees fahrenheit = 47,397.594 kelvin',
         structured_answer => {
-            input => ['84,856 °F'],
-            operation => 'Convert',
-            result => '47,397.594 K'
+            input => ['84,856 degrees fahrenheit'],
+            operation => 'convert',
+            result => '47,397.594 kelvin'
         }
     ),
     '84856 celsius in kelvin' => test_zci(
-        '84,856 °C = 85,129.150 K',
+        '84,856 degrees celsius = 85,129.150 kelvin',
         structured_answer => {
-            input => ['84,856 °C'],
-            operation => 'Convert',
-            result => '85,129.150 K'
+            input => ['84,856 degrees celsius'],
+            operation => 'convert',
+            result => '85,129.150 kelvin'
         }
     ),
     '84856 kelvin in kelvin' => test_zci(
-        '84,856 K = 84,856 K',
+        '84,856 kelvin = 84,856 kelvin',
         structured_answer => {
-            input => ['84,856 K'],
-            operation => 'Convert',
-            result => '84,856 K'
+            input => ['84,856 kelvin'],
+            operation => 'convert',
+            result => '84,856 kelvin'
         }
     ),
     '84856 rankine in kelvin' => test_zci(
-        '84,856 °R = 47,142.222 K',
+        '84,856 degrees rankine = 47,142.222 kelvin',
         structured_answer => {
-            input => ['84,856 °R'],
-            operation => 'Convert',
-            result => '47,142.222 K'
+            input => ['84,856 degrees rankine'],
+            operation => 'convert',
+            result => '47,142.222 kelvin'
         }
     ),
     '84856 fahrenheit in rankine' => test_zci(
-        '84,856 °F = 85,315.670 °R',
+        '84,856 degrees fahrenheit = 85,315.670 degrees rankine',
         structured_answer => {
-            input => ['84,856 °F'],
-            operation => 'Convert',
-            result => '85,315.670 °R'
+            input => ['84,856 degrees fahrenheit'],
+            operation => 'convert',
+            result => '85,315.670 degrees rankine'
         }
     ),
     '84856 celsius in rankine' => test_zci(
-        '84,856 °C = 153,232.470 °R',
+        '84,856 degrees celsius = 153,232.470 degrees rankine',
         structured_answer => {
-            input => ['84,856 °C'],
-            operation => 'Convert',
-            result => '153,232.470 °R'
+            input => ['84,856 degrees celsius'],
+            operation => 'convert',
+            result => '153,232.470 degrees rankine'
         }
     ),
     '84856 kelvin in rankine' => test_zci(
-        '84,856 K = 152,740.800 °R',
+        '84,856 kelvin = 152,740.800 degrees rankine',
         structured_answer => {
-            input => ['84,856 K'],
-            operation => 'Convert',
-            result => '152,740.800 °R'
+            input => ['84,856 kelvin'],
+            operation => 'convert',
+            result => '152,740.800 degrees rankine'
         }
     ),
     '84856 rankine in rankine' => test_zci(
-        '84,856 °R = 84,856 °R',
+        '84,856 degrees rankine = 84,856 degrees rankine',
         structured_answer => {
-            input => ['84,856 °R'],
-            operation => 'Convert',
-            result => '84,856 °R'
+            input => ['84,856 degrees rankine'],
+            operation => 'convert',
+            result => '84,856 degrees rankine'
         }
     ),
     

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -1003,7 +1003,14 @@ ddg_goodie_test(
     '-7 kelvin in fahrenheit' => undef,
     '-7 rankine in fahrenheit' => undef,
     
-    '0 fahrenheit in fahrenheit' => undef,
+    '0 fahrenheit in fahrenheit' => test_zci(
+        '0 degrees fahrenheit = 0 degrees fahrenheit',
+        structured_answer => {
+            input => ['0 degrees fahrenheit'],
+            operation => 'convert',
+            result => '0 degrees fahrenheit'
+        }
+    ),,
     '0 celsius in fahrenheit' => test_zci(
         '0 degrees celsius = 32 degrees fahrenheit',
         structured_answer => {
@@ -1137,7 +1144,14 @@ ddg_goodie_test(
             result => '-17.778 degrees celsius'
         }
     ),
-    '0 celsius in celsius' => undef,
+    '0 celsius in celsius' => test_zci(
+        '0 degrees celsius = 0 degrees celsius',
+        structured_answer => {
+            input => ['0 degrees celsius'],
+            operation => 'convert',
+            result => '0 degrees celsius'
+        }
+    ),,
     '0 kelvin in celsius' => test_zci(
         '0 kelvin = -273.150 degrees celsius',
         structured_answer => {
@@ -1271,9 +1285,16 @@ ddg_goodie_test(
             result => '273.150 kelvin'
         }
     ),
-    '0 kelvin in kelvin' => undef,
+    '0 kelvin in kelvin' => test_zci(
+        '0 kelvin = 0 kelvin',
+        structured_answer => {
+            input => ['0 kelvin'],
+            operation => 'convert',
+            result => '0 kelvin'
+        }
+    ),,
     '0 rankine in kelvin' => test_zci(
-        '0 rankine = 0 kelvin',
+        '0 degrees rankine = 0 kelvin',
         structured_answer => {
             input => ['0 degrees rankine'],
             operation => 'convert',
@@ -1405,7 +1426,14 @@ ddg_goodie_test(
             result => '0 degrees rankine'
         }
     ),
-    '0 rankine in rankine' => undef,
+    '0 rankine in rankine' => test_zci(
+        '0 degrees rankine = 0 degrees rankine',
+        structured_answer => {
+            input => ['0 degrees rankine'],
+            operation => 'convert',
+            result => '0 degrees rankine'
+        }
+    ),,
         
     '84856 fahrenheit in fahrenheit' => test_zci(
         '84,856 degrees fahrenheit = 84,856 degrees fahrenheit',

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -640,11 +640,11 @@ ddg_goodie_test(
         }
     ),
     'how many ounces in a cup' => test_zci(
-        '1 us cup = 16 fluid ounces',
+        '1 us cup = 8 us fluid ounces',
         structured_answer => {
             input => ['1 us cup'],
             operation => 'convert',
-            result => '16 fluid ounces'
+            result => '8 us fluid ounces'
         }
     ),
     # Unusual number formats

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -623,6 +623,22 @@ ddg_goodie_test(
             result    => '25.400 millimeters'
         }
     ),
+    'how many fl oz in a cup' => test_zci (
+        '1 us cup = 8 us fluid ounces',
+        structured_answer => {
+            input => ['1 us cup'],
+            operation => 'convert',
+            result => '8 us fluid ounces'
+        }
+    ),
+    '4 cups in quarts' => test_zci(
+        '4 us cups = 1 quart',
+        structured_answer => {
+            input => ['4 us cups'],
+            operation => 'convert',
+            result => '1 quart'
+        }
+    ),
     # Unusual number formats
     '3e60 degrees in revolutions' => test_zci(
         '3 * 10^60 degrees = 8.33 * 10^57 revolutions',

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -1002,7 +1002,7 @@ ddg_goodie_test(
     ),
     '-7 kelvin in fahrenheit' => undef,
     '-7 rankine in fahrenheit' => undef,
-    #TODO: look at this undef
+    
     '0 fahrenheit in fahrenheit' => test_zci(
         '0 degrees fahrenheit = 0 degrees fahrenheit',
         structured_answer => {
@@ -1059,15 +1059,12 @@ ddg_goodie_test(
             result => '-263.150 degrees celsius'
         }
     ),
-    #TODO: investigate accuracy here
-    # according to WA: 267.6degrees celsius;
-    # https://www.wolframalpha.com/input/?i=10R+in+C
     '10 rankine in celsius' => test_zci(
-        '10 degrees rankine = -268 degrees celsius',
+        '10 degrees rankine = -267.594 degrees celsius',
         structured_answer => {
             input => ['10 degrees rankine'],
             operation => 'convert',
-            result => '-268 degrees celsius'
+            result => '-267.594 degrees celsius'
         }
     ),
     

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -1003,14 +1003,7 @@ ddg_goodie_test(
     '-7 kelvin in fahrenheit' => undef,
     '-7 rankine in fahrenheit' => undef,
     
-    '0 fahrenheit in fahrenheit' => test_zci(
-        '0 degrees fahrenheit = 0 degrees fahrenheit',
-        structured_answer => {
-            input => ['0 degrees fahrenheit'],
-            operation => 'convert',
-            result => '0 degrees fahrenheit'
-        }
-    ),
+    '0 fahrenheit in fahrenheit' => undef,
     '0 celsius in fahrenheit' => test_zci(
         '0 degrees celsius = 32 degrees fahrenheit',
         structured_answer => {
@@ -1144,15 +1137,7 @@ ddg_goodie_test(
             result => '-17.778 degrees celsius'
         }
     ),
-    #TODO: Also no answer here?
-    '0 celsius in celsius' => test_zci(
-        '0 degrees celsius = 0 degrees celsius',
-        structured_answer => {
-            input => ['0 degrees celsius'],
-            operation => 'convert',
-            result => '0 degrees celsius'
-        }
-    ),
+    '0 celsius in celsius' => undef,
     '0 kelvin in celsius' => test_zci(
         '0 kelvin = -273.150 degrees celsius',
         structured_answer => {
@@ -1233,32 +1218,31 @@ ddg_goodie_test(
             result => '685.556 kelvin'
         }
     ),
-    #TODO NOT TRIGGERING!!
     '-87 fahrenheit in kelvin' => test_zci(
-        '-87 degrees fahrenheit = 212 kelvin',
+        '-87 degrees fahrenheit = 207.039 kelvin',
         structured_answer => {
             input => ['-87 degrees fahrenheit'],
             operation => 'convert',
-            result => '212 kelvin'
+            result => '207.039 kelvin'
         }
     ),
     '-87 celsius in kelvin' => test_zci(
-        '-87 degrees celsius = 193.150 K ',
+        '-87 degrees celsius = 186.150 kelvin',
         structured_answer => {
             input => ['-87 degrees celsius'],
             operation => 'convert',
-            result => '193.150 kelvin'
+            result => '186.150 kelvin'
         }
     ),
     '-87 kelvin in kelvin' => undef,
     '-87 rankine in kelvin' => undef,
-    #TODO NOT TRIGGERING!!
+    
     '-7 fahrenheit in kelvin' => test_zci(
-        '-7 degrees fahrenheit = 251.500 kelvin',
+        '-7 degrees fahrenheit = 251.483 kelvin',
         structured_answer => {
             input => ['-7 degrees fahrenheit'],
             operation => 'convert',
-            result => '251.500 kelvin'
+            result => '251.483 kelvin'
         }
     ),
     '-7 celsius in kelvin' => test_zci(
@@ -1287,16 +1271,7 @@ ddg_goodie_test(
             result => '273.150 kelvin'
         }
     ),
-    #FAILING:
-    '0 kelvin in kelvin' => test_zci(
-        '0 kelvin = 0 kelvin',
-        structured_answer => {
-            input => ['0 kelvin'],
-            operation => 'convert',
-            result => '0 kelvin'
-        }
-    ),
-    # doesn't trigger:
+    '0 kelvin in kelvin' => undef,
     '0 rankine in kelvin' => test_zci(
         '0 rankine = 0 kelvin',
         structured_answer => {
@@ -1370,40 +1345,38 @@ ddg_goodie_test(
             result => '1,234 degrees rankine'
         }
     ),
-    #TOOD: FAILING, don't trigger correctly
     '-87 fahrenheit in rankine' => test_zci(
-        '-87 degrees fahrenheit = 372.700 degrees rankine',
+        '-87 degrees fahrenheit = 372.670 degrees rankine',
         structured_answer => {
             input => ['-87 degrees fahrenheit'],
             operation => 'convert',
-            result => '372.700 degrees rankine'
+            result => '372.670 degrees rankine'
         }
     ),
     '-87 celsius in rankine' => test_zci(
-        '-87 degrees celsius = 335.100 degrees rankine',
+        '-87 degrees celsius = 335.070 degrees rankine',
         structured_answer => {
             input => ['-87 degrees celsius'],
             operation => 'convert',
-            result => '335.100 degrees rankine'
+            result => '335.070 degrees rankine'
         }
     ),
     '-87 kelvin in rankine' => undef,
     '-87 rankine in rankine' => undef,
-    #TODO: Failing, don't trigger correctly
     '-7 fahrenheit in rankine' => test_zci(
-        '-7 degrees fahrenheit = 452.700 degrees rankine',
+        '-7 degrees fahrenheit = 452.670 degrees rankine',
         structured_answer => {
             input => ['-7 degrees fahrenheit'],
             operation => 'convert',
-            result => '452.700 degrees rankine'
+            result => '452.670 degrees rankine'
         }
     ),
     '-7 celsius in rankine' => test_zci(
-        '-7 degrees celsius = 479.100 degrees rankine',
+        '-7 degrees celsius = 479.070 degrees rankine',
         structured_answer => {
             input => ['-7 degrees celsius'],
             operation => 'convert',
-            result => '479.100 degrees rankine'
+            result => '479.070 degrees rankine'
         }
     ),
     '-7 kelvin in rankine' => undef,
@@ -1424,7 +1397,6 @@ ddg_goodie_test(
             result => '491.670 degrees rankine'
         }
     ),
-    # FAILING: 0 != 0
     '0 kelvin in rankine' => test_zci(
         '0 kelvin = 0 degrees rankine',
         structured_answer => {
@@ -1433,17 +1405,8 @@ ddg_goodie_test(
             result => '0 degrees rankine'
         }
     ),
-    # Doesn't Trigger
-    '0 rankine in rankine' => test_zci(
-        '0 degrees rankine = 0 degrees rankine',
-        structured_answer => {
-            input => ['0 degrees rankine'],
-            operation => 'convert',
-            result => '0 degrees rankine'
-        }
-    ),
-    
-    
+    '0 rankine in rankine' => undef,
+        
     '84856 fahrenheit in fahrenheit' => test_zci(
         '84,856 degrees fahrenheit = 84,856 degrees fahrenheit',
         structured_answer => {


### PR DESCRIPTION
Hello Everyone.

We've been discussing for a while what we want to do around unit conversion. I've been evaluating a number of API's and npm modules as @moollaza knows. I've not found any which cover the same breadth of units that we do currently and that are easily extensible for us to add more later. I feel that given the profile of this IA, it's important for us to be able to customise, fix and maintain it quickly and easily.

I was in conversation with @GuiltyDolphin about what we can do for the future of both Calculator and Conversions. It seems like a natural progression would be to be able to handle queries such as `33 inches + 5 cm in yards`. Extending the grammar for the calculator in https://github.com/duckduckgo/zeroclickinfo-goodies/pull/1927 for units should be relatively trivial, especially if it is handed a list or collection of units from somewhere; however it means we need control over the units and conversions handling etc. 

I think this leads us down a path of modularising both Conversions and Calculator into a collection of Roles (or similar) so we can easily assemble what we need. 

We were also discussing about interactivity of these IA's; we have a couple of choices. One is to re-implement them entirely in JS (relatively trivial for Conversions) however much more difficult for Calculator as grammar parsing isn't very mature in JS. @GuiltyDolphin suggested that there was a conversation around being able to 50-50 it, so that we can build a front-end in JS and do some AJAX off to the backend for processing. This seems like an ideal compromise to me, but I don't believe the IA architecture currently supports such an arrangement.

I've assumed that either way we could do with centralising and tidying this up a bit so I've resurrected an old branch where I brought everything back together and tidied things out in order to kick start the conversation.

This branch:
* Fixes the temperature conversions (includes passing tests from: https://github.com/duckduckgo/zeroclickinfo-goodies/pull/1731)
* Thus fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/1413
* Includes https://github.com/duckduckgo/zeroclickinfo-goodies/pull/1992
* Can be easily extended by adding units to the `ratios.yaml` : i.e. resolves: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/828
* Adds support for queries like `How to convert meters to inches` as suggested by @GuiltyDolphin 
* Fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/1754
* Fixes (by expanding the existing bodge, until ambiguous units can be resolved, I'd like to tackle that as a separate unit of work) https://github.com/duckduckgo/zeroclickinfo-goodies/issues/1767
* Fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/1847 by increasing accuracy of definition rather than rounding the result off sooner
* Fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/1729


I would like (if we agree to go down this path) to separate out prefixes from the rest (so all units can be expressed as kiloX or megaX) etc which would simplify things massively and help the modularity.

I'm keen to hear what people think about this, I think we've been a bit stuck-in-the-mud around conversions for too long now.

@duckduckgo/community-leaders @moollaza @jagtalon 

===============
https://duck.co/ia/view/conversions