### PR TITLE
Language cheat sheets: add "play pronunciation" feature

### DIFF
--- a/share/goodie/cheat_sheets/cheat_sheets.css
+++ b/share/goodie/cheat_sheets/cheat_sheets.css
@@ -128,6 +128,19 @@
   font-size: 7px;
 }
 
+.zci--cheat_sheets .language li .cheatsheet__audio {
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  opacity: .7;
+}
+
+.zci--cheat_sheets .language li .cheatsheet__audio:hover {
+  opacity: 1;
+}
+
 /**/
 
 .zci--cheat_sheets .cheatsheet__footer {

--- a/share/goodie/cheat_sheets/cheat_sheets.js
+++ b/share/goodie/cheat_sheets/cheat_sheets.js
@@ -109,6 +109,7 @@ DDH.cheat_sheets.build = function(ops) {
                 $hideRow   = $section.find("tbody tr:nth-child(n+4), ul li:nth-child(n+4)"),
                 $showhide  = $container.find(".cheatsheet__section.showhide"),
                 $more_btn  = $dom.find(".chomp--link"),
+                $audio_btn = $container.find(".cheatsheet__audio");
                 isExpanded = false,
                 loadedMasonry = false,
                 masonryOps = {
@@ -141,6 +142,10 @@ DDH.cheat_sheets.build = function(ops) {
                         $container.masonry(masonryOps);
                     }
                 };
+            
+            $audio_btn.click(function() {
+                $(this).next("audio").get(0).play();
+            });
 
             // Removes all tr's after the 3rd before masonry fires
             if ($container.hasClass("compressed")) {

--- a/share/goodie/cheat_sheets/language.handlebars
+++ b/share/goodie/cheat_sheets/language.handlebars
@@ -2,7 +2,9 @@
   {{#each items}}
     <li class="text--primary">
       <div class="cheatsheet__key">{{key}}</div>
-      <div class="cheatsheet__value text--secondary">{{val}}</div>
+      <div class="cheatsheet__value text--secondary">{{val}}{{#if aud}}
+        <span class="cheatsheet__audio">&#128266;</span><audio src="{{aud}}"></audio>
+      {{/if}}</div>
       {{#if trn}}
         <div class="cheatsheet__translit text--secondary"><em>{{trn}}</em></div>
       {{/if}}


### PR DESCRIPTION
Provides a button near a phrase to play pronunciation audio if given in the JSON file.
![19b5ec5e-c606-11e5-90a5-cb0f8d60df55](https://cloud.githubusercontent.com/assets/9462146/12673615/1ba25c1e-c67e-11e5-9922-a6a05e895a69.jpg)
