### PR TITLE
8086/8085 Cheat Sheet: Append 'intel' to 8085, 8086.json, update accordingly

### DIFF
--- a/share/goodie/cheat_sheets/json/intel-8085.json
+++ b/share/goodie/cheat_sheets/json/intel-8085.json
@@ -1,6 +1,6 @@
 {
-    "id": "8085_cheat_sheet",
-    "name": "8085 Instruction Set",
+    "id": "intel_8085_cheat_sheet",
+    "name": "Intel 8085 Instruction Set",
     "description": "8085 instructions and their explanations",
     "metadata": {
         "sourceName": "IITK",
@@ -16,6 +16,7 @@
         "Control Instructions"
     ],
     "aliases": [
+        "8085",
         "8085 instructionset",
         "8085 instruction set",
         "8085 programming",

--- a/share/goodie/cheat_sheets/json/intel-8086.json
+++ b/share/goodie/cheat_sheets/json/intel-8086.json
@@ -1,6 +1,6 @@
 {
-    "id": "8086_cheat_sheet",
-    "name": "8086 Instruction Set",
+    "id": "intel_8086_cheat_sheet",
+    "name": "Intel 8086 Instruction Set",
     "description": "8086 instructions and their explanations",
     "metadata": {
         "sourceName": "utcluj",
@@ -16,6 +16,7 @@
         "Flag Manipulation Instructions"
     ],
     "aliases": [
+        "8086",
         "8086 instructionset",
         "8086 instruction set",
         "8086 programming",


### PR DESCRIPTION
Instant Answer ID's cannot start with numbers as it causes problems.

These are the only two IAs with ID's that start with numbers, so I've opted to change their id's, and add in aliases to ensure they still trigger as before.

/cc @jagtalon 

-----
IA Page: https://duck.co/ia/view/intel_8085_cheat_sheet
IA Page: https://duck.co/ia/view/intel_8086_cheat_sheet