### PR TITLE
Add template_type to gnome cheat sheet

### DIFF
--- a/share/goodie/cheat_sheets/json/gnome.json
+++ b/share/goodie/cheat_sheets/json/gnome.json
@@ -6,6 +6,7 @@
         "sourceName": "GNOME Help",
         "sourceUrl": "https://help.gnome.org/users/gnome-help/stable/keyboard-shortcuts-set.html.en"
     },
+    "template_type": "keyboard",
     "section_order": [
         "Windows",
         "System",


### PR DESCRIPTION
Noticed when testing today that the gnome cheat sheet doesn't have a `template_type`.