### PR TITLE
Put 'use big*' after is_cached

### DIFF
--- a/lib/DDG/Goodie/Base.pm
+++ b/lib/DDG/Goodie/Base.pm
@@ -6,6 +6,10 @@ use DDG::Goodie;
 
 use Math::Int2Base qw/int2base/;
 use 5.010;
+
+zci answer_type => "conversion";
+zci is_cached => 1;
+
 use bigint;
 
 my %base_map = (
@@ -19,9 +23,6 @@ my $map_keys = join '|', keys %base_map;
 
 triggers any => 'base', keys %base_map;
 
-zci answer_type => "conversion";
-zci is_cached => 1;
-
 handle query_clean => sub {
     return unless /^(?<num>[0-9]+)\s*(?:(?:in|as|to)\s+)?(?:(?<bt>$map_keys)|(?:base\s*(?<bn>[0-9]+)))$/;
     my $number = $+{'num'};
@@ -33,7 +34,7 @@ handle query_clean => sub {
         input     => ["$number"],
         operation => 'Decimal to base ' . $base,
         result    => $based
-      };
+    };
 };
 
 1;

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -6,12 +6,13 @@ use DDG::Goodie;
 with 'DDG::GoodieRole::NumberStyler';
 
 use Math::Round qw/nearest/;
-use bignum;
 use utf8;
 use YAML::XS 'LoadFile';
 
 zci answer_type => 'conversions';
 zci is_cached   => 1;
+
+use bignum;
 
 my @types = LoadFile(share('ratios.yml'));
 

--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -6,11 +6,12 @@ use DDG::Goodie;
 
 use Math::Prime::Util 'factor_exp', 'is_prime';
 
-use bignum;
 use utf8;
 
 zci answer_type => "prime_factors";
 zci is_cached => 1;
+
+use bignum;
 
 triggers startend => (
     'prime factors',

--- a/lib/DDG/Goodie/SumOfNaturalNumbers.pm
+++ b/lib/DDG/Goodie/SumOfNaturalNumbers.pm
@@ -3,13 +3,14 @@ package DDG::Goodie::SumOfNaturalNumbers;
 
 use strict;
 use DDG::Goodie;
-use bignum;
 
 triggers start => "add", "sum from";
 triggers startend => "sum";
 
 zci is_cached => 1;
 zci answer_type => "sum";
+
+use bignum;
 
 # This adds commas to the number.
 # It converts 10000000 to 10,000,000.


### PR DESCRIPTION
`is_cached` gets converted to a BigInt with the pragmas declared in their current spots.  This can cause problems during deep tests.