### PR TITLE
Use the same bignum/int pragmas in the tests for Test::Deep

### DIFF
--- a/t/Base.t
+++ b/t/Base.t
@@ -6,7 +6,11 @@ use Test::More;
 use DDG::Test::Goodie;
 
 zci answer_type => 'conversion';
+
+# is_cached is promoted in the IA
+use bigint;
 zci is_cached   => 1;
+no bigint;
 
 ddg_goodie_test([qw(
           DDG::Goodie::Base

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -8,7 +8,11 @@ use DDG::Test::Goodie;
 use utf8;
 
 zci answer_type => 'conversions';
+
+# Match the promotion to BigInt in the IA
+use bignum;
 zci is_cached   => 1;
+no bignum;
 
 ddg_goodie_test(
     ['DDG::Goodie::Conversions'],

--- a/t/PrimeFactors.t
+++ b/t/PrimeFactors.t
@@ -8,7 +8,11 @@ use Test::More;
 use DDG::Test::Goodie;
 
 zci answer_type => "prime_factors";
+
+# Match the promotion in the IA
+use bignum;
 zci is_cached => 1;
+no bignum;
 
 sub build_answer {
     my ($subtitle, $title) = @_;

--- a/t/SumOfNaturalNumbers.t
+++ b/t/SumOfNaturalNumbers.t
@@ -5,7 +5,11 @@ use warnings;
 use Test::More;
 use DDG::Test::Goodie;
 
+# match promotion in IA
+use bignum;
 zci is_cached => 1;
+no bignum;
+
 zci answer_type => 'sum';
 
 ddg_goodie_test(


### PR DESCRIPTION
Instant answers using the `bignum/int pragmas` are auto-promoting other integer values, e.g. `is_cached`, to `BigInt`.   This causes problems when using `Test::Deep` and not including the same pragmas in the tests.  This is one way of fixing it.