### PR TITLE
Goodie Tests: Remove `bignum` from tests, no need to cast is_cached to bignum anymore

### DIFF
--- a/t/Base.t
+++ b/t/Base.t
@@ -6,11 +6,7 @@ use Test::More;
 use DDG::Test::Goodie;
 
 zci answer_type => 'conversion';
-
-# is_cached is promoted in the IA
-use bigint;
 zci is_cached   => 1;
-no bigint;
 
 ddg_goodie_test([qw(
           DDG::Goodie::Base

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -8,11 +8,7 @@ use DDG::Test::Goodie;
 use utf8;
 
 zci answer_type => 'conversions';
-
-# Match the promotion to BigInt in the IA
-use bignum;
 zci is_cached   => 1;
-no bignum;
 
 ddg_goodie_test(
     ['DDG::Goodie::Conversions'],

--- a/t/PrimeNumber.t
+++ b/t/PrimeNumber.t
@@ -8,10 +8,6 @@ use DDG::Test::Goodie;
 zci answer_type => "prime";
 zci is_cached   => 1;
 
-sub make_structued_answer {
-    return
-}
-
 ddg_goodie_test(
     [qw( DDG::Goodie::PrimeNumber )],
     'prime numbers between 4 and 100' => test_zci(

--- a/t/SumOfNaturalNumbers.t
+++ b/t/SumOfNaturalNumbers.t
@@ -5,11 +5,7 @@ use warnings;
 use Test::More;
 use DDG::Test::Goodie;
 
-# match promotion in IA
-use bignum;
 zci is_cached => 1;
-no bignum;
-
 zci answer_type => 'sum';
 
 ddg_goodie_test(


### PR DESCRIPTION
Preparing for https://github.com/duckduckgo/duckduckgo/pull/172

Once that is installed these tests fail and these changes get them to pass again.

/cc @zachthompson @GuiltyDolphin @mintsoft 
