### PR TITLE
A javascript-focused template group

### DIFF
--- a/template/lib/DDG/Goodie/Example.pm
+++ b/template/lib/DDG/Goodie/Example.pm
@@ -10,10 +10,10 @@ use strict;
 zci answer_type => '<: $ia_id :>';
 
 # Caching - https://duck.co/duckduckhack/spice_advanced_backend#caching-api-responses
-zci is_cached   => 1;
+zci is_cached => 1;
 
 # Triggers - https://duck.co/duckduckhack/goodie_triggers
-triggers any => 'triggerWord', 'trigger phrase';
+triggers any => 'triggerword', 'trigger phrase';
 
 # Handle statement
 handle remainder => sub {

--- a/template/lib/DDG/Goodie/Minimal.pm
+++ b/template/lib/DDG/Goodie/Minimal.pm
@@ -10,10 +10,10 @@ use strict;
 zci answer_type => '<: $ia_id :>';
 
 # Caching - https://duck.co/duckduckhack/spice_advanced_backend#caching-api-responses
-zci is_cached   => 1;
+zci is_cached => 1;
 
 # Triggers - https://duck.co/duckduckhack/goodie_triggers
-triggers any => 'triggerWord', 'trigger phrase';
+triggers any => 'triggerword', 'trigger phrase';
 
 # Handle statement
 handle remainder => sub {

--- a/template/lib/DDG/Goodie/Minimal.pm
+++ b/template/lib/DDG/Goodie/Minimal.pm
@@ -1,0 +1,46 @@
+package DDG::Goodie::<: $ia_package_name :>;
+
+# ABSTRACT: Write an abstract here
+# Start at https://duck.co/duckduckhack/goodie_overview if you are new
+# to instant answer development
+
+use DDG::Goodie;
+use strict;
+
+zci answer_type => '<: $ia_id :>';
+
+# Caching - https://duck.co/duckduckhack/spice_advanced_backend#caching-api-responses
+zci is_cached   => 1;
+
+# Triggers - https://duck.co/duckduckhack/goodie_triggers
+triggers any => 'triggerWord', 'trigger phrase';
+
+# Handle statement
+handle remainder => sub {
+
+    return "plain text response",
+        structured_answer => {
+
+            # ID - Must be unique and match Instant Answer page
+            # E.g. https://duck.co/ia/view/calculator has `id => 'calculator'``
+            id => '<: $ia_id :>',
+
+            # Name - Used for Answer Bar Tab
+            # Value should be chosen from existing Instant Answer topics
+            # see https://duck.co/duckduckhack/display_reference#codenamecode-emstringem-required
+            name => 'Answer',
+
+            data => {
+                remainder => $_
+            },
+
+            templates => {
+                group => "text",
+                # options => {
+                #
+                # }
+            }
+        };
+};
+
+1;

--- a/template/templates.yml
+++ b/template/templates.yml
@@ -8,6 +8,11 @@ templates:
         input:  lib/DDG/Goodie/Example.pm
         output: lib/DDG/Goodie/<:$ia_path:>.pm
 
+    min-pm:
+        label:  Minimal Perl Module
+        input:  lib/DDG/Goodie/Minimal.pm
+        output: lib/DDG/Goodie/<:$ia_path:>.pm
+
     test:
         label:  Perl Module Test
         input:  t/Example.t
@@ -49,6 +54,11 @@ template_sets:
         description: Cheat Sheet Instant Answer
         required: [ cheatsheet_json ]
         subdir_support: false
+
+    javascript:
+        description: Javascript-focused instant answer
+        required: [ min-pm, js, test ]
+        optional: [ css, handlebars  ]
 
     all:
         description: Goodie with all backend and frontend files


### PR DESCRIPTION
Add a new template group with a javascript file in the configuration.  Also added a semi-modified Perl module template that puts the query remainder directly in the data, i.e. the processing will be done in the js.

See if this makes sense or if we just want to have people roll through the optional templates and select js to do the same thing.