### PR TITLE
corrected intel-8085 cheat sheet

### DIFF
--- a/share/goodie/cheat_sheets/json/intel-8085.json
+++ b/share/goodie/cheat_sheets/json/intel-8085.json
@@ -9,14 +9,13 @@
     "template_type": "reference",
     "section_order": [
         "Data Transfer Instructions",
-        "Arithmetic Instructions",
-        "Logical Instructions",
-        "Rotate Instructions",
         "Control Transfer Instructions",
+        "Logical Instructions",
+        "Rotate Instructions", 
+        "Arithmetic Instructions",
         "Control Instructions"
     ],
     "aliases": [
-        "8085",
         "8085 instructionset",
         "8085 instruction set",
         "8085 programming",
@@ -38,15 +37,15 @@
             },
             {
                 "key": "LXI Reg.Pair, 16-bit data",
-                "val": "Loads 16-bit data in the register pair "
+                "val": "Loads 16-bit data in the register pair"
             },
             {
                 "key": "STA 16-bit address",
-                "val": "Stores the content of Accumulator in memory location specified by the 16-bit address "
+                "val": "Stores the content of Accumulator in memory location specified by the 16-bit address"
             },
             {
                 "key": "XCHG",
-                "val": "Contents of register H are exchanged with the contents of register D, and the contents of register L are exchanged with the contents of register E "
+                "val": "Contents of register H are exchanged with the contents of register D, and the contents of register L are exchanged with the contents of register E"
             },
             {
                 "key": "LHLD 16-bit address",
@@ -62,7 +61,7 @@
             },
             {
                 "key": "IN 8-bit port address",
-                "val": "Contents of the input port designated in the operand are read and loaded into the accumulator."
+                "val": "Contents of the input port designated in the operand are read and loaded into the accumulator"
             }
         ],
         "Arithmetic Instructions": [
@@ -76,11 +75,11 @@
             },
             {
                 "key": "INX Reg.pair",
-                "val": "Contents of the designated register pair are incremented by 1 "
+                "val": "Contents of the designated register pair are incremented by 1"
             },
             {
                 "key": "DCX Reg.pair",
-                "val": "Contents of the designated register pair are decremented by 1 "
+                "val": "Contents of the designated register pair are decremented by 1"
             },
             {
                 "key": "INR R/M",

--- a/share/goodie/cheat_sheets/json/intel-8085.json
+++ b/share/goodie/cheat_sheets/json/intel-8085.json
@@ -16,6 +16,7 @@
         "Control Instructions"
     ],
     "aliases": [
+        "8085",
         "8085 instructionset",
         "8085 instruction set",
         "8085 programming",


### PR DESCRIPTION
Corrected mistakes in 8085 cheat sheets like spaces problem and sections order
before -
![8085 o](https://cloud.githubusercontent.com/assets/11630812/12423789/41d20c46-bef3-11e5-938b-a4170dcf72af.png)
![8085 o2](https://cloud.githubusercontent.com/assets/11630812/12423794/488cbefa-bef3-11e5-9f20-88d38f2c7fb5.png)


after - 
![8085 1](https://cloud.githubusercontent.com/assets/11630812/12423812/557b2e1c-bef3-11e5-884d-157eb7b1408d.png)

https://duck.co/ia/view/intel_8085_cheat_sheet