### PR TITLE
MacOS cheat sheet: Remove redundant keyboard shortcut

### DIFF
--- a/share/goodie/cheat_sheets/json/apple-mac-os.json
+++ b/share/goodie/cheat_sheets/json/apple-mac-os.json
@@ -58,10 +58,6 @@
                 "val": "Open force quit dialog"
             },
             {
-                "key": "[⌘] [Shift] [3]",
-                "val": "Take a screenshot (saved in Desktop)"
-            },
-            {
                 "key": "[Ctrl] [Shift] [⌽ (Power)]",
                 "val": "Lock the screen"
             }


### PR DESCRIPTION
This PR removes redundant keyboard shortcut.

IA Page: https://duck.co/ia/view/apple_mac_os_cheat_sheet