### PR TITLE
Markdown cheat sheet: Removed spaces from Emphasis section

### DIFF
--- a/share/goodie/cheat_sheets/json/markdown.json
+++ b/share/goodie/cheat_sheets/json/markdown.json
@@ -47,19 +47,19 @@
     ],
     "Emphasis": [
       {
-        "key": "* Text *",
+        "key": "*Text*",
         "val": "Displays text in italics"
       },
       {
-        "key": "** Text **",
+        "key": "**Text**",
         "val": "Displays the text in bold"
       },
       {
-        "key": "** _Text_ ** ",
+        "key": "**_Text_** ",
         "val": "Displays the text in bold and italics"
       },
       {
-        "key": "~~ Text ~~",
+        "key": "~~Text~~",
         "val": "Adds strikethrough effect to the text"
       }
     ],

--- a/share/goodie/cheat_sheets/json/markdown.json
+++ b/share/goodie/cheat_sheets/json/markdown.json
@@ -47,7 +47,7 @@
     ],
     "Emphasis": [
       {
-        "key": "*Text*",
+        "key": "_Text_",
         "val": "Displays text in italics"
       },
       {


### PR DESCRIPTION
The spaces change the behaviour, e.g. formatting as a list item instead of emphasis.

---
https://duck.co/ia/view/markdown_cheat_sheet