### PR TITLE
Rexep: Ensure HTML chars are escaped

### DIFF
--- a/lib/DDG/Goodie/Regexp.pm
+++ b/lib/DDG/Goodie/Regexp.pm
@@ -1,5 +1,6 @@
 package DDG::Goodie::Regexp;
-# ABSTRACT: Parse a regexp.
+
+# ABSTRACT: Parse a regexp and list the matches
 
 use strict;
 use warnings;
@@ -20,7 +21,7 @@ sub compile_re {
 
 # Using $& causes a performance penalty, apparently.
 sub get_full_match {
-    return substr(shift, $-[0], $+[0] - $-[0]);
+    return html_enc(substr(shift, $-[0], $+[0] - $-[0]));
 }
 
 # Ensures that the correct numbered matches are being produced.
@@ -44,11 +45,11 @@ sub get_match_record {
     my $matches = {};
     $matches->{'Full Match'} = get_full_match($str);
     foreach my $match (keys %+) {
-		    $matches->{"Named Capture <$match>"} = $+{$match};
+        $matches->{"Named Capture <$match>"} = html_enc($+{$match});
     };
     my $i = 1;
     foreach my $match (@numbered) {
-        $matches->{"Subpattern Match $i"} = $match;
+        $matches->{"Subpattern Match $i"} = html_enc($match);
         $i++;
     };
     return $matches;
@@ -80,7 +81,7 @@ handle query => sub {
             name => 'Answer',
             data => {
                 title       => "Regular Expression Match",
-                subtitle    => "Match regular expression /$regexp/$modifiers on $str",
+                subtitle    => html_enc("Match regular expression /$regexp/$modifiers on $str"),
                 record_data => $matches,
                 record_keys => \@key_order,
             },

--- a/t/Regexp.t
+++ b/t/Regexp.t
@@ -37,7 +37,7 @@ ddg_goodie_test([qw( DDG::Goodie::Regexp )],
         'Full Match'           => 'Harry is awesome',
         'Named Capture <name>' => 'Harry',
         'Subpattern Match 1'   => 'Harry',
-    }, '/(?<name>Harry|Larry) is awesome/', 'Harry is awesome'),
+    }, '/(?&lt;name&gt;Harry|Larry) is awesome/', 'Harry is awesome'),
     'regex /(he|she) walked away/ he walked away' => build_test({
         'Full Match'         => 'he walked away',
         'Subpattern Match 1' => 'he',
@@ -53,7 +53,7 @@ ddg_goodie_test([qw( DDG::Goodie::Regexp )],
         'Full Match'             => 'DDG::Goodie::Regexp',
         'Named Capture <goodie>' => 'Regexp',
         'Subpattern Match 1'     => 'Regexp',
-    }, '/^DDG::Goodie::(?<goodie>\w+)$/', 'DDG::Goodie::Regexp'),
+    }, '/^DDG::Goodie::(?&lt;goodie&gt;\w+)$/', 'DDG::Goodie::Regexp'),
     'regexp /foo/ foo' => build_test({
         'Full Match' => 'foo',
     }, '/foo/', 'foo'),
@@ -84,4 +84,3 @@ ddg_goodie_test([qw( DDG::Goodie::Regexp )],
 );
 
 done_testing;
-


### PR DESCRIPTION
Need to HTML escape *everything* to prevent SERP breakage right now.

This updated the code + tests.

/cc @GuiltyDolphin 