### PR TITLE
Add missing 'template_type' to cheat sheets

### DIFF
--- a/share/goodie/cheat_sheets/json/gta-vice-city.json
+++ b/share/goodie/cheat_sheets/json/gta-vice-city.json
@@ -9,6 +9,7 @@
   "aliases": [
     "vice city"
   ],
+  "template_type": "reference",
   "section_order": [
     "Cheat codes I",
     "Cheat codes II"

--- a/share/goodie/cheat_sheets/json/kerbal-space-program.json
+++ b/share/goodie/cheat_sheets/json/kerbal-space-program.json
@@ -6,6 +6,7 @@
         "sourceName": "Kerbal Space Program Wiki",
         "sourceUrl": "http://wiki.kerbalspaceprogram.com/wiki/Key_bindings"
     },
+    "template_type": "keyboard",
     "section_order": [
         "System/UI Commands",
         "Flight Controls",


### PR DESCRIPTION
Some cheat sheets were missing a template type @moollaza.