### PR TITLE
CSS cheat sheet: Add import syntax

### DIFF
--- a/share/goodie/cheat_sheets/json/css.json
+++ b/share/goodie/cheat_sheets/json/css.json
@@ -33,7 +33,10 @@
             "key": "<tag style=\"property: value\">"  
         }, {
             "val": "Import CSS",
-            "key": "@import \\[ <string> | <url> \\] \\[<media-query-list>\\]?;"
+            "key": "@import url(\"style.css\");"
+        }, {
+            "val": "Import CSS and apply only to the corresponding media type",
+            "key": "@import url(\"style.css\") list-of-media-queries;"
         }],
         "General Syntax": [{
             "val": "Basic syntax of css declaration block",

--- a/share/goodie/cheat_sheets/json/css.json
+++ b/share/goodie/cheat_sheets/json/css.json
@@ -33,7 +33,7 @@
             "key": "<tag style=\"property: value\">"  
         }, {
             "val": "Import CSS",
-            "key": "@import [ <string> | <url> ] [<media-query-list>]?;"
+            "key": "@import \\[ <string> | <url> \\] \\[<media-query-list>\\]?;"
         }],
         "General Syntax": [{
             "val": "Basic syntax of css declaration block",

--- a/share/goodie/cheat_sheets/json/css.json
+++ b/share/goodie/cheat_sheets/json/css.json
@@ -31,6 +31,9 @@
         }, {
             "val": "Inline style",
             "key": "<tag style=\"property: value\">"  
+        }, {
+            "val": "Import CSS",
+            "key": "@import [ <string> | <url> ] [<media-query-list>]?;"
         }],
         "General Syntax": [{
             "val": "Basic syntax of css declaration block",


### PR DESCRIPTION
This PR adds import syntax to cheat sheet.

IA Page : https://duck.co/ia/view/css_cheat_sheet