### PR TITLE
UltimateAnswer: Expand query space

### DIFF
--- a/lib/DDG/Goodie/UltimateAnswer.pm
+++ b/lib/DDG/Goodie/UltimateAnswer.pm
@@ -18,7 +18,7 @@ zci is_cached   => 1;
 
 handle remainder => sub {
     
-    return unless $_ =~ qr/^(what is)?( )?(the)?$/i;
+    return unless $_ =~ qr/^(what is )?(the)?$/i;
 
     my $answer = 'Forty-two';
 

--- a/lib/DDG/Goodie/UltimateAnswer.pm
+++ b/lib/DDG/Goodie/UltimateAnswer.pm
@@ -3,13 +3,38 @@ package DDG::Goodie::UltimateAnswer;
 
 use strict;
 use DDG::Goodie;
-triggers start => 'what is the ultimate answer', 'what is the ultimate answer to life the universe and everything', 'what is the answer to the ultimate question of life the universe and everything', 'answer to life the universe and everything';
+
+triggers any =>
+    'life the universe and everything',
+    'ultimate answer',
+    'answer to the ultimate question';
 
 zci answer_type => 'ultimate_answer';
 zci is_cached   => 1;
 
-handle remainder => sub {
-    return unless ($_ eq '' || $_ eq '?');
+handle query => sub {
+    
+    return if (
+        # 'life the universe and everything' is the name of a book in the series.
+        # Want to restrict this query a bit.
+        (
+            $_ =~ /life the universe and everything/ &&
+            !($_ =~ /question|answer|what is|meaning/)
+        ) ||
+        # 'ultimate answer' can refer to other topics (e.g. 'ultimate answer to kings')
+        # Also want to restrict this query.
+        (
+            $_ =~ /ultimate answer/ &&
+            !( $_ =~ /^(what is the )?ultimate answer(\?)?$/) &&
+            !( $_ =~ /life the universe and everything/ )
+        ) ||
+        # Restrict 'answer to the ultimate question' just to be safe
+        (
+            $_ =~ /answer to the ultimate question/ &&
+            !( $_ =~ /^((what is the )?(ultimate )?answer to the ultimate question(\?)?)$/) &&
+            !( $_ =~ /life the universe and everything/)
+        )
+    );
 
     my $answer = 'Forty-two';
 

--- a/lib/DDG/Goodie/UltimateAnswer.pm
+++ b/lib/DDG/Goodie/UltimateAnswer.pm
@@ -12,7 +12,7 @@ triggers any =>
 zci answer_type => 'ultimate_answer';
 zci is_cached   => 1;
 
-handle query => sub {
+handle query_lc => sub {
     
     return if (
         # 'life the universe and everything' is the name of a book in the series.
@@ -40,8 +40,8 @@ handle query => sub {
 
     return $answer,
         structured_answer => {
-            id        => 'ultimateanswer',
-            name      => 'Ultimate Answer',
+            id        => 'ultimate_answer',
+            name      => 'Answer',
             data      => {
                 title      => $answer,
                 subtitle   => 'The answer to the ultimate question of life, the universe and everything.'

--- a/lib/DDG/Goodie/UltimateAnswer.pm
+++ b/lib/DDG/Goodie/UltimateAnswer.pm
@@ -3,7 +3,7 @@ package DDG::Goodie::UltimateAnswer;
 
 use strict;
 use DDG::Goodie;
-triggers start => 'what is the ultimate answer', 'what is the ultimate answer to life the universe and everything', 'what is the answer to the ultimate question of life the universe and everything';
+triggers start => 'what is the ultimate answer', 'what is the ultimate answer to life the universe and everything', 'what is the answer to the ultimate question of life the universe and everything', 'answer to life the universe and everything';
 
 zci answer_type => 'ultimate_answer';
 zci is_cached   => 1;

--- a/lib/DDG/Goodie/UltimateAnswer.pm
+++ b/lib/DDG/Goodie/UltimateAnswer.pm
@@ -28,7 +28,7 @@ handle remainder => sub {
             name      => 'Answer',
             data      => {
                 title      => $answer,
-                subtitle   => 'The answer to the ultimate question of life, the universe and everything.'
+                subtitle   => 'The Answer to the Ultimate Question of Life, the Universe, and Everything.'
             },
             meta      => {
                 sourceName => 'Wikipedia',

--- a/lib/DDG/Goodie/UltimateAnswer.pm
+++ b/lib/DDG/Goodie/UltimateAnswer.pm
@@ -4,37 +4,21 @@ package DDG::Goodie::UltimateAnswer;
 use strict;
 use DDG::Goodie;
 
-triggers any =>
-    'life the universe and everything',
+triggers end =>
+    'meaning of life the universe and everything',
+    'answer to life the universe and everything',
+    'ultimate answer to life the universe and everything',
+    'answer to the question of life the universe and everything',
+    'answer to the ultimate question of life the universe and everything',
     'ultimate answer',
     'answer to the ultimate question';
 
 zci answer_type => 'ultimate_answer';
 zci is_cached   => 1;
 
-handle query_lc => sub {
+handle remainder => sub {
     
-    return if (
-        # 'life the universe and everything' is the name of a book in the series.
-        # Want to restrict this query a bit.
-        (
-            $_ =~ /life the universe and everything/ &&
-            !($_ =~ /question|answer|what is|meaning/)
-        ) ||
-        # 'ultimate answer' can refer to other topics (e.g. 'ultimate answer to kings')
-        # Also want to restrict this query.
-        (
-            $_ =~ /ultimate answer/ &&
-            !( $_ =~ /^(what is the )?ultimate answer(\?)?$/) &&
-            !( $_ =~ /life the universe and everything/ )
-        ) ||
-        # Restrict 'answer to the ultimate question' just to be safe
-        (
-            $_ =~ /answer to the ultimate question/ &&
-            !( $_ =~ /^((what is the )?(ultimate )?answer to the ultimate question(\?)?)$/) &&
-            !( $_ =~ /life the universe and everything/)
-        )
-    );
+    return unless $_ =~ qr/^(what is)?( )?(the)?$/i;
 
     my $answer = 'Forty-two';
 

--- a/lib/DDG/Goodie/UltimateAnswer.pm
+++ b/lib/DDG/Goodie/UltimateAnswer.pm
@@ -39,11 +39,21 @@ handle query => sub {
     my $answer = 'Forty-two';
 
     return $answer,
-      structured_answer => {
-        input     => [],
-        operation => 'The answer to the ultimate question of life, the universe and everything',
-        result    => $answer
-      };
+        structured_answer => {
+            id        => 'ultimateanswer',
+            name      => 'Ultimate Answer',
+            data      => {
+                title      => $answer,
+                subtitle   => 'The answer to the ultimate question of life, the universe and everything.'
+            },
+            meta      => {
+                sourceName => 'Wikipedia',
+                sourceUrl  => 'https://en.wikipedia.org/wiki/Phrases_from_The_Hitchhiker%27s_Guide_to_the_Galaxy#Answer_to_the_Ultimate_Question_of_Life.2C_the_Universe.2C_and_Everything_.2842.29'
+            },
+            templates => {
+                group      => 'text'
+            }
+    };
 };
 
 1;

--- a/t/UltimateAnswer.t
+++ b/t/UltimateAnswer.t
@@ -11,8 +11,8 @@ zci is_cached   => 1;
 
 my $answer = 'Forty-two';
 my $structuredAnswer = {
-    id        => 'ultimateanswer',
-    name      => 'Ultimate Answer',
+    id        => 'ultimate_answer',
+    name      => 'Answer',
     data      => {
         title      => $answer,
         subtitle   => 'The answer to the ultimate question of life, the universe and everything.'
@@ -30,6 +30,10 @@ ddg_goodie_test(
     ['DDG::Goodie::UltimateAnswer'],
 
     'what is the answer to life the universe and everything' => test_zci(
+        $answer,
+        structured_answer => $structuredAnswer
+    ),
+    '!What is the Answer to Life the Universe and Everything' => test_zci(
         $answer,
         structured_answer => $structuredAnswer
     ),
@@ -57,6 +61,10 @@ ddg_goodie_test(
         $answer,
         structured_answer => $structuredAnswer
     ),
+    'Ultimate Answer' => test_zci(
+        $answer,
+        structured_answer => $structuredAnswer
+    ),
     'what is the ultimate answer' => test_zci(
         $answer,
         structured_answer => $structuredAnswer
@@ -70,6 +78,10 @@ ddg_goodie_test(
         structured_answer => $structuredAnswer
     ),
     'answer to the ultimate question' => test_zci(
+        $answer,
+        structured_answer => $structuredAnswer
+    ),
+    'Answer to the Ultimate Question' => test_zci(
         $answer,
         structured_answer => $structuredAnswer
     ),

--- a/t/UltimateAnswer.t
+++ b/t/UltimateAnswer.t
@@ -20,6 +20,14 @@ ddg_goodie_test(
             result    => 'Forty-two',
         }
     ),
+    'answer to life the universe and everything' => test_zci(
+        'Forty-two',
+        structured_answer => {
+            input     => [],
+            operation => 'The answer to the ultimate question of life, the universe and everything',
+            result    => 'Forty-two',
+        }
+    ),
     'what is the answer to my homework question' => undef,
     'why?'                                       => undef,
 );

--- a/t/UltimateAnswer.t
+++ b/t/UltimateAnswer.t
@@ -9,96 +9,81 @@ use DDG::Test::Goodie;
 zci answer_type => "ultimate_answer";
 zci is_cached   => 1;
 
+my $answer = 'Forty-two';
+my $structuredAnswer = {
+    id        => 'ultimateanswer',
+    name      => 'Ultimate Answer',
+    data      => {
+        title      => $answer,
+        subtitle   => 'The answer to the ultimate question of life, the universe and everything.'
+    },
+    meta      => {
+        sourceName => 'Wikipedia',
+        sourceUrl  => 'https://en.wikipedia.org/wiki/Phrases_from_The_Hitchhiker%27s_Guide_to_the_Galaxy#Answer_to_the_Ultimate_Question_of_Life.2C_the_Universe.2C_and_Everything_.2842.29'
+    },
+    templates => {
+        group      => 'text'
+    }
+};
+
 ddg_goodie_test(
     ['DDG::Goodie::UltimateAnswer'],
 
     'what is the answer to life the universe and everything' => test_zci(
-        'Forty-two',
-        structured_answer => {
-            input     => [],
-            operation => 'The answer to the ultimate question of life, the universe and everything',
-            result    => 'Forty-two',
-        }
+        $answer,
+        structured_answer => $structuredAnswer
+    ),
+    'what is the answer to life the universe and everything?' => test_zci(
+        $answer,
+        structured_answer => $structuredAnswer
     ),
     'question life the universe and everything' => test_zci(
-        'Forty-two',
-        structured_answer => {
-            input     => [],
-            operation => 'The answer to the ultimate question of life, the universe and everything',
-            result    => 'Forty-two',
-        }
+        $answer,
+        structured_answer => $structuredAnswer
     ),
     'answer to life the universe and everything' => test_zci(
-        'Forty-two',
-        structured_answer => {
-            input     => [],
-            operation => 'The answer to the ultimate question of life, the universe and everything',
-            result    => 'Forty-two',
-        }
+        $answer,
+        structured_answer => $structuredAnswer
     ),
     'what is life the universe and everything' => test_zci(
-        'Forty-two',
-        structured_answer => {
-            input     => [],
-            operation => 'The answer to the ultimate question of life, the universe and everything',
-            result    => 'Forty-two',
-        }
+        $answer,
+        structured_answer => $structuredAnswer
     ),
     'meaning of life the universe and everything' => test_zci(
-        'Forty-two',
-        structured_answer => {
-            input     => [],
-            operation => 'The answer to the ultimate question of life, the universe and everything',
-            result    => 'Forty-two',
-        }
+        $answer,
+        structured_answer => $structuredAnswer
     ),
     'ultimate answer' => test_zci(
-        'Forty-two',
-        structured_answer => {
-            input     => [],
-            operation => 'The answer to the ultimate question of life, the universe and everything',
-            result    => 'Forty-two',
-        }
+        $answer,
+        structured_answer => $structuredAnswer
     ),
     'what is the ultimate answer' => test_zci(
-        'Forty-two',
-        structured_answer => {
-            input     => [],
-            operation => 'The answer to the ultimate question of life, the universe and everything',
-            result    => 'Forty-two',
-        }
+        $answer,
+        structured_answer => $structuredAnswer
+    ),
+    'what is the ultimate answer?' => test_zci(
+        $answer,
+        structured_answer => $structuredAnswer
     ),
     'what is the ultimate answer to life the universe and everything' => test_zci(
-        'Forty-two',
-        structured_answer => {
-            input     => [],
-            operation => 'The answer to the ultimate question of life, the universe and everything',
-            result    => 'Forty-two',
-        }
+        $answer,
+        structured_answer => $structuredAnswer
     ),
     'answer to the ultimate question' => test_zci(
-        'Forty-two',
-        structured_answer => {
-            input     => [],
-            operation => 'The answer to the ultimate question of life, the universe and everything',
-            result    => 'Forty-two',
-        }
+        $answer,
+        structured_answer => $structuredAnswer
     ),
     'what is the answer to the ultimate question' => test_zci(
-        'Forty-two',
-        structured_answer => {
-            input     => [],
-            operation => 'The answer to the ultimate question of life, the universe and everything',
-            result    => 'Forty-two',
-        }
+        $answer,
+        structured_answer => $structuredAnswer
+    ),
+    'what is the answer to the ultimate question?' => test_zci(
+        $answer,
+        structured_answer => $structuredAnswer
     ),
     'what is the answer to the ultimate question of life the universe and everything' => test_zci(
-        'Forty-two',
-        structured_answer => {
-            input     => [],
-            operation => 'The answer to the ultimate question of life, the universe and everything',
-            result    => 'Forty-two',
-        }
+        $answer,
+        structured_answer => $structuredAnswer
     ),
     'life the universe and everything'           => undef,
     'life the universe and everything 42'        => undef,

--- a/t/UltimateAnswer.t
+++ b/t/UltimateAnswer.t
@@ -33,7 +33,7 @@ ddg_goodie_test(
         $answer,
         structured_answer => $structuredAnswer
     ),
-    '!What is the Answer to Life the Universe and Everything' => test_zci(
+    'What is the Answer to Life the Universe and Everything' => test_zci(
         $answer,
         structured_answer => $structuredAnswer
     ),
@@ -41,15 +41,7 @@ ddg_goodie_test(
         $answer,
         structured_answer => $structuredAnswer
     ),
-    'question life the universe and everything' => test_zci(
-        $answer,
-        structured_answer => $structuredAnswer
-    ),
     'answer to life the universe and everything' => test_zci(
-        $answer,
-        structured_answer => $structuredAnswer
-    ),
-    'what is life the universe and everything' => test_zci(
         $answer,
         structured_answer => $structuredAnswer
     ),

--- a/t/UltimateAnswer.t
+++ b/t/UltimateAnswer.t
@@ -12,7 +12,15 @@ zci is_cached   => 1;
 ddg_goodie_test(
     ['DDG::Goodie::UltimateAnswer'],
 
-    'what is the answer to the ultimate question of life the universe and everything' => test_zci(
+    'what is the answer to life the universe and everything' => test_zci(
+        'Forty-two',
+        structured_answer => {
+            input     => [],
+            operation => 'The answer to the ultimate question of life, the universe and everything',
+            result    => 'Forty-two',
+        }
+    ),
+    'question life the universe and everything' => test_zci(
         'Forty-two',
         structured_answer => {
             input     => [],
@@ -28,6 +36,77 @@ ddg_goodie_test(
             result    => 'Forty-two',
         }
     ),
+    'what is life the universe and everything' => test_zci(
+        'Forty-two',
+        structured_answer => {
+            input     => [],
+            operation => 'The answer to the ultimate question of life, the universe and everything',
+            result    => 'Forty-two',
+        }
+    ),
+    'meaning of life the universe and everything' => test_zci(
+        'Forty-two',
+        structured_answer => {
+            input     => [],
+            operation => 'The answer to the ultimate question of life, the universe and everything',
+            result    => 'Forty-two',
+        }
+    ),
+    'ultimate answer' => test_zci(
+        'Forty-two',
+        structured_answer => {
+            input     => [],
+            operation => 'The answer to the ultimate question of life, the universe and everything',
+            result    => 'Forty-two',
+        }
+    ),
+    'what is the ultimate answer' => test_zci(
+        'Forty-two',
+        structured_answer => {
+            input     => [],
+            operation => 'The answer to the ultimate question of life, the universe and everything',
+            result    => 'Forty-two',
+        }
+    ),
+    'what is the ultimate answer to life the universe and everything' => test_zci(
+        'Forty-two',
+        structured_answer => {
+            input     => [],
+            operation => 'The answer to the ultimate question of life, the universe and everything',
+            result    => 'Forty-two',
+        }
+    ),
+    'answer to the ultimate question' => test_zci(
+        'Forty-two',
+        structured_answer => {
+            input     => [],
+            operation => 'The answer to the ultimate question of life, the universe and everything',
+            result    => 'Forty-two',
+        }
+    ),
+    'what is the answer to the ultimate question' => test_zci(
+        'Forty-two',
+        structured_answer => {
+            input     => [],
+            operation => 'The answer to the ultimate question of life, the universe and everything',
+            result    => 'Forty-two',
+        }
+    ),
+    'what is the answer to the ultimate question of life the universe and everything' => test_zci(
+        'Forty-two',
+        structured_answer => {
+            input     => [],
+            operation => 'The answer to the ultimate question of life, the universe and everything',
+            result    => 'Forty-two',
+        }
+    ),
+    'life the universe and everything'           => undef,
+    'life the universe and everything 42'        => undef,
+    'blah life the universe and everything'      => undef,
+    'ultimate answer to kings'                   => undef,
+    'blah ultimate answer'                       => undef,
+    'answer to the ultimate question of life'    => undef,
+    'blah answer to the ultimate question'       => undef,
     'what is the answer to my homework question' => undef,
     'why?'                                       => undef,
 );

--- a/t/UltimateAnswer.t
+++ b/t/UltimateAnswer.t
@@ -15,7 +15,7 @@ my $structuredAnswer = {
     name      => 'Answer',
     data      => {
         title      => $answer,
-        subtitle   => 'The answer to the ultimate question of life, the universe and everything.'
+        subtitle   => 'The Answer to the Ultimate Question of Life, the Universe, and Everything.'
     },
     meta      => {
         sourceName => 'Wikipedia',
@@ -74,6 +74,14 @@ ddg_goodie_test(
         structured_answer => $structuredAnswer
     ),
     'Answer to the Ultimate Question' => test_zci(
+        $answer,
+        structured_answer => $structuredAnswer
+    ),
+    'Answer to the Ultimate Question of Life, the Universe, and Everything' => test_zci(
+        $answer,
+        structured_answer => $structuredAnswer
+    ),
+    'The Answer to the Ultimate Question of Life, the Universe, and Everything' => test_zci(
         $answer,
         structured_answer => $structuredAnswer
     ),


### PR DESCRIPTION
Thought it might be nice to expand the query space a bit. I didn't realize this goodie existed at first because I couldn't get it to trigger.

If you type in 'answer to' in DDG, the second suggestion is currently 'answer to life the universe and everything'.

And if you type this query into Google, it will output 42 as the answer. So I think it makes sense that the query should also trigger this goodie in DDG.

IA: https://duck.co/ia/view/ultimate_answer