### PR TITLE
Use Git::Tag::IAChangelog in dist.ini

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,7 +14,6 @@ module = Dist::Zilla::Plugin::UploadToDuckPAN
 module = Dist::Zilla::Plugin::BuildShareAssets
 module = Dist::Zilla::Plugin::IAChangelog
 module = Dist::Zilla::Plugin::AnnounceRelease
-module = Dist::Zilla::Plugin::Git::Tag::IAChangelog
 
 [AutoPrereqs]
 

--- a/dist.ini
+++ b/dist.ini
@@ -14,6 +14,7 @@ module = Dist::Zilla::Plugin::UploadToDuckPAN
 module = Dist::Zilla::Plugin::BuildShareAssets
 module = Dist::Zilla::Plugin::IAChangelog
 module = Dist::Zilla::Plugin::AnnounceRelease
+module = Dist::Zilla::Plugin::Git::Tag::IAChangelog
 
 [AutoPrereqs]
 

--- a/dist.ini
+++ b/dist.ini
@@ -16,7 +16,6 @@ module = Dist::Zilla::Plugin::IAChangelog
 module = Dist::Zilla::Plugin::AnnounceRelease
 
 [AutoPrereqs]
-skip=Git::Tag::IAChangelog$
 
 [GatherDir]
 exclude_match = \.(?:js|handlebars|md|ini|p[ly]|rb|go|tcl|sh|tx)$

--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,7 @@ module = Dist::Zilla::Plugin::IAChangelog
 module = Dist::Zilla::Plugin::AnnounceRelease
 
 [AutoPrereqs]
+skip=Git::Tag::IAChangelog$
 
 [GatherDir]
 exclude_match = \.(?:js|handlebars|md|ini|p[ly]|rb|go|tcl|sh|tx)$

--- a/dist.ini
+++ b/dist.ini
@@ -40,7 +40,9 @@ sharedir_method = module_share_dir
 version_regexp = ^(.+)$
 [PkgVersion]
 [GithubMeta]
-[@Git]
+[Git::Check]
+[Git::Commit]
+[Git::Tag::IAChangelog]
 tag_format = %v
 
 [Git::Push]


### PR DESCRIPTION
Use new dzil plugin to update our tag message on release.