### PR TITLE
CONTRIBUTING.md must contain pull request naming conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,22 @@
 # Contributing an Instant Answer
 
 An overview of how to submit an Instant Answer can [be found over in our docs](http://docs.duckduckhack.com/submitting/submitting-overview.html).
+
+#### Chosing a title for your pull request: 
+
+If your IA is new, use the format: `"New {IA TOPIC} {IA TYPE}"`. For example:
+
+	- "New Instagram Spice"
+	- "New Firefox Cheat Sheet"
+	- "New Color Hex Goodie"
+	
+If you're submitting a fix, use the format: `"{IA NAME}: Fixes #ISSUE"` as the title and description (Conveniently, this syntax will auto-close the Github issue when your pull request is merged.). For example:
+	
+	- "Forecast: Fixes #3434"
+	- "Cheat Sheet: Fixes #4102"
+	
+
+
+
+Dont forget to paste your **[Instant Answer Page URL](https://duck.co/ia/new_ia)** in the description field, while creating new pull requests.
+	


### PR DESCRIPTION
I think CONTRIBUTING.md must contain pull request naming conventions.It will help new contributors to chose the correct title for their PR. as you can see in the screenshot below, the link to readme.md is displayed on GitHub while opening a new PR. 
![screenshot 143](https://cloud.githubusercontent.com/assets/8397274/12215227/c8182ece-b6d9-11e5-8d82-153a65b89e02.png)
