### PR TITLE
Apt-get: Add aliases

### DIFF
--- a/share/goodie/cheat_sheets/json/apt-get.json
+++ b/share/goodie/cheat_sheets/json/apt-get.json
@@ -6,6 +6,9 @@
         "sourceName": "Ubuntu Wiki",
         "sourceUrl": "https://help.ubuntu.com/community/AptGet/Howto"
     },
+    "aliases": [
+        "aptget", "apt-get"
+    ],
     "template_type": "terminal",
     "section_order": [
         "Installation commands",


### PR DESCRIPTION
Add `apt-get` and `aptget` to aliases for the apt-get cheatsheet.

-----
IA Page: https://duck.co/ia/view/apt_get_cheat_sheet