### PR TITLE
Remove Perforce and perforce open source triggers, they belong to perforce_cheat_sheet

### DIFF
--- a/share/goodie/cheat_sheets/json/perforce-workshop.json
+++ b/share/goodie/cheat_sheets/json/perforce-workshop.json
@@ -9,7 +9,7 @@
     },
 
     "aliases": [
-        "perforce", "perforce open source", "p4workshop"
+        "p4workshop"
     ],
 
     "template_type": "terminal",


### PR DESCRIPTION
/cc @lizlam 

-----
IA Page: https://duck.co/ia/view/perforce_workshop_cheat_sheet