### PR TITLE
go-lang : Removed HTML tags and Periods 

### DIFF
--- a/share/goodie/cheat_sheets/json/golang.json
+++ b/share/goodie/cheat_sheets/json/golang.json
@@ -223,13 +223,13 @@
             "val": "new creates a pointer to a new struct instance"
         }],
         "Interfaces": [{
-            "key": "type Awesomizer interface \\{<br>&nbsp;&nbsp;&nbsp;&nbsp;Awesomize() string<br>\\}",
+            "key": "type Awesomizer interface \\{ Awesomize() string\\}",
             "val": "Interface declaration"
         }, {
             "key":"type Foo struct \\{\\}",
             "val": "Types do *not* declare to implement interfaces"
         }, {
-            "key": "func (foo Foo) Awesomize() string \\{<br>&nbsp;&nbsp;&nbsp;&nbsp;return \"Awesome!\"<br>\\}",
+            "key": "func (foo Foo) Awesomize() string \\{ return \"Awesome!\"\\}",
             "val": "Rather, types implicitly satisfy an interface if they implement all required methods"
         }],
         "Operators and aliases": [{

--- a/share/goodie/cheat_sheets/json/golang.json
+++ b/share/goodie/cheat_sheets/json/golang.json
@@ -52,67 +52,61 @@
             "key": "func functionName(param1, param2 int) \\{\\}"
         }, {
             "val": "Return type declaration",
-            "key": "func functionName() int \\{ <br> &nbsp;&nbsp;&nbsp;&nbsp;return 42  <br>\\}"
-        }, {
-            "val": "Can return multiple values at once",
-            "key": "func returnMulti() (int, string) \\{ <br>&nbsp;&nbsp;&nbsp;&nbsp;return 42, \"foobar\" <br>\\} <br> var x, str = returnMulti()"
-        }, {
-            "val": "Return multiple named results simply by return",
-            "key": "func returnMulti2() (n int, s string) \\{ <br> &nbsp;&nbsp;&nbsp;&nbsp;n = 42 <br> &nbsp;&nbsp;&nbsp;&nbsp;s = \"foobar\" <br>  &nbsp;&nbsp;&nbsp;&nbsp;// n and s will be returned <br> &nbsp;&nbsp;&nbsp;&nbsp;return <br> \\} <br> var x, str = returnMulti2()"
+            "key": "func functionName() int \\{ return 42  \\}"
         }],
         "Built In Types": [{
-            "val": "Bool is the set of boolean values, true and false.",
+            "val": "Bool is the set of boolean values, true and false",
             "key": "bool"
         }, {
-            "val": "string is the set of all strings of 8-bit bytes, conventionally but not necessarily representing UTF-8-encoded text. A string may be empty, but not nil. Values of string type are immutable.",
+            "val": "string is the set of all strings of 8-bit bytes, conventionally but not necessarily representing UTF-8-encoded text. A string may be empty, but not nil. Values of string type are immutable",
             "key": "string"
         }, {
-            "val": "int is a signed integer type that is at least 32 bits in size. It is a distinct type, however, and not an alias for, say, int32.",
+            "val": "int is a signed integer type that is at least 32 bits in size. It is a distinct type, however, and not an alias for, say, int32",
             "key": "int"
         },  {
-            "val": "int8 is the set of all signed 8-bit integers. Range: -128 through 127.",
+            "val": "int8 is the set of all signed 8-bit integers. Range: -128 through 127",
             "key": "int8"
         },  {
-            "val": "int16 is the set of all signed 16-bit integers. Range: -32768 through 32767.",
+            "val": "int16 is the set of all signed 16-bit integers. Range: -32768 through 32767",
             "key": "int16"
         },  {
-            "val": "int32 is the set of all signed 32-bit integers. Range: -2147483648 through 2147483647.",
+            "val": "int32 is the set of all signed 32-bit integers. Range: -2147483648 through 2147483647",
             "key": "int32"
         },  {
-            "val": "int64 is the set of all signed 64-bit integers. Range: -9223372036854775808 through 9223372036854775807.",
+            "val": "int64 is the set of all signed 64-bit integers. Range: -9223372036854775808 through 9223372036854775807",
             "key": "int64"
         },  {
-            "val": "uint is an unsigned integer type that is at least 32 bits in size. It is a distinct type, however, and not an alias for, say, uint32.",
+            "val": "uint is an unsigned integer type that is at least 32 bits in size. It is a distinct type, however, and not an alias for, say, uint32",
             "key": "uint"
         },  {
-            "val": "uint8 is the set of all unsigned 8-bit integers. Range: 0 through 255.",
+            "val": "uint8 is the set of all unsigned 8-bit integers. Range: 0 through 255",
             "key": "uint8"
         },  {
-            "val": "uint16 is the set of all unsigned 16-bit integers. Range: 0 through 65535.",
+            "val": "uint16 is the set of all unsigned 16-bit integers. Range: 0 through 65535",
             "key": "uint16"
         },  {
-            "val": "uint32 is the set of all unsigned 32-bit integers. Range: 0 through 4294967295.",
+            "val": "uint32 is the set of all unsigned 32-bit integers. Range: 0 through 4294967295",
             "key": "uint32"
         },  {
-            "val": "uint64 is the set of all unsigned 64-bit integers. Range: 0 through 18446744073709551615.",
+            "val": "uint64 is the set of all unsigned 64-bit integers. Range: 0 through 18446744073709551615",
             "key": "uint64"
         },  {
-            "val": "uintptr is an integer type that is large enough to hold the bit pattern of any pointer.",
+            "val": "uintptr is an integer type that is large enough to hold the bit pattern of any pointer",
             "key": "uintptr"
         },  {
-            "val": "byte is an alias for uint8 and is equivalent to uint8 in all ways. It is used, by convention, to distinguish byte values from 8-bit unsigned integer values.",
+            "val": "byte is an alias for uint8 and is equivalent to uint8 in all ways. It is used, by convention, to distinguish byte values from 8-bit unsigned integer values",
             "key": "byte"
         },  {
-            "val": "rune is an alias for int32 and is equivalent to int32 in all ways. It is used, by convention, to distinguish character values from integer values.",
+            "val": "rune is an alias for int32 and is equivalent to int32 in all ways. It is used, by convention, to distinguish character values from integer values",
             "key": "rune"
         },  {
-            "val": "float32 is the set of all IEEE-754 32-bit floating-point numbers.",
+            "val": "float32 is the set of all IEEE-754 32-bit floating-point numbers",
             "key": "float32"
         },  {
-            "val": "float64 is the set of all IEEE-754 64-bit floating-point numbers.",
+            "val": "float64 is the set of all IEEE-754 64-bit floating-point numbers",
             "key": "float64"
         },  {
-            "val": "complex64 is the set of all complex numbers with float32 real and imaginary parts.",
+            "val": "complex64 is the set of all complex numbers with float32 real and imaginary parts",
             "key": "complex64"
         },  {
             "val": "complex128 is the set of all complex numbers with float64 real and imaginary parts.",
@@ -123,7 +117,7 @@
             "key": "func main() \\{...\\}"
         }, {
             "val": "If",
-            "key": "if x > 0 \\{<br>&nbsp;&nbsp;&nbsp;&nbsp; return x<br>\\} else \\{<br>&nbsp;&nbsp;&nbsp;&nbsp; return -x<br>\\}"
+            "key": "if x > 0 \\{ return x\\} else \\{ return -x\\}"
         }, {
             "val": "For Loop",
             "key": "for i := 1; i < 10; i++ \\{...\\}"
@@ -133,16 +127,10 @@
         }, {
             "val": "For Loop (no condition)",
             "key": "for \\{...\\}"
-        }, {
-            "val": "Switch",
-            "key": "switch operatingSystem \\{<br>case \"darwin\":<br>&nbsp;&nbsp;&nbsp;&nbsp;fmt.Println(\"Mac OS Hipster\")<br>case \"linux\":<br>&nbsp;&nbsp;&nbsp;&nbsp;fmt.Println(\"Linux Geek\")<br>default:<br>&nbsp;&nbsp;&nbsp;&nbsp;fmt.Println(\"Other\")<br>\\}"
-        }, {
-            "val": "Switch (with preceeding assignement)",
-            "key": "switch os := runtime.GOOS; os \\{<br>case \"darwin\": ...<br>\\}"
         }],
         "Arrays, Slices, Ranges": [{
             "key": "var a \\[10\\]int",
-            "val": "Declare an int array with length 10. Array length is part of the type!"
+            "val": "Declare an int array with length 10. Array length is part of the type"
         }, {
             "key": "a\\[3\\] = 42",
             "val": "set elements"
@@ -168,8 +156,8 @@
             "key": "a := \\[\\]int\\{1, 2, 3, 4\\}",
             "val": "Shorthand"
         }, {
-            "key":"chars := \\[\\]string\\{0:&quot;a&quot;, 2:&quot;c&quot;, 1: &quot;b&quot;\\}",
-            "val": " \\[ \"a\", \"b\", \"c\" \\] "
+            "key":"chars := \\[\\]string\\{0: \"a\", 2:\"c\", 1:\"b\"\\}",
+            "val": "\\[ \"a\", \"b\", \"c\" \\]"
         }, {
             "key": "var b = a\\[lo:hi\\]",
             "val": "Creates a slice (view of the array) from index lo to hi-1"
@@ -189,21 +177,21 @@
             "key":"a = make(\\[\\]byte, 5)",
             "val":"Create a slice with make, capacity is optional"
         }, {
-            "key":"x := \\[3\\]string\\{&quot;applies&quot;,&quot;oranges&quot;,&quot;kiwis&quot;\\}",
+            "key":"x := \\[2\\]string\\{\"applies\", \"oranges\"\\}",
             "val":"Create a slice from an array"
         }, {
             "key":"s := x\\[:\\]",
             "val":"A slice referencing the storage of x"
         }],
         "Maps": [{
-            "key": "var m map\\[string\\]int<br>m = make(map\\[string\\]int)<br>m\\[\"key\"\\] = 42<br>fmt.Println(m\\[\"key\"\\])<br><br>delete(m, \"key\")<br>elem, ok := m\\[\"key\"\\]",
+            "key": "var m map\\[string\\]int m = make(map\\[string\\]int) m\\[\"key\"\\] = 42 fmt.Println(m\\[\"key\"\\]) delete(m, \"key\") elem, ok := m\\[\"key\"\\]",
             "val": "Map syntax"
         }, {
-            "key": "var m = map\\[string\\]Vertex\\{<br>&nbsp;&nbsp;&nbsp;&nbsp;\"Bell Labs\": \\{40.68433, -74.39967\\},<br>&nbsp;&nbsp;&nbsp;&nbsp;\"Google\": \\{37.42202, -122.08408\\},<br>\\}",
+            "key": "var m = map\\[string\\]Vertex\\{\"Bell Labs\": \\{40.68433, -74.39967\\}, \"Google\": \\{37.42202, -122.08408\\}\\}",
             "val": "Map literal"
         }],
         "Structs": [{
-            "key": "type Vertex struct \\{<br>&nbsp;&nbsp;&nbsp;&nbsp;X, Y int<br>\\}",
+            "key": "type Vertex struct \\{ X, Y int \\}",
             "val": "Struct declaration"
         }, {
             "key": "var v = Vertex\\{1, 2\\}",
@@ -215,14 +203,8 @@
             "key": "v.X = 4",
             "val": "Accessing members"
         }, {
-            "key": "func (v Vertex) Abs() float64 \\{<br>&nbsp;&nbsp;&nbsp;&nbsp;return math.Sqrt(v.X*v.X + v.Y*v.Y)<br>\\}",
-            "val": "You can declare methods on structs. The struct you want to declare the method on (the receiving type) comes between the the func keyword and the method name. The struct is copied on each method call."
-        }, {
             "key": "v.Abs()",
             "val": "Call method"
-        }, {
-            "key": "func (v *Vertex) add(n float64) \\{<br>&nbsp;&nbsp;&nbsp;&nbsp;v.X += n<br>&nbsp;&nbsp;&nbsp;&nbsp;v.Y += n<br>\\}",
-            "val": "For mutating methods, you need to use a pointer (see below) to the Struct as the type. With this, the struct value is not copied for the method call."
         }, {
             "key": "point := struct \\{<br>&nbsp;&nbsp;&nbsp;&nbsp;X, Y int<br>\\}\\{1, 2\\}",
             "val": "Anonymous structs"

--- a/share/goodie/cheat_sheets/json/golang.json
+++ b/share/goodie/cheat_sheets/json/golang.json
@@ -58,10 +58,10 @@
             "val": "Bool is the set of boolean values, true and false",
             "key": "bool"
         }, {
-            "val": "string is the set of all strings of 8-bit bytes, conventionally but not necessarily representing UTF-8-encoded text. A string may be empty, but not nil. Values of string type are immutable",
+            "val": "string is the set of all strings of 8-bit bytes. A string may be empty, but not nil",
             "key": "string"
         }, {
-            "val": "int is a signed integer type that is at least 32 bits in size. It is a distinct type, however, and not an alias for, say, int32",
+            "val": "int is a signed integer type that is at least 32 bits in size",
             "key": "int"
         },  {
             "val": "int8 is the set of all signed 8-bit integers. Range: -128 through 127",
@@ -76,7 +76,7 @@
             "val": "int64 is the set of all signed 64-bit integers. Range: -9223372036854775808 through 9223372036854775807",
             "key": "int64"
         },  {
-            "val": "uint is an unsigned integer type that is at least 32 bits in size. It is a distinct type, however, and not an alias for, say, uint32",
+            "val": "uint is an unsigned integer type that is at least 32 bits in size",
             "key": "uint"
         },  {
             "val": "uint8 is the set of all unsigned 8-bit integers. Range: 0 through 255",
@@ -94,10 +94,10 @@
             "val": "uintptr is an integer type that is large enough to hold the bit pattern of any pointer",
             "key": "uintptr"
         },  {
-            "val": "byte is an alias for uint8 and is equivalent to uint8 in all ways. It is used, by convention, to distinguish byte values from 8-bit unsigned integer values",
+            "val": "It is used, by convention, to distinguish byte values from 8-bit unsigned integer values",
             "key": "byte"
         },  {
-            "val": "rune is an alias for int32 and is equivalent to int32 in all ways. It is used, by convention, to distinguish character values from integer values",
+            "val": "It is used, by convention, to distinguish character values from integer values",
             "key": "rune"
         },  {
             "val": "float32 is the set of all IEEE-754 32-bit floating-point numbers",
@@ -109,7 +109,7 @@
             "val": "complex64 is the set of all complex numbers with float32 real and imaginary parts",
             "key": "complex64"
         },  {
-            "val": "complex128 is the set of all complex numbers with float64 real and imaginary parts.",
+            "val": "complex128 is the set of all complex numbers with float64 real and imaginary parts",
             "key": "complex128"
         } ],
         "Control Structures": [{
@@ -157,7 +157,7 @@
             "val": "Shorthand"
         }, {
             "key":"chars := \\[\\]string\\{0: \"a\", 2:\"c\", 1:\"b\"\\}",
-            "val": "\\[ \"a\", \"b\", \"c\" \\]"
+            "val": "\\['a', 'b', 'c'\\]"
         }, {
             "key": "var b = a\\[lo:hi\\]",
             "val": "Creates a slice (view of the array) from index lo to hi-1"

--- a/share/goodie/cheat_sheets/json/golang.json
+++ b/share/goodie/cheat_sheets/json/golang.json
@@ -145,7 +145,7 @@
             "val": "Shorthand"
         }, {
             "key": "a := \\[...\\]int\\{1, 2\\}",
-            "val": "Elipsis -&gt; Compiler figures out array length"
+            "val": "Elipsis -> Compiler figures out array length"
         }, {
             "key": "var a \\[\\]int",
             "val": "Declare a slice - similar to an array, but length is unspecified"
@@ -206,7 +206,7 @@
             "key": "v.Abs()",
             "val": "Call method"
         }, {
-            "key": "point := struct \\{<br>&nbsp;&nbsp;&nbsp;&nbsp;X, Y int<br>\\}\\{1, 2\\}",
+            "key": "point := struct \\{X, Y int\\}\\{1, 2\\}",
             "val": "Anonymous structs"
         }],
         "Pointers": [{
@@ -248,7 +248,7 @@
             "key": "%",
             "val":"Remainder"
         }, {
-            "key": "&amp;",
+            "key": "&",
             "val":"Bitwise and"
         }, {
             "key": "|",
@@ -257,13 +257,13 @@
             "key": "^",
             "val":"Bitwise xor"
         }, {
-            "key": "&amp;^",
+            "key": "&^",
             "val":"Bit clear (and not)"
         }, {
-            "key": "&lt;&lt;",
+            "key": "<<",
             "val":"Left shift"
         }, {
-            "key": "&gt;&gt;",
+            "key": ">>",
             "val":"Right shift"
         }, {
             "key": "==",
@@ -272,19 +272,19 @@
             "key": "!=",
             "val":"Not equal"
         }, {
-            "key": "&lt;",
+            "key": "<",
             "val":"Less than"
         }, {
-            "key": "&lt;=",
+            "key": "<=",
             "val":"Less than or equal"
         }, {
-            "key": "&gt;",
+            "key": ">",
             "val":"Greater than"
         }, {
-            "key": "&gt;=",
+            "key": ">=",
             "val":"Greater than or equal"
         }, {
-            "key": "&amp;&amp;",
+            "key": "&&",
             "val":"Logical and"
         }, {
             "key": "||",
@@ -293,13 +293,13 @@
             "key": "!",
             "val":"Logical not"
         },  {
-            "key": "&amp;",
+            "key": "&",
             "val":"Address of / create pointer"
         }, {
             "key": "*",
             "val":"Dereference pointer"
         }, {
-            "key": "&lt;-",
+            "key": "<-",
             "val":"Send / receive operator"
         } ]
     }


### PR DESCRIPTION
There were html tags like "`<br />`" to break the line but they were displayed on result page also. As it's not parsing the html tags.
There were periods and extra spaces also in val field.

https://duck.co/ia/view/golang_cheat_sheet