### PR TITLE
Zodiac - Remove DateTime::Event::Zodiac Dependency

### DIFF
--- a/share/goodie/zodiac/dates.json
+++ b/share/goodie/zodiac/dates.json
@@ -1,0 +1,76 @@
+{
+  "zodiacs": [
+      {
+        "name": "aries",
+        "duration": 25,
+        "start": [21, 3],
+        "end": [20, 4]
+      },
+      {
+        "name": "taurus",
+        "duration": 37,
+        "start": [21, 4],
+        "end": [21, 5]
+      },
+      {
+        "name": "gemini",
+        "duration": 31,
+        "start": [22, 5],
+        "end": [21, 6]
+      },
+      {
+        "name": "cancer",
+        "duration": 20,
+        "start": [22, 6],
+        "end": [22, 7]
+      },
+      {
+        "name": "leo",
+        "duration": 37,
+        "start": [23, 7],
+        "end": [22, 8]
+      },
+      {
+        "name": "virgo",
+        "duration": 45,
+        "start": [23, 8],
+        "end": [23, 9]
+      },
+      {
+        "name": "libra",
+        "duration": 23,
+        "start": [24, 9],
+        "end": [23, 10]
+      },
+      {
+        "name": "scorpius",
+        "duration": 7,
+        "start": [24, 10],
+        "end": [22, 11]
+      },
+      {
+        "name": "sagittarius",
+        "duration": 32,
+        "start": [23, 11],
+        "end": [21, 12]
+      },
+      {
+        "name": "capricornus",
+        "duration": 24,
+        "start": [22, 12],
+        "end": [20, 1]
+      },
+      {
+        "name": "aquarius",
+        "start": [21, 1],
+        "end": [19, 2]
+      },
+      {
+        "name": "pisces",
+        "duration": 38,
+        "start": [20, 2],
+        "end": [20, 3]
+      }
+  ]
+}
+

--- a/share/goodie/zodiac/dates.json
+++ b/share/goodie/zodiac/dates.json
@@ -2,73 +2,62 @@
   "zodiacs": [
       {
         "name": "aries",
-        "duration": 25,
         "start": [21, 3],
         "end": [20, 4]
       },
       {
         "name": "taurus",
-        "duration": 37,
         "start": [21, 4],
-        "end": [21, 5]
+        "end": [20, 5]
       },
       {
         "name": "gemini",
-        "duration": 31,
-        "start": [22, 5],
+        "start": [21, 5],
         "end": [21, 6]
       },
       {
         "name": "cancer",
-        "duration": 20,
         "start": [22, 6],
         "end": [22, 7]
       },
       {
         "name": "leo",
-        "duration": 37,
         "start": [23, 7],
-        "end": [22, 8]
+        "end": [23, 8]
       },
       {
         "name": "virgo",
-        "duration": 45,
-        "start": [23, 8],
-        "end": [23, 9]
+        "start": [24, 8],
+        "end": [22, 9]
       },
       {
         "name": "libra",
-        "duration": 23,
-        "start": [24, 9],
-        "end": [23, 10]
+        "start": [23, 9],
+        "end": [22, 10]
       },
       {
         "name": "scorpius",
-        "duration": 7,
-        "start": [24, 10],
-        "end": [22, 11]
+        "start": [23, 10],
+        "end": [21, 11]
       },
       {
         "name": "sagittarius",
-        "duration": 32,
-        "start": [23, 11],
+        "start": [22, 11],
         "end": [21, 12]
       },
       {
         "name": "capricornus",
-        "duration": 24,
         "start": [22, 12],
-        "end": [20, 1]
+        "end": [19, 1]
       },
       {
         "name": "aquarius",
-        "start": [21, 1],
-        "end": [19, 2]
+        "start": [20, 1],
+        "end": [18, 2]
       },
       {
         "name": "pisces",
-        "duration": 38,
-        "start": [20, 2],
+        "start": [19, 2],
         "end": [20, 3]
       }
   ]

--- a/t/Zodiac.t
+++ b/t/Zodiac.t
@@ -25,717 +25,101 @@ sub build_structured_answer {
         };
 }
 
-    'StarSign 30 Mar'        => test_zci(
-	'Zodiac for 30 Mar 2015: Aries',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--red circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
 sub build_test { test_zci(build_structured_answer(@_)) }
 
-    '20 April star sign'     => test_zci(
-	'Zodiac for 20 Apr 2015: Aries',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--red circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+set_fixed_time("2015-12-30T00:00:00");
+zci answer_type => 'zodiac';
+ddg_goodie_test([ qw( DDG::Goodie::Zodiac ) ],
+
+    #Test Aries
+    'Zodiac 21st March 1967' => build_test('bg-clr--red circle', 'Zodiac for 21 Mar 1967: Aries'),
+
+    'StarSign 30 Mar' => build_test('bg-clr--red circle', 'Zodiac for 30 Mar 2015: Aries'),
+
+    '20 April star sign' => build_test('bg-clr--red circle', 'Zodiac for 20 Apr 2015: Aries'),
 
     #Test Taurus
-    'Zodiac 21st April 2014' => test_zci(
-	'Zodiac for 21 Apr 2014: Taurus',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--green circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
-    'StarSign 27 Apr'        => test_zci(
-	'Zodiac for 27 Apr 2015: Taurus',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--green circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'Zodiac 21st April 2014' => build_test('bg-clr--green circle', 'Zodiac for 21 Apr 2014: Taurus'),
+    'StarSign 27 Apr' => build_test('bg-clr--green circle', 'Zodiac for 27 Apr 2015: Taurus'),
 
     #Test Gemini
-    '21 May star sign'     => test_zci(
-	'Zodiac for 21 May 2015: Gemini',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--grey circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    '21 May star sign' => build_test('bg-clr--grey circle', 'Zodiac for 21 May 2015: Gemini'),
 
-    'Zodiac 22nd May 1500' => test_zci(
-	'Zodiac for 22 May 1500: Gemini',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--grey circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'Zodiac 22nd May 1500' => build_test('bg-clr--grey circle', 'Zodiac for 22 May 1500: Gemini'),
 
-    'Zodiac 21.05.1965'    => test_zci(
-	'Zodiac for 21 May 1965: Gemini',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--grey circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'Zodiac 21.05.1965' => build_test('bg-clr--grey circle', 'Zodiac for 21 May 1965: Gemini'),
 
-    'StarSign 31 May'      => test_zci(
-	'Zodiac for 31 May 2015: Gemini',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--grey circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'StarSign 31 May' => build_test('bg-clr--grey circle', 'Zodiac for 31 May 2015: Gemini'),
 
-    '21 jun star sign'     => test_zci(
-	'Zodiac for 21 Jun 2015: Gemini',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--grey circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    '21 jun star sign' => build_test('bg-clr--grey circle', 'Zodiac for 21 Jun 2015: Gemini'),
 
     #Test Cancer
-    'Zodiac 22nd June 1889' => test_zci(
-	'Zodiac for 22 Jun 1889: Cancer',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--blue-light circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'Zodiac 22nd June 1889' => build_test('bg-clr--blue-light circle', 'Zodiac for 22 Jun 1889: Cancer'),
 
-    'StarSign 30 June 2017' => test_zci(
-	'Zodiac for 30 Jun 2017: Cancer',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--blue-light circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'StarSign 30 June 2017' => build_test('bg-clr--blue-light circle', 'Zodiac for 30 Jun 2017: Cancer'),
 
-    '22nd july star sign'   => test_zci(
-	'Zodiac for 22 Jul 2015: Cancer',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--blue-light circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    '22nd july star sign' => build_test('bg-clr--blue-light circle', 'Zodiac for 22 Jul 2015: Cancer'),
 
     #Test Leo
-    'Zodiac 23 July 1654'  => test_zci(
-	'Zodiac for 23 Jul 1654: Leo',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--red circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'Zodiac 23 July 1654' => build_test('bg-clr--red circle', 'Zodiac for 23 Jul 1654: Leo'),
 
-    'StarSign 24th July'   => test_zci(
-	'Zodiac for 24 Jul 2015: Leo',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--red circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'StarSign 24th July' => build_test('bg-clr--red circle', 'Zodiac for 24 Jul 2015: Leo'),
 
-    '22 aug star sign'     => test_zci(
-	'Zodiac for 22 Aug 2015: Leo',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--red circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    '22 aug star sign' => build_test('bg-clr--red circle', 'Zodiac for 22 Aug 2015: Leo'),
 
-    'Zodiac 23rd Aug 1700' => test_zci(
-	'Zodiac for 23 Aug 1700: Leo',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--red circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'Zodiac 23rd Aug 1700' => build_test('bg-clr--red circle', 'Zodiac for 23 Aug 1700: Leo'),
 
     #Test Virgo
-    'StarSign 1 Sep' => test_zci(
-	'Zodiac for 01 Sep 2015: Virgo',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--green circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'StarSign 1 Sep' => build_test('bg-clr--green circle', 'Zodiac for 01 Sep 2015: Virgo'),
 
     #Test Libra
-    '23rd Sep star sign'       => test_zci(
-	'Zodiac for 23 Sep 2015: Libra',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--grey circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    '23rd Sep star sign' => build_test('bg-clr--grey circle', 'Zodiac for 23 Sep 2015: Libra'),
 
-    'Zodiac 24 September 2001' => test_zci(
-	'Zodiac for 24 Sep 2001: Libra',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--grey circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'Zodiac 24 September 2001' => build_test('bg-clr--grey circle', 'Zodiac for 24 Sep 2001: Libra'),
 
-    'StarSign 7th October'     => test_zci(
-	'Zodiac for 07 Oct 2015: Libra',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--grey circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'StarSign 7th October' => build_test('bg-clr--grey circle', 'Zodiac for 07 Oct 2015: Libra'),
 
     #Test Scorpius
-    '23 oct star sign'       => test_zci(
-	'Zodiac for 23 Oct 2015: Scorpius',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--blue-light circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    '23 oct star sign' => build_test('bg-clr--blue-light circle', 'Zodiac for 23 Oct 2015: Scorpius'),
 
-    'Zodiac 24 October 1213' => test_zci(
-	'Zodiac for 24 Oct 1213: Scorpius',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--blue-light circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'Zodiac 24 October 1213' => build_test('bg-clr--blue-light circle', 'Zodiac for 24 Oct 1213: Scorpius'),
 
-    'StarSign 9th November'  => test_zci(
-	'Zodiac for 09 Nov 2015: Scorpius',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--blue-light circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'StarSign 9th November' => build_test('bg-clr--blue-light circle', 'Zodiac for 09 Nov 2015: Scorpius'),
 
     #Test Sagittarius
-    '22 nov star sign'   => test_zci(
-	'Zodiac for 22 Nov 2015: Sagittarius',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--red circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    '22 nov star sign' => build_test('bg-clr--red circle', 'Zodiac for 22 Nov 2015: Sagittarius'),
 
-    'Zodiac 23 Nov 1857' => test_zci(
-	'Zodiac for 23 Nov 1857: Sagittarius',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--red circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'Zodiac 23 Nov 1857' => build_test('bg-clr--red circle', 'Zodiac for 23 Nov 1857: Sagittarius'),
 
-    'StarSign 6 Dec'     => test_zci(
-	'Zodiac for 06 Dec 2015: Sagittarius',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--red circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-     ),
+    'StarSign 6 Dec' => build_test('bg-clr--red circle', 'Zodiac for 06 Dec 2015: Sagittarius'),
 
-    '21 Dec star sign'   => test_zci(
-	'Zodiac for 21 Dec 2015: Sagittarius',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--red circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-     ),
+    '21 Dec star sign' => build_test('bg-clr--red circle', 'Zodiac for 21 Dec 2015: Sagittarius'),
 
     #Test Capricornus
-    'Zodiac 22nd December' => test_zci(
-	'Zodiac for 22 Dec 2015: Capricornus',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--green circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'Zodiac 22nd December' => build_test('bg-clr--green circle', 'Zodiac for 22 Dec 2015: Capricornus'),
 
-    'StarSign 23 Dec 1378' => test_zci(
-	'Zodiac for 23 Dec 1378: Capricornus',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--green circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'StarSign 23 Dec 1378' => build_test('bg-clr--green circle', 'Zodiac for 23 Dec 1378: Capricornus'),
 
-    'starsign 31 Dec 2009' => test_zci(
-	'Zodiac for 31 Dec 2009: Capricornus',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--green circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'starsign 31 Dec 2009' => build_test('bg-clr--green circle', 'Zodiac for 31 Dec 2009: Capricornus'),
 
-    '31.12.2100 zodiac'    => test_zci(
-	'Zodiac for 31 Dec 2100: Capricornus',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--green circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    '31.12.2100 zodiac' => build_test('bg-clr--green circle', 'Zodiac for 31 Dec 2100: Capricornus'),
 
-    '1 Jan zodiac'         => test_zci(
-	'Zodiac for 01 Jan 2015: Capricornus',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--green circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    '1 Jan zodiac' => build_test('bg-clr--green circle', 'Zodiac for 01 Jan 2015: Capricornus'),
 
     #Test Aquarius
-    '20 Jan star sign' => test_zci(
-	'Zodiac for 20 Jan 2015: Aquarius',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--grey circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    '20 Jan star sign' => build_test('bg-clr--grey circle', 'Zodiac for 20 Jan 2015: Aquarius'),
 
-    'Zodiac 21st Jan'  => test_zci(
-	'Zodiac for 21 Jan 2015: Aquarius',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--grey circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'Zodiac 21st Jan' => build_test('bg-clr--grey circle', 'Zodiac for 21 Jan 2015: Aquarius'),
 
-    'StarSign 1st Feb' => test_zci(
-	'Zodiac for 01 Feb 2015: Aquarius',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--grey circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    'StarSign 1st Feb' => build_test('bg-clr--grey circle', 'Zodiac for 01 Feb 2015: Aquarius'),
 
     #Test Pisces
-    '19 Feb star sign'     => test_zci(
-	'Zodiac for 19 Feb 2015: Pisces',
-        structured_answer => {
-            id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--blue-light circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-    ),
+    '19 Feb star sign' => build_test('bg-clr--blue-light circle', 'Zodiac for 19 Feb 2015: Pisces'),
 
-    'Zodiac 20th Feb 1967' => test_zci(
-	'Zodiac for 20 Feb 1967: Pisces',
-     structured_answer => { 
-        id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--blue-light circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-     ),
-    'StarSign 1st Mar'     => test_zci(
-	'Zodiac for 01 Mar 2015: Pisces',
-    structured_answer => {
-        id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--blue-light circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-     ),
+    'Zodiac 20th Feb 1967' => build_test('bg-clr--blue-light circle', 'Zodiac for 20 Feb 1967: Pisces'),
+    'StarSign 1st Mar' => build_test('bg-clr--blue-light circle', 'Zodiac for 01 Mar 2015: Pisces'),
 
-    '20 Mar star sign'     => test_zci(
-	'Zodiac for 20 Mar 2015: Pisces',
-    structured_answer => {
-        id => "zodiac",
-            name => "Answer",
-            data => '-ANY-',
-            templates => {
-                group => 'icon',
-                elClass => {
-                    iconImage => 'bg-clr--blue-light circle'
-                },
-                variants => {
-                     iconImage => 'large'
-                }
-            }
-        }
-     ),
+    '20 Mar star sign' => build_test('bg-clr--blue-light circle', 'Zodiac for 20 Mar 2015: Pisces'),
 
     #Test Invalid Inputs
     '31st April 1876 zodiac' => undef,

--- a/t/Zodiac.t
+++ b/t/Zodiac.t
@@ -31,101 +31,77 @@ set_fixed_time("2015-12-30T00:00:00");
 zci answer_type => 'zodiac';
 ddg_goodie_test([ qw( DDG::Goodie::Zodiac ) ],
 
-    #Test Aries
+    # Aries
     'Zodiac 21st March 1967' => build_test('bg-clr--red circle', 'Zodiac for 21 Mar 1967: Aries'),
+    'StarSign 30 Mar'        => build_test('bg-clr--red circle', 'Zodiac for 30 Mar 2015: Aries'),
+    '20 April star sign'     => build_test('bg-clr--red circle', 'Zodiac for 20 Apr 2015: Aries'),
 
-    'StarSign 30 Mar' => build_test('bg-clr--red circle', 'Zodiac for 30 Mar 2015: Aries'),
-
-    '20 April star sign' => build_test('bg-clr--red circle', 'Zodiac for 20 Apr 2015: Aries'),
-
-    #Test Taurus
+    # Taurus
     'Zodiac 21st April 2014' => build_test('bg-clr--green circle', 'Zodiac for 21 Apr 2014: Taurus'),
-    'StarSign 27 Apr' => build_test('bg-clr--green circle', 'Zodiac for 27 Apr 2015: Taurus'),
+    'StarSign 27 Apr'        => build_test('bg-clr--green circle', 'Zodiac for 27 Apr 2015: Taurus'),
 
-    #Test Gemini
-    '21 May star sign' => build_test('bg-clr--grey circle', 'Zodiac for 21 May 2015: Gemini'),
-
+    # Gemini
+    '21 May star sign'     => build_test('bg-clr--grey circle', 'Zodiac for 21 May 2015: Gemini'),
     'Zodiac 22nd May 1500' => build_test('bg-clr--grey circle', 'Zodiac for 22 May 1500: Gemini'),
+    'Zodiac 21.05.1965'    => build_test('bg-clr--grey circle', 'Zodiac for 21 May 1965: Gemini'),
+    'StarSign 31 May'      => build_test('bg-clr--grey circle', 'Zodiac for 31 May 2015: Gemini'),
+    '21 jun star sign'     => build_test('bg-clr--grey circle', 'Zodiac for 21 Jun 2015: Gemini'),
 
-    'Zodiac 21.05.1965' => build_test('bg-clr--grey circle', 'Zodiac for 21 May 1965: Gemini'),
-
-    'StarSign 31 May' => build_test('bg-clr--grey circle', 'Zodiac for 31 May 2015: Gemini'),
-
-    '21 jun star sign' => build_test('bg-clr--grey circle', 'Zodiac for 21 Jun 2015: Gemini'),
-
-    #Test Cancer
+    # Cancer
     'Zodiac 22nd June 1889' => build_test('bg-clr--blue-light circle', 'Zodiac for 22 Jun 1889: Cancer'),
-
     'StarSign 30 June 2017' => build_test('bg-clr--blue-light circle', 'Zodiac for 30 Jun 2017: Cancer'),
+    '22nd july star sign'   => build_test('bg-clr--blue-light circle', 'Zodiac for 22 Jul 2015: Cancer'),
 
-    '22nd july star sign' => build_test('bg-clr--blue-light circle', 'Zodiac for 22 Jul 2015: Cancer'),
-
-    #Test Leo
-    'Zodiac 23 July 1654' => build_test('bg-clr--red circle', 'Zodiac for 23 Jul 1654: Leo'),
-
-    'StarSign 24th July' => build_test('bg-clr--red circle', 'Zodiac for 24 Jul 2015: Leo'),
-
-    '22 aug star sign' => build_test('bg-clr--red circle', 'Zodiac for 22 Aug 2015: Leo'),
-
+    # Leo
+    'Zodiac 23 July 1654'  => build_test('bg-clr--red circle', 'Zodiac for 23 Jul 1654: Leo'),
+    'StarSign 24th July'   => build_test('bg-clr--red circle', 'Zodiac for 24 Jul 2015: Leo'),
+    '22 aug star sign'     => build_test('bg-clr--red circle', 'Zodiac for 22 Aug 2015: Leo'),
     'Zodiac 23rd Aug 1700' => build_test('bg-clr--red circle', 'Zodiac for 23 Aug 1700: Leo'),
 
-    #Test Virgo
+    # Virgo
     'StarSign 1 Sep' => build_test('bg-clr--green circle', 'Zodiac for 01 Sep 2015: Virgo'),
 
-    #Test Libra
-    '23rd Sep star sign' => build_test('bg-clr--grey circle', 'Zodiac for 23 Sep 2015: Libra'),
-
+    # Libra
+    '23rd Sep star sign'       => build_test('bg-clr--grey circle', 'Zodiac for 23 Sep 2015: Libra'),
     'Zodiac 24 September 2001' => build_test('bg-clr--grey circle', 'Zodiac for 24 Sep 2001: Libra'),
+    'StarSign 7th October'     => build_test('bg-clr--grey circle', 'Zodiac for 07 Oct 2015: Libra'),
 
-    'StarSign 7th October' => build_test('bg-clr--grey circle', 'Zodiac for 07 Oct 2015: Libra'),
-
-    #Test Scorpius
-    '23 oct star sign' => build_test('bg-clr--blue-light circle', 'Zodiac for 23 Oct 2015: Scorpius'),
-
+    # Scorpius
+    '23 oct star sign'       => build_test('bg-clr--blue-light circle', 'Zodiac for 23 Oct 2015: Scorpius'),
     'Zodiac 24 October 1213' => build_test('bg-clr--blue-light circle', 'Zodiac for 24 Oct 1213: Scorpius'),
+    'StarSign 9th November'  => build_test('bg-clr--blue-light circle', 'Zodiac for 09 Nov 2015: Scorpius'),
 
-    'StarSign 9th November' => build_test('bg-clr--blue-light circle', 'Zodiac for 09 Nov 2015: Scorpius'),
-
-    #Test Sagittarius
-    '22 nov star sign' => build_test('bg-clr--red circle', 'Zodiac for 22 Nov 2015: Sagittarius'),
-
+    # Sagittarius
+    '22 nov star sign'   => build_test('bg-clr--red circle', 'Zodiac for 22 Nov 2015: Sagittarius'),
     'Zodiac 23 Nov 1857' => build_test('bg-clr--red circle', 'Zodiac for 23 Nov 1857: Sagittarius'),
+    'StarSign 6 Dec'     => build_test('bg-clr--red circle', 'Zodiac for 06 Dec 2015: Sagittarius'),
+    '21 Dec star sign'   => build_test('bg-clr--red circle', 'Zodiac for 21 Dec 2015: Sagittarius'),
 
-    'StarSign 6 Dec' => build_test('bg-clr--red circle', 'Zodiac for 06 Dec 2015: Sagittarius'),
-
-    '21 Dec star sign' => build_test('bg-clr--red circle', 'Zodiac for 21 Dec 2015: Sagittarius'),
-
-    #Test Capricornus
+    # Capricornus
     'Zodiac 22nd December' => build_test('bg-clr--green circle', 'Zodiac for 22 Dec 2015: Capricornus'),
-
     'StarSign 23 Dec 1378' => build_test('bg-clr--green circle', 'Zodiac for 23 Dec 1378: Capricornus'),
-
     'starsign 31 Dec 2009' => build_test('bg-clr--green circle', 'Zodiac for 31 Dec 2009: Capricornus'),
+    '31.12.2100 zodiac'    => build_test('bg-clr--green circle', 'Zodiac for 31 Dec 2100: Capricornus'),
+    '1 Jan zodiac'         => build_test('bg-clr--green circle', 'Zodiac for 01 Jan 2015: Capricornus'),
 
-    '31.12.2100 zodiac' => build_test('bg-clr--green circle', 'Zodiac for 31 Dec 2100: Capricornus'),
-
-    '1 Jan zodiac' => build_test('bg-clr--green circle', 'Zodiac for 01 Jan 2015: Capricornus'),
-
-    #Test Aquarius
+    # Aquarius
     '20 Jan star sign' => build_test('bg-clr--grey circle', 'Zodiac for 20 Jan 2015: Aquarius'),
-
-    'Zodiac 21st Jan' => build_test('bg-clr--grey circle', 'Zodiac for 21 Jan 2015: Aquarius'),
-
+    'Zodiac 21st Jan'  => build_test('bg-clr--grey circle', 'Zodiac for 21 Jan 2015: Aquarius'),
     'StarSign 1st Feb' => build_test('bg-clr--grey circle', 'Zodiac for 01 Feb 2015: Aquarius'),
 
-    #Test Pisces
-    '19 Feb star sign' => build_test('bg-clr--blue-light circle', 'Zodiac for 19 Feb 2015: Pisces'),
-
+    # Pisces
+    '19 Feb star sign'     => build_test('bg-clr--blue-light circle', 'Zodiac for 19 Feb 2015: Pisces'),
     'Zodiac 20th Feb 1967' => build_test('bg-clr--blue-light circle', 'Zodiac for 20 Feb 1967: Pisces'),
-    'StarSign 1st Mar' => build_test('bg-clr--blue-light circle', 'Zodiac for 01 Mar 2015: Pisces'),
+    'StarSign 1st Mar'     => build_test('bg-clr--blue-light circle', 'Zodiac for 01 Mar 2015: Pisces'),
+    '20 Mar star sign'     => build_test('bg-clr--blue-light circle', 'Zodiac for 20 Mar 2015: Pisces'),
 
-    '20 Mar star sign' => build_test('bg-clr--blue-light circle', 'Zodiac for 20 Mar 2015: Pisces'),
-
-    #Test Invalid Inputs
+    # Invalid Inputs
     '31st April 1876 zodiac' => undef,
     'Zodiac 31Feb'           => undef,
     'Zodiac 5thMay1200'      => undef,
 
 );
+
 restore_time();
+
 done_testing;

--- a/t/Zodiac.t
+++ b/t/Zodiac.t
@@ -7,14 +7,18 @@ use DDG::Test::Goodie;
 use Test::MockTime qw( :all );
 
 sub build_structured_answer {
-    my ($image, $formatted) = @_;
-    return $formatted,
+    my ($result, $image, $formatted) = @_;
+    return $result,
         structured_answer => {
-            id => "zodiac",
+            id   => "zodiac",
             name => "Answer",
-            data => '-ANY-',
+            data => {
+                image    => "/share/goodie/zodiac/". lc($result) . ".png",
+                title    => $result,
+                subtitle => $formatted,
+            },
             templates => {
-                group => 'icon',
+                group   => 'icon',
                 elClass => {
                     iconImage => $image,
                 },
@@ -32,68 +36,68 @@ zci answer_type => 'zodiac';
 ddg_goodie_test([ qw( DDG::Goodie::Zodiac ) ],
 
     # Aries
-    'Zodiac 21st March 1967' => build_test('bg-clr--red circle', 'Zodiac for 21 Mar 1967: Aries'),
-    'StarSign 30 Mar'        => build_test('bg-clr--red circle', 'Zodiac for 30 Mar 2015: Aries'),
-    '20 April star sign'     => build_test('bg-clr--red circle', 'Zodiac for 20 Apr 2015: Aries'),
+    'Zodiac 21st March 1967' => build_test('Aries', 'bg-clr--red circle', 'Zodiac for 21 Mar 1967'),
+    'StarSign 30 Mar'        => build_test('Aries', 'bg-clr--red circle', 'Zodiac for 30 Mar 2015'),
+    '20 April star sign'     => build_test('Aries', 'bg-clr--red circle', 'Zodiac for 20 Apr 2015'),
 
     # Taurus
-    'Zodiac 21st April 2014' => build_test('bg-clr--green circle', 'Zodiac for 21 Apr 2014: Taurus'),
-    'StarSign 27 Apr'        => build_test('bg-clr--green circle', 'Zodiac for 27 Apr 2015: Taurus'),
+    'Zodiac 21st April 2014' => build_test('Taurus', 'bg-clr--green circle', 'Zodiac for 21 Apr 2014'),
+    'StarSign 27 Apr'        => build_test('Taurus', 'bg-clr--green circle', 'Zodiac for 27 Apr 2015'),
 
     # Gemini
-    '21 May star sign'     => build_test('bg-clr--grey circle', 'Zodiac for 21 May 2015: Gemini'),
-    'Zodiac 22nd May 1500' => build_test('bg-clr--grey circle', 'Zodiac for 22 May 1500: Gemini'),
-    'Zodiac 21.05.1965'    => build_test('bg-clr--grey circle', 'Zodiac for 21 May 1965: Gemini'),
-    'StarSign 31 May'      => build_test('bg-clr--grey circle', 'Zodiac for 31 May 2015: Gemini'),
-    '21 jun star sign'     => build_test('bg-clr--grey circle', 'Zodiac for 21 Jun 2015: Gemini'),
+    '21 May star sign'     => build_test('Gemini', 'bg-clr--grey circle', 'Zodiac for 21 May 2015'),
+    'Zodiac 22nd May 1500' => build_test('Gemini', 'bg-clr--grey circle', 'Zodiac for 22 May 1500'),
+    'Zodiac 21.05.1965'    => build_test('Gemini', 'bg-clr--grey circle', 'Zodiac for 21 May 1965'),
+    'StarSign 31 May'      => build_test('Gemini', 'bg-clr--grey circle', 'Zodiac for 31 May 2015'),
+    '21 jun star sign'     => build_test('Gemini', 'bg-clr--grey circle', 'Zodiac for 21 Jun 2015'),
 
     # Cancer
-    'Zodiac 22nd June 1889' => build_test('bg-clr--blue-light circle', 'Zodiac for 22 Jun 1889: Cancer'),
-    'StarSign 30 June 2017' => build_test('bg-clr--blue-light circle', 'Zodiac for 30 Jun 2017: Cancer'),
-    '22nd july star sign'   => build_test('bg-clr--blue-light circle', 'Zodiac for 22 Jul 2015: Cancer'),
+    'Zodiac 22nd June 1889' => build_test('Cancer', 'bg-clr--blue-light circle', 'Zodiac for 22 Jun 1889'),
+    'StarSign 30 June 2017' => build_test('Cancer', 'bg-clr--blue-light circle', 'Zodiac for 30 Jun 2017'),
+    '22nd july star sign'   => build_test('Cancer', 'bg-clr--blue-light circle', 'Zodiac for 22 Jul 2015'),
 
     # Leo
-    'Zodiac 23 July 1654'  => build_test('bg-clr--red circle', 'Zodiac for 23 Jul 1654: Leo'),
-    'StarSign 24th July'   => build_test('bg-clr--red circle', 'Zodiac for 24 Jul 2015: Leo'),
-    '22 aug star sign'     => build_test('bg-clr--red circle', 'Zodiac for 22 Aug 2015: Leo'),
-    'Zodiac 23rd Aug 1700' => build_test('bg-clr--red circle', 'Zodiac for 23 Aug 1700: Leo'),
+    'Zodiac 23 July 1654'  => build_test('Leo', 'bg-clr--red circle', 'Zodiac for 23 Jul 1654'),
+    'StarSign 24th July'   => build_test('Leo', 'bg-clr--red circle', 'Zodiac for 24 Jul 2015'),
+    '22 aug star sign'     => build_test('Leo', 'bg-clr--red circle', 'Zodiac for 22 Aug 2015'),
+    'Zodiac 23rd Aug 1700' => build_test('Leo', 'bg-clr--red circle', 'Zodiac for 23 Aug 1700'),
 
     # Virgo
-    'StarSign 1 Sep' => build_test('bg-clr--green circle', 'Zodiac for 01 Sep 2015: Virgo'),
+    'StarSign 1 Sep' => build_test('Virgo', 'bg-clr--green circle', 'Zodiac for 01 Sep 2015'),
 
     # Libra
-    '23rd Sep star sign'       => build_test('bg-clr--grey circle', 'Zodiac for 23 Sep 2015: Libra'),
-    'Zodiac 24 September 2001' => build_test('bg-clr--grey circle', 'Zodiac for 24 Sep 2001: Libra'),
-    'StarSign 7th October'     => build_test('bg-clr--grey circle', 'Zodiac for 07 Oct 2015: Libra'),
+    '23rd Sep star sign'       => build_test('Libra', 'bg-clr--grey circle', 'Zodiac for 23 Sep 2015'),
+    'Zodiac 24 September 2001' => build_test('Libra', 'bg-clr--grey circle', 'Zodiac for 24 Sep 2001'),
+    'StarSign 7th October'     => build_test('Libra', 'bg-clr--grey circle', 'Zodiac for 07 Oct 2015'),
 
     # Scorpius
-    '23 oct star sign'       => build_test('bg-clr--blue-light circle', 'Zodiac for 23 Oct 2015: Scorpius'),
-    'Zodiac 24 October 1213' => build_test('bg-clr--blue-light circle', 'Zodiac for 24 Oct 1213: Scorpius'),
-    'StarSign 9th November'  => build_test('bg-clr--blue-light circle', 'Zodiac for 09 Nov 2015: Scorpius'),
+    '23 oct star sign'       => build_test('Scorpius', 'bg-clr--blue-light circle', 'Zodiac for 23 Oct 2015'),
+    'Zodiac 24 October 1213' => build_test('Scorpius', 'bg-clr--blue-light circle', 'Zodiac for 24 Oct 1213'),
+    'StarSign 9th November'  => build_test('Scorpius', 'bg-clr--blue-light circle', 'Zodiac for 09 Nov 2015'),
 
     # Sagittarius
-    '22 nov star sign'   => build_test('bg-clr--red circle', 'Zodiac for 22 Nov 2015: Sagittarius'),
-    'Zodiac 23 Nov 1857' => build_test('bg-clr--red circle', 'Zodiac for 23 Nov 1857: Sagittarius'),
-    'StarSign 6 Dec'     => build_test('bg-clr--red circle', 'Zodiac for 06 Dec 2015: Sagittarius'),
-    '21 Dec star sign'   => build_test('bg-clr--red circle', 'Zodiac for 21 Dec 2015: Sagittarius'),
+    '22 nov star sign'   => build_test('Sagittarius', 'bg-clr--red circle', 'Zodiac for 22 Nov 2015'),
+    'Zodiac 23 Nov 1857' => build_test('Sagittarius', 'bg-clr--red circle', 'Zodiac for 23 Nov 1857'),
+    'StarSign 6 Dec'     => build_test('Sagittarius', 'bg-clr--red circle', 'Zodiac for 06 Dec 2015'),
+    '21 Dec star sign'   => build_test('Sagittarius', 'bg-clr--red circle', 'Zodiac for 21 Dec 2015'),
 
     # Capricornus
-    'Zodiac 22nd December' => build_test('bg-clr--green circle', 'Zodiac for 22 Dec 2015: Capricornus'),
-    'StarSign 23 Dec 1378' => build_test('bg-clr--green circle', 'Zodiac for 23 Dec 1378: Capricornus'),
-    'starsign 31 Dec 2009' => build_test('bg-clr--green circle', 'Zodiac for 31 Dec 2009: Capricornus'),
-    '31.12.2100 zodiac'    => build_test('bg-clr--green circle', 'Zodiac for 31 Dec 2100: Capricornus'),
-    '1 Jan zodiac'         => build_test('bg-clr--green circle', 'Zodiac for 01 Jan 2015: Capricornus'),
+    'Zodiac 22nd December' => build_test('Capricornus', 'bg-clr--green circle', 'Zodiac for 22 Dec 2015'),
+    'StarSign 23 Dec 1378' => build_test('Capricornus', 'bg-clr--green circle', 'Zodiac for 23 Dec 1378'),
+    'starsign 31 Dec 2009' => build_test('Capricornus', 'bg-clr--green circle', 'Zodiac for 31 Dec 2009'),
+    '31.12.2100 zodiac'    => build_test('Capricornus', 'bg-clr--green circle', 'Zodiac for 31 Dec 2100'),
+    '1 Jan zodiac'         => build_test('Capricornus', 'bg-clr--green circle', 'Zodiac for 01 Jan 2015'),
 
     # Aquarius
-    '20 Jan star sign' => build_test('bg-clr--grey circle', 'Zodiac for 20 Jan 2015: Aquarius'),
-    'Zodiac 21st Jan'  => build_test('bg-clr--grey circle', 'Zodiac for 21 Jan 2015: Aquarius'),
-    'StarSign 1st Feb' => build_test('bg-clr--grey circle', 'Zodiac for 01 Feb 2015: Aquarius'),
+    '20 Jan star sign' => build_test('Aquarius', 'bg-clr--grey circle', 'Zodiac for 20 Jan 2015'),
+    'Zodiac 21st Jan'  => build_test('Aquarius', 'bg-clr--grey circle', 'Zodiac for 21 Jan 2015'),
+    'StarSign 1st Feb' => build_test('Aquarius', 'bg-clr--grey circle', 'Zodiac for 01 Feb 2015'),
 
     # Pisces
-    '19 Feb star sign'     => build_test('bg-clr--blue-light circle', 'Zodiac for 19 Feb 2015: Pisces'),
-    'Zodiac 20th Feb 1967' => build_test('bg-clr--blue-light circle', 'Zodiac for 20 Feb 1967: Pisces'),
-    'StarSign 1st Mar'     => build_test('bg-clr--blue-light circle', 'Zodiac for 01 Mar 2015: Pisces'),
-    '20 Mar star sign'     => build_test('bg-clr--blue-light circle', 'Zodiac for 20 Mar 2015: Pisces'),
+    '19 Feb star sign'     => build_test('Pisces', 'bg-clr--blue-light circle', 'Zodiac for 19 Feb 2015'),
+    'Zodiac 20th Feb 1967' => build_test('Pisces', 'bg-clr--blue-light circle', 'Zodiac for 20 Feb 1967'),
+    'StarSign 1st Mar'     => build_test('Pisces', 'bg-clr--blue-light circle', 'Zodiac for 01 Mar 2015'),
+    '20 Mar star sign'     => build_test('Pisces', 'bg-clr--blue-light circle', 'Zodiac for 20 Mar 2015'),
 
     # Invalid Inputs
     '31st April 1876 zodiac' => undef,

--- a/t/Zodiac.t
+++ b/t/Zodiac.t
@@ -6,16 +6,9 @@ use Test::More;
 use DDG::Test::Goodie;
 use Test::MockTime qw( :all );
 
-zci answer_type => 'zodiac';
-set_fixed_time("2015-12-30T00:00:00");
-ddg_goodie_test([qw(
-          DDG::Goodie::Zodiac
-          )
-    ],
-
-    #Test Aries
-    'Zodiac 21st March 1967' => test_zci(
-        'Zodiac for 21 Mar 1967: Aries',
+sub build_structured_answer {
+    my ($image, $formatted) = @_;
+    return $formatted,
         structured_answer => {
             id => "zodiac",
             name => "Answer",
@@ -23,14 +16,14 @@ ddg_goodie_test([qw(
             templates => {
                 group => 'icon',
                 elClass => {
-                    iconImage => 'bg-clr--red circle'
+                    iconImage => $image,
                 },
                 variants => {
                      iconImage => 'large'
                 }
             }
-        }    
-    ),
+        };
+}
 
     'StarSign 30 Mar'        => test_zci(
 	'Zodiac for 30 Mar 2015: Aries',
@@ -49,6 +42,7 @@ ddg_goodie_test([qw(
             }
         }
     ),
+sub build_test { test_zci(build_structured_answer(@_)) }
 
     '20 April star sign'     => test_zci(
 	'Zodiac for 20 Apr 2015: Aries',


### PR DESCRIPTION
Removes the `DateTime::Event::Zodiac` dependency.

See discussion on #2009 (although fixing this in a future PR may be wise).

---

[IA Page](https://duck.co/ia/view/zodiac)