### PR TITLE
Corrected mistakes in 8085 cheat sheets like spaces problem

### DIFF
--- a/share/goodie/cheat_sheets/json/8085.json
+++ b/share/goodie/cheat_sheets/json/8085.json
@@ -9,10 +9,10 @@
     "template_type": "reference",
     "section_order": [
         "Data Transfer Instructions",
-        "Arithmetic Instructions",
-        "Logical Instructions",
-        "Rotate Instructions",
         "Control Transfer Instructions",
+        "Logical Instructions",
+        "Rotate Instructions", 
+        "Arithmetic Instructions",
         "Control Instructions"
     ],
     "aliases": [
@@ -37,15 +37,15 @@
             },
             {
                 "key": "LXI Reg.Pair, 16-bit data",
-                "val": "Loads 16-bit data in the register pair "
+                "val": "Loads 16-bit data in the register pair"
             },
             {
                 "key": "STA 16-bit address",
-                "val": "Stores the content of Accumulator in memory location specified by the 16-bit address "
+                "val": "Stores the content of Accumulator in memory location specified by the 16-bit address"
             },
             {
                 "key": "XCHG",
-                "val": "Contents of register H are exchanged with the contents of register D, and the contents of register L are exchanged with the contents of register E "
+                "val": "Contents of register H are exchanged with the contents of register D, and the contents of register L are exchanged with the contents of register E"
             },
             {
                 "key": "LHLD 16-bit address",
@@ -61,7 +61,7 @@
             },
             {
                 "key": "IN 8-bit port address",
-                "val": "Contents of the input port designated in the operand are read and loaded into the accumulator."
+                "val": "Contents of the input port designated in the operand are read and loaded into the accumulator"
             }
         ],
         "Arithmetic Instructions": [
@@ -75,11 +75,11 @@
             },
             {
                 "key": "INX Reg.pair",
-                "val": "Contents of the designated register pair are incremented by 1 "
+                "val": "Contents of the designated register pair are incremented by 1"
             },
             {
                 "key": "DCX Reg.pair",
-                "val": "Contents of the designated register pair are decremented by 1 "
+                "val": "Contents of the designated register pair are decremented by 1"
             },
             {
                 "key": "INR R/M",


### PR DESCRIPTION
Corrected mistakes in 8085 cheat sheets like spaces problem and sections order
before -
![8085 o](https://cloud.githubusercontent.com/assets/11630812/12419775/29e0860e-bede-11e5-8b13-f18c0873e590.png)
![8085 o2](https://cloud.githubusercontent.com/assets/11630812/12419782/2f9579e2-bede-11e5-8ab4-0ffa416bd592.png)

after - 
![8085 1](https://cloud.githubusercontent.com/assets/11630812/12419792/3c61c6c6-bede-11e5-918c-ecd97dd119e8.png)

