### PR TITLE
 POTUS Fixes: #1863

### DIFF
--- a/lib/DDG/Goodie/POTUS.pm
+++ b/lib/DDG/Goodie/POTUS.pm
@@ -7,8 +7,7 @@ use Lingua::EN::Numbers::Ordinate qw(ordsuf ordinate);
 use Lingua::EN::Words2Nums;
 use YAML::XS 'LoadFile';
 
-triggers startend => 'potus';
-triggers any => 'president of the united states', 'president of the us';
+triggers query_lc => qr/^((who\s+(is|was)\s+(the\s)?((\d+(?:st|nd|rd|th)\s+)?))?(POTUS|(president\s+of\s+(USA|US|united\s+states|united\s+states\s+of\s+america))))$/i; 
 
 zci answer_type => 'potus';
 zci is_cached   => 1;

--- a/lib/DDG/Goodie/POTUS.pm
+++ b/lib/DDG/Goodie/POTUS.pm
@@ -15,13 +15,12 @@ zci is_cached   => 1;
 my @presidents = @{LoadFile(share('presidents.yml'))};
 my $prez_count = scalar @presidents;
 
-handle remainder => sub {
+handle query_lc => sub {
     my $rem = shift;
     $rem =~ s/
       |who\s+(is|was)\s+the\s+
       |^POTUS\s+
-      |\s+(POTUS|president\s+of\s+the\s+united\s+states)$
-      |^(POTUS|president\s+of\s+the\s+united\s+states)\s+
+      |\s+(POTUS|president\s+of\s+(the\s+)?(united\s+states|us|usa|united\s+states\s+of\s+america))$  
     //gix;
 
     my $num = ($rem =~ /^\d+$/) ? $rem : words2nums($rem) || $prez_count;

--- a/t/POTUS.t
+++ b/t/POTUS.t
@@ -90,6 +90,7 @@ ddg_goodie_test(
             result    => 'Abraham Lincoln'
         }
     ),
+    "vice president of the united states" => undef,
 );
 
 done_testing;


### PR DESCRIPTION
Modified trigger to prevent queries such as `abc POTUS`

//cc @mintsoft 

IA : https://duck.co/ia/view/potus