### PR TITLE
Regexp: Improvements!

### DIFF
--- a/lib/DDG/Goodie/Regexp.pm
+++ b/lib/DDG/Goodie/Regexp.pm
@@ -21,10 +21,18 @@ sub get_full_match {
     return substr(shift, $-[0], $+[0] - $-[0]);
 }
 
+# Ensures that the correct numbered matches are being produced.
+sub real_number_matches {
+    my ($one, @numbered) = @_;
+    # If the first match isn't defined then neither are the others!
+    return defined $one ? @numbered : ();
+}
+
 sub get_match_record {
     my ($regexp, $str) = @_;
     my $compiler = Safe->new->reval(q{ sub { qr/$_[0]/ } });
     my @numbered = $str =~ compile_re($regexp, $compiler) or return;
+    @numbered = real_number_matches($1, @numbered);
 		my $matches = {};
 		$matches->{'Full Match'} = get_full_match($str);
     foreach my $match (keys %+) {

--- a/lib/DDG/Goodie/Regexp.pm
+++ b/lib/DDG/Goodie/Regexp.pm
@@ -2,6 +2,7 @@ package DDG::Goodie::Regexp;
 # ABSTRACT: Parse a regexp.
 
 use strict;
+use warnings;
 use DDG::Goodie;
 
 use Safe;
@@ -31,11 +32,17 @@ sub real_number_matches {
 
 sub get_match_record {
     my ($regexp, $str, $modifiers) = @_;
-    my $compiler = Safe->new->reval(q{ sub { qr/(?$_[1])$_[0]/ } });
+    my $compiler = Safe->new->reval(q { sub { qr/(?$_[1])$_[0]/ } }) or return;
+    BEGIN {
+        $SIG{'__WARN__'} = sub {
+            warn $_[0] if $_[0] !~ /Use of uninitialized value in regexp compilation/i;
+        }
+    }
+
     my @numbered = $str =~ compile_re($regexp, $modifiers, $compiler) or return;
     @numbered = real_number_matches($1, @numbered);
-		my $matches = {};
-		$matches->{'Full Match'} = get_full_match($str);
+    my $matches = {};
+    $matches->{'Full Match'} = get_full_match($str);
     foreach my $match (keys %+) {
 		    $matches->{"Named Capture <$match>"} = $+{$match};
     };

--- a/lib/DDG/Goodie/Regexp.pm
+++ b/lib/DDG/Goodie/Regexp.pm
@@ -65,6 +65,7 @@ handle query => sub {
     my ($regexp, $str, $modifiers) = extract_regex_text($query) or return;
     my $matches = get_match_record($regexp, $str, $modifiers) or return;
     my @key_order = get_match_keys($matches);
+    return unless $matches->{'Full Match'} ne '';
 
     return $matches,
         structured_answer => {

--- a/lib/DDG/Goodie/Regexp.pm
+++ b/lib/DDG/Goodie/Regexp.pm
@@ -27,8 +27,23 @@ handle query => sub {
 		@results = $str =~ compile_re($regexp, $compiler);
     };
 
-    return join( ' | ', @results ), heading => 'Regexp Result' if @results;
-    return;
+    return $matches,
+        structured_answer => {
+            id   => 'regexp',
+            name => 'Answer',
+            data => {
+                title       => "Regular Expression Match",
+                subtitle    => "Match regular expression /$regexp/ on $str",
+                record_data => $matches,
+            },
+            templates => {
+                group   => 'list',
+                options => {
+                    content => 'record',
+                },
+                moreAt  => 0,
+            },
+        };
 };
 
 1;

--- a/lib/DDG/Goodie/Regexp.pm
+++ b/lib/DDG/Goodie/Regexp.pm
@@ -58,10 +58,13 @@ sub extract_regex_text {
     return ($+{regex}, $+{text}, $modifiers);
 }
 
+sub get_match_keys { return sort (keys %{$_[0]}) }
+
 handle query => sub {
     my $query = $_;
     my ($regexp, $str, $modifiers) = extract_regex_text($query) or return;
     my $matches = get_match_record($regexp, $str, $modifiers) or return;
+    my @key_order = get_match_keys($matches);
 
     return $matches,
         structured_answer => {
@@ -71,6 +74,7 @@ handle query => sub {
                 title       => "Regular Expression Match",
                 subtitle    => "Match regular expression /$regexp/$modifiers on $str",
                 record_data => $matches,
+                record_keys => \@key_order,
             },
             templates => {
                 group   => 'list',

--- a/lib/DDG/Goodie/Regexp.pm
+++ b/lib/DDG/Goodie/Regexp.pm
@@ -37,11 +37,11 @@ sub get_match_record {
 		my $matches = {};
 		$matches->{'Full Match'} = get_full_match($str);
     foreach my $match (keys %+) {
-		    $matches->{"Named Match ($match)"} = $+{$match};
+		    $matches->{"Named Capture <$match>"} = $+{$match};
     };
     my $i = 1;
     foreach my $match (@numbered) {
-        $matches->{"Number Match ($i)"} = $match;
+        $matches->{"Subpattern Match $i"} = $match;
         $i++;
     };
     return $matches;

--- a/share/goodie/regexp/regexp.css
+++ b/share/goodie/regexp/regexp.css
@@ -1,0 +1,4 @@
+.zci--regexp .record .record__cell--key {
+    width: 20em;
+    text-transform: none;
+}

--- a/t/Regexp.t
+++ b/t/Regexp.t
@@ -16,7 +16,7 @@ sub build_structured_answer {
             name => 'Answer',
             data => {
                 title       => 'Regular Expression Match',
-                subtitle    => "Match regular expression /$expression/ on $text",
+                subtitle    => "Match regular expression $expression on $text",
                 record_data => $result,
             },
             templates => {
@@ -36,31 +36,39 @@ ddg_goodie_test([qw( DDG::Goodie::Regexp )],
         'Full Match'         => 'Harry is awesome',
         'Named Match (name)' => 'Harry',
         'Number Match (1)'   => 'Harry',
-    }, '(?<name>Harry|Larry) is awesome', 'Harry is awesome'),
+    }, '/(?<name>Harry|Larry) is awesome/', 'Harry is awesome'),
     'regex /(he|she) walked away/ he walked away' => build_test({
         'Full Match'       => 'he walked away',
         'Number Match (1)' => 'he',
-    }, '(he|she) walked away', 'he walked away'),
+    }, '/(he|she) walked away/', 'he walked away'),
     'match regex /How are (?:we|you) (doing|today)\?/ How are you today?' => build_test({
         'Full Match'       => 'How are you today?',
         'Number Match (1)' => 'today',
-    }, 'How are (?:we|you) (doing|today)\?', 'How are you today?'),
+    }, '/How are (?:we|you) (doing|today)\?/', 'How are you today?'),
     'abc =~ /[abc]+/' => build_test({
         'Full Match' => 'abc',
-    }, '[abc]+', 'abc'),
+    }, '/[abc]+/', 'abc'),
     'DDG::Goodie::Regexp =~ /^DDG::Goodie::(?<goodie>\w+)$/' => build_test({
         'Full Match'           => 'DDG::Goodie::Regexp',
         'Named Match (goodie)' => 'Regexp',
         'Number Match (1)'     => 'Regexp',
-    }, '^DDG::Goodie::(?<goodie>\w+)$', 'DDG::Goodie::Regexp'),
+    }, '/^DDG::Goodie::(?<goodie>\w+)$/', 'DDG::Goodie::Regexp'),
     'regexp /foo/ foo' => build_test({
         'Full Match' => 'foo',
-    }, 'foo', 'foo'),
+    }, '/foo/', 'foo'),
+    # Modifiers
+    'Foo =~ /(foo)/i' => build_test({
+        'Full Match' => 'Foo',
+        'Number Match (1)' => 'Foo',
+    }, '/(foo)/i', 'Foo'),
+    'regexp /hello/i HELLO' => build_test({
+        'Full Match' => 'HELLO',
+    }, '/hello/i', 'HELLO'),
     # Primary example query
     'regexp /(.*)/ ddg' => build_test({
         'Full Match'       => 'ddg',
         'Number Match (1)' => 'ddg',
-    }, '(.*)', 'ddg'),
+    }, '/(.*)/', 'ddg'),
     # Does not match.
     'regexp /foo/ bar'      => undef,
     'match /^foo$/ foo bar' => undef,
@@ -70,6 +78,7 @@ ddg_goodie_test([qw( DDG::Goodie::Regexp )],
     'regex'            => undef,
     '/foo/ =~ foo'     => undef,
     'regex foo /foo/'  => undef,
+    'BaR =~ /bar/x'    => undef,
 );
 
 done_testing;

--- a/t/Regexp.t
+++ b/t/Regexp.t
@@ -18,6 +18,7 @@ sub build_structured_answer {
                 title       => 'Regular Expression Match',
                 subtitle    => "Match regular expression $expression on $text",
                 record_data => $result,
+                record_keys => \@{[sort (keys %$result)]},
             },
             templates => {
                 group   => 'list',

--- a/t/Regexp.t
+++ b/t/Regexp.t
@@ -8,25 +8,29 @@ use DDG::Test::Goodie;
 zci answer_type => 'regexp';
 zci is_cached   => 1;
 
-ddg_goodie_test(
-        [qw( DDG::Goodie::Regexp )],
-        'regexp /(hello\s)/ hello probably' => test_zci(
-        	"hello ",
-        	heading => 'Regexp Result',
-        ),
-        'regexp /(dd)/ ddg' => test_zci(
-        	"dd",
-        	heading => 'Regexp Result',
-        ),
-        'regex /(poss)/ many possibilities' => test_zci(
-        	"poss",
-        	heading => 'Regexp Result',
-        ),
-        'regexp /(.*)/ ddg' => test_zci(
-            'ddg',
-            heading => 'Regexp Result'
-        ),
-);
+sub build_structured_answer {
+    my ($result, $expression, $text) = @_;
+    return $result,
+        structured_answer => {
+            id   => 'regexp',
+            name => 'Answer',
+            data => {
+                title       => 'Regular Expression Match',
+                subtitle    => "Match regular expression /$expression/ on $text",
+                record_data => $result,
+            },
+            templates => {
+                group   => 'list',
+                options => {
+                    content => 'record',
+                },
+                moreAt  => 0,
+            },
+        };
+}
+
+sub build_test { test_zci(build_structured_answer(@_)) }
+
 
 done_testing;
 

--- a/t/Regexp.t
+++ b/t/Regexp.t
@@ -34,41 +34,41 @@ sub build_test { test_zci(build_structured_answer(@_)) }
 
 ddg_goodie_test([qw( DDG::Goodie::Regexp )],
     'regexp /(?<name>Harry|Larry) is awesome/ Harry is awesome' => build_test({
-        'Full Match'         => 'Harry is awesome',
-        'Named Match (name)' => 'Harry',
-        'Number Match (1)'   => 'Harry',
+        'Full Match'           => 'Harry is awesome',
+        'Named Capture <name>' => 'Harry',
+        'Subpattern Match 1'   => 'Harry',
     }, '/(?<name>Harry|Larry) is awesome/', 'Harry is awesome'),
     'regex /(he|she) walked away/ he walked away' => build_test({
-        'Full Match'       => 'he walked away',
-        'Number Match (1)' => 'he',
+        'Full Match'         => 'he walked away',
+        'Subpattern Match 1' => 'he',
     }, '/(he|she) walked away/', 'he walked away'),
     'match regex /How are (?:we|you) (doing|today)\?/ How are you today?' => build_test({
-        'Full Match'       => 'How are you today?',
-        'Number Match (1)' => 'today',
+        'Full Match'         => 'How are you today?',
+        'Subpattern Match 1' => 'today',
     }, '/How are (?:we|you) (doing|today)\?/', 'How are you today?'),
     'abc =~ /[abc]+/' => build_test({
         'Full Match' => 'abc',
     }, '/[abc]+/', 'abc'),
     'DDG::Goodie::Regexp =~ /^DDG::Goodie::(?<goodie>\w+)$/' => build_test({
-        'Full Match'           => 'DDG::Goodie::Regexp',
-        'Named Match (goodie)' => 'Regexp',
-        'Number Match (1)'     => 'Regexp',
+        'Full Match'             => 'DDG::Goodie::Regexp',
+        'Named Capture <goodie>' => 'Regexp',
+        'Subpattern Match 1'     => 'Regexp',
     }, '/^DDG::Goodie::(?<goodie>\w+)$/', 'DDG::Goodie::Regexp'),
     'regexp /foo/ foo' => build_test({
         'Full Match' => 'foo',
     }, '/foo/', 'foo'),
     # Modifiers
     'Foo =~ /(foo)/i' => build_test({
-        'Full Match' => 'Foo',
-        'Number Match (1)' => 'Foo',
+        'Full Match'         => 'Foo',
+        'Subpattern Match 1' => 'Foo',
     }, '/(foo)/i', 'Foo'),
     'regexp /hello/i HELLO' => build_test({
         'Full Match' => 'HELLO',
     }, '/hello/i', 'HELLO'),
     # Primary example query
     'regexp /(.*)/ ddg' => build_test({
-        'Full Match'       => 'ddg',
-        'Number Match (1)' => 'ddg',
+        'Full Match'         => 'ddg',
+        'Subpattern Match 1' => 'ddg',
     }, '/(.*)/', 'ddg'),
     # Does not match.
     'regexp /foo/ bar'      => undef,

--- a/t/Regexp.t
+++ b/t/Regexp.t
@@ -31,6 +31,32 @@ sub build_structured_answer {
 
 sub build_test { test_zci(build_structured_answer(@_)) }
 
+ddg_goodie_test([qw( DDG::Goodie::Regexp )],
+    'regexp /(?<name>Harry|Larry) is awesome/ Harry is awesome' => build_test({
+        'Full Match'         => 'Harry is awesome',
+        'Named Match (name)' => 'Harry',
+        'Number Match (1)'   => 'Harry',
+    }, '(?<name>Harry|Larry) is awesome', 'Harry is awesome'),
+    'regex /(he|she) walked away/ he walked away' => build_test({
+        'Full Match'       => 'he walked away',
+        'Number Match (1)' => 'he',
+    }, '(he|she) walked away', 'he walked away'),
+    'match regex /How are (?:we|you) (doing|today)\?/ How are you today?' => build_test({
+        'Full Match'       => 'How are you today?',
+        'Number Match (1)' => 'today',
+    }, 'How are (?:we|you) (doing|today)\?', 'How are you today?'),
+    'regexp /(.*)/ ddg' => build_test({
+        'Full Match'       => 'ddg',
+        'Number Match (1)' => 'ddg',
+    }, '(.*)', 'ddg'),
+    # Does not match.
+    'regexp /foo/ bar'      => undef,
+    'match /^foo$/ foo bar' => undef,
+    # Should not trigger.
+    'What is regex?'   => undef,
+    'regex cheatsheet' => undef,
+    'regex'            => undef,
+);
 
 done_testing;
 

--- a/t/Regexp.t
+++ b/t/Regexp.t
@@ -45,13 +45,22 @@ ddg_goodie_test([qw( DDG::Goodie::Regexp )],
         'Full Match'       => 'How are you today?',
         'Number Match (1)' => 'today',
     }, 'How are (?:we|you) (doing|today)\?', 'How are you today?'),
+    'abc =~ /[abc]+/' => build_test({
+        'Full Match' => 'abc',
+    }, '[abc]+', 'abc'),
+    'DDG::Goodie::Regexp =~ /^DDG::Goodie::(?<goodie>\w+)$/' => build_test({
+        'Full Match'           => 'DDG::Goodie::Regexp',
+        'Named Match (goodie)' => 'Regexp',
+        'Number Match (1)'     => 'Regexp',
+    }, '^DDG::Goodie::(?<goodie>\w+)$', 'DDG::Goodie::Regexp'),
+    'regexp /foo/ foo' => build_test({
+        'Full Match' => 'foo',
+    }, 'foo', 'foo'),
+    # Primary example query
     'regexp /(.*)/ ddg' => build_test({
         'Full Match'       => 'ddg',
         'Number Match (1)' => 'ddg',
     }, '(.*)', 'ddg'),
-    'regexp /foo/ foo' => build_test({
-        'Full Match' => 'foo',
-    }, 'foo', 'foo'),
     # Does not match.
     'regexp /foo/ bar'      => undef,
     'match /^foo$/ foo bar' => undef,
@@ -59,6 +68,8 @@ ddg_goodie_test([qw( DDG::Goodie::Regexp )],
     'What is regex?'   => undef,
     'regex cheatsheet' => undef,
     'regex'            => undef,
+    '/foo/ =~ foo'     => undef,
+    'regex foo /foo/'  => undef,
 );
 
 done_testing;

--- a/t/Regexp.t
+++ b/t/Regexp.t
@@ -74,12 +74,13 @@ ddg_goodie_test([qw( DDG::Goodie::Regexp )],
     'regexp /foo/ bar'      => undef,
     'match /^foo$/ foo bar' => undef,
     # Should not trigger.
-    'What is regex?'   => undef,
-    'regex cheatsheet' => undef,
-    'regex'            => undef,
-    '/foo/ =~ foo'     => undef,
-    'regex foo /foo/'  => undef,
-    'BaR =~ /bar/x'    => undef,
+    'What is regex?'          => undef,
+    'regex cheatsheet'        => undef,
+    'regex'                   => undef,
+    '/foo/ =~ foo'            => undef,
+    'regex foo /foo/'         => undef,
+    'BaR =~ /bar/x'           => undef,
+    'regexp /(?<hh(h)h>h)/ h' => undef,
 );
 
 done_testing;

--- a/t/Regexp.t
+++ b/t/Regexp.t
@@ -49,6 +49,9 @@ ddg_goodie_test([qw( DDG::Goodie::Regexp )],
         'Full Match'       => 'ddg',
         'Number Match (1)' => 'ddg',
     }, '(.*)', 'ddg'),
+    'regexp /foo/ foo' => build_test({
+        'Full Match' => 'foo',
+    }, 'foo', 'foo'),
     # Does not match.
     'regexp /foo/ bar'      => undef,
     'match /^foo$/ foo bar' => undef,


### PR DESCRIPTION
Which of these do you prefer?

![screenshot from 2016-01-02 16 08 13](https://cloud.githubusercontent.com/assets/8598426/12075062/27a350a4-b16b-11e5-8357-05cbec136a9e.png)

**OR**

![screenshot from 2016-01-02 16 10 16](https://cloud.githubusercontent.com/assets/8598426/12075067/60f293e2-b16b-11e5-9720-dfaad6aa7008.png)


Yeah, I thought so. The first one is clearly superior ;)

## To-do

- [x] Support Perl-style matching (`foo =~ /foo/`).
- [x] Improve ordering of results (full match first, numbered matches in order etc...).
- [ ] Ensure that the Goodie won't try and compute really complex regexes (maybe time limit or just detect complexity?). 
- [x] Support basic modifiers (ignore case, for example).
- [x] Expand key width a bit - named captures are wrapping too early.

### Bugs

- [x] Matches like `regexp /foo/ foo` will allocate `1` to the first numbered match.
- [x] Uppercases the named captures (i.e, `Named Capture <x>` becomes `Named Capture <X>`).

---
[IA Page](https://duck.co/ia/view/regexp)