### PR TITLE
Fixes #2317 - Mozilla Thunderbird Cheat Sheet : A Command Symbol shown

### DIFF
--- a/share/goodie/cheat_sheets/json/mozilla-thunderbird.json
+++ b/share/goodie/cheat_sheets/json/mozilla-thunderbird.json
@@ -112,7 +112,7 @@
                 "val": "Label: Later"
             },
             {
-                "key": "[Ctrl/⌘]  [⇧]  [C]",
+                "key": "[Ctrl]  [⇧]  [C]",
                 "val": "Mark All Read"
             },
             {


### PR DESCRIPTION
#2317 - removed the command symbol
#2266 - for reference