### PR TITLE
EmToPx: Convert to template + improvements

### DIFF
--- a/lib/DDG/Goodie/EmToPx.pm
+++ b/lib/DDG/Goodie/EmToPx.pm
@@ -27,10 +27,21 @@ handle query_raw => sub {
     my ($target, $num, $source, $fontsize) = map { $+{$_} } qw(target num source fs);
     $fontsize ||= 16;
 
+sub em_to_px {
+    my ($to_convert, $fontsize) = @_;
+    return $to_convert * $fontsize;
+}
+
+sub px_to_em {
+    my ($to_convert, $fontsize) = @_;
+    return sprintf('%.3f', $to_convert / $fontsize) =~ s/\.?0+$//r;
+}
+
     return if ($target eq $source || !$num);
 
-    my $result = ($target eq 'px') ? $num * $fontsize : $num / $fontsize;
     my $plur   = $result == 1      ? "is"             : "are";
+    my $result = ($target eq 'px') ? em_to_px($num, $fontsize) . 'px'
+                                   : px_to_em($num, $fontsize) . 'em';
 
     return $result,
         structured_answer => {

--- a/lib/DDG/Goodie/EmToPx.pm
+++ b/lib/DDG/Goodie/EmToPx.pm
@@ -2,6 +2,7 @@ package DDG::Goodie::EmToPx;
 # ABSTRACT: em <-> px for font sizes.
 
 use strict;
+use warnings;
 use DDG::Goodie;
 
 triggers any => "em", "px";
@@ -31,12 +32,19 @@ handle query_raw => sub {
     my $result = ($target eq 'px') ? $num * $fontsize : $num / $fontsize;
     my $plur   = $result == 1      ? "is"             : "are";
 
-    return "There $plur $result $target in $num $source (assuming a ${fontsize}px font size)",
-      structured_answer => {
-        input     => [$num . $source, $fontsize . 'px font size'],
-        operation => 'Convert to ' . $target,
-        result    => $result . $target
-      };
+    return $result,
+        structured_answer => {
+            id   => 'em_to_px',
+            name => 'Answer',
+            data => {
+                title    => $result,
+                subtitle => $formatted_input,
+            },
+            templates => {
+                group  => 'text',
+                moreAt => 0,
+            },
+        };
 };
 
 1;

--- a/lib/DDG/Goodie/EmToPx.pm
+++ b/lib/DDG/Goodie/EmToPx.pm
@@ -20,12 +20,6 @@ topics 'programming';
 attribution twitter => ['crazedpsyc','crazedpsyc'],
             cpan    => ['CRZEDPSYC','crazedpsyc'];
 
-handle query_raw => sub {
-    my $q = lc $_;
-    $q =~ s/(?![\.\s])\W//g;
-    return unless $q =~ /^(?:convert|change|what\s*(?:s|is|are)\s+)?(?<num>\d+\.\d*|\d*\.\d+|\d+)\s*(?<source>em|px)\s+(?:in|to)\s+(?<target>em|px)(?:\s+(?:with|at|using|assuming)(?:\s+an?)?\s+(?<fs>\d+\.\d*|\d*\.\d+|\d+)\s*px)?/;
-    my ($target, $num, $source, $fontsize) = map { $+{$_} } qw(target num source fs);
-    $fontsize ||= 16;
 
 sub em_to_px {
     my ($to_convert, $fontsize) = @_;
@@ -37,11 +31,27 @@ sub px_to_em {
     return sprintf('%.3f', $to_convert / $fontsize) =~ s/\.?0+$//r;
 }
 
+my $number = qr/(\d++\.\d*+|\d*+\.\d++|\d++)/;
+my $whatis = qr/(convert|change|what\s*('?s|is|are))?/i;
+my $amount = qr/(?<amount>$number)/i;
+my $source = qr/(?<source>em|px)/i;
+my $target = qr/(?<target>em|px)/i;
+my $fs = qr/((font[ -]?|base[- ]?pixel[- ]?)size)/i;
+my $fontsize = qr/((with|at|using|assuming)(\s*an?)?)?\s*(?<fm>$fs\s*(of)?\s*)?((?<fontsize>$number)\s*(px)?)\s*(?(<fm>)|($fs))?/i;
+
+handle query_lc => sub {
+    my $query = $_;
+    $query =~ s/(?![\.\s])\W//g;
+    return unless $query =~ /^${whatis}?\s*${amount}\s*${source}\s*(?:in|to)\s*${target}\s*${fontsize}?\s*$/i;
+    my $target   = $+{target};
+    my $num      = $+{amount};
+    my $source   = $+{source};
+    my $fontsize = $+{fontsize} // 16;
     return if ($target eq $source || !$num);
 
-    my $plur   = $result == 1      ? "is"             : "are";
     my $result = ($target eq 'px') ? em_to_px($num, $fontsize) . 'px'
                                    : px_to_em($num, $fontsize) . 'em';
+    my $formatted_input = "Convert $num $source to $target with a font-size of ${fontsize}px";
 
     return $result,
         structured_answer => {

--- a/t/EmToPx.t
+++ b/t/EmToPx.t
@@ -1,5 +1,3 @@
-#!/usr/bin/env perl
-
 use strict;
 use warnings;
 use Test::More;
@@ -8,41 +6,41 @@ use DDG::Test::Goodie;
 zci answer_type => 'conversion';
 zci is_cached   => 1;
 
+sub build_structured_answer {
+    my ($result, $size, $type, $fontsize) = @_;
+    my $target = $type eq 'em' ? 'px' : 'em';
+    return $result,
+        structured_answer => {
+            id   => 'em_to_px',
+            name => 'Answer',
+            data => {
+                title    => $result,
+                subtitle => "Convert $size $type to $target with a font-size of ${fontsize}px",
+            },
+            templates => {
+                group  => 'text',
+                moreAt => 0,
+            },
+        };
+}
+
+sub build_test { test_zci(build_structured_answer(@_)) }
+
 ddg_goodie_test(
     [qw( DDG::Goodie::EmToPx )],
-    '10 px to em' => test_zci(
-        'There are 0.625 em in 10 px (assuming a 16px font size)',
-        structured_answer => {
-            input     => ['10px', '16px font size'],
-            operation => 'Convert to em',
-            result    => '0.625em'
-        }
-    ),
-    '1em to px' => test_zci(
-        'There are 16 px in 1 em (assuming a 16px font size)',
-        structured_answer => {
-            input     => ['1em', '16px font size'],
-            operation => 'Convert to px',
-            result    => '16px'
-        }
-    ),
-    '12.2 px in em assuming a 12.2px font size' => test_zci(
-        "There is 1 em in 12.2 px (assuming a 12.2px font size)",
-        structured_answer => {
-            input     => ['12.2px', '12.2px font size'],
-            operation => 'Convert to em',
-            result    => '1em'
-        }
-    ),
-    '12.2 px in em assuming a 12.2 font size' => test_zci(
-        'There are 0.7625 em in 12.2 px (assuming a 16px font size)',
-        structured_answer => {
-            input     => ['12.2px', '16px font size'],
-            operation => 'Convert to em',
-            result    => '0.7625em'
-        }
-    ),
+    # Simple queries
+    '10 px to em'   => build_test('0.625em', '10', 'px', '16'),
+    '1em to px'     => build_test('16px', '1', 'em', '16'),
     '10 px to 10em' => undef,
+    # Font size
+    '12.2 px in em assuming a 12.2px font size' => build_test('1em', '12.2', 'px', '12.2'),
+    '12.2 px in em assuming a 12.2 font size'   => build_test('1em', '12.2', 'px', '12.2'),
+    '15px to em font-size 11'                   => build_test('1.364em', '15', 'px', '11'),
+    # Pixel size
+    '7em to px base pixel size 10'                    => build_test('70px', '7', 'em', '10'),
+    '3px to em with a base pixel size of 17'          => build_test('0.176em', '3', 'px', '17'),
+    'what is 9px in em with a base pixel size of 24?' => build_test('0.375em', '9', 'px', '24'),
+    '11px to em at base-pixel size 23px'              => build_test('0.478em', '11', 'px', '23'),
 );
 
 done_testing;


### PR DESCRIPTION
- Converted to 'text' template.
- Improves regular expression matching.
- Fixes some bugs with font-size not being recognized.
- Adds some more tests (I ran some conversions on an existing site).
- Rounds results to 3dp


---
[IA Page](https://duck.co/ia/view/em_to_px)