### PR TITLE
Modified adobe-brackets cheat sheet

### DIFF
--- a/share/goodie/cheat_sheets/json/adobe-brackets.json
+++ b/share/goodie/cheat_sheets/json/adobe-brackets.json
@@ -1,7 +1,7 @@
 {
     "id": "adobe_brackets_cheat_sheet",
     "name": "Adobe Brackets",
-    "description": "A modern, open source text editor from Adobe",
+    "description": "Keyboard shortcuts for Brackets, an open source text editor from Adobe",
     "metadata": {
         "sourceName": "GitHub",
         "sourceUrl": "https://github.com/adobe/brackets/wiki/Brackets-Shortcuts"
@@ -58,7 +58,7 @@
             "key": "[Ctrl] [Shift] [S]"
         }, {
             "val": "Rename file",
-            "key": "[F2]"
+            "key": "F2"
         }, {
             "val": "Close file",
             "key": "[Ctrl] [W]"

--- a/share/goodie/cheat_sheets/json/adobe-brackets.json
+++ b/share/goodie/cheat_sheets/json/adobe-brackets.json
@@ -1,7 +1,7 @@
 {
     "id": "adobe_brackets_cheat_sheet",
     "name": "Adobe Brackets",
-    "description": "Text Editor",
+    "description": "A modern, open source text editor from Adobe",
     "metadata": {
         "sourceName": "GitHub",
         "sourceUrl": "https://github.com/adobe/brackets/wiki/Brackets-Shortcuts"
@@ -9,10 +9,10 @@
     "aliases": ["brackets", "brackets editor", "adobe brackets editor"],
     "template_type": "keyboard",
     "section_order": [
-        "View",
-        "Files",
         "Editing",
+        "Files",
         "Navigation",
+        "View", 
         "Debug"
     ],
     "sections": {


### PR DESCRIPTION
added proper description to this cheat sheet and modified the way cheat sheet was displayed.
 before - 
![brackets o](https://cloud.githubusercontent.com/assets/11630812/12444701/4c495ccc-bf86-11e5-97bb-df196c603eb4.png)
![brackets o2](https://cloud.githubusercontent.com/assets/11630812/12444710/546897e2-bf86-11e5-9fc4-98f62c558723.png)

after - 
![brackets 1](https://cloud.githubusercontent.com/assets/11630812/12444845/d2f1e62c-bf86-11e5-8988-8073129b7e49.png)

https://duck.co/ia/view/adobe_brackets_cheat_sheet