### PR TITLE
Linux cheatsheet: corrected background & stop command shortcut

### DIFF
--- a/share/goodie/cheat_sheets/json/linux.json
+++ b/share/goodie/cheat_sheets/json/linux.json
@@ -345,11 +345,11 @@
         "Shortcuts":[
             {
                 "val":"backgrounds current command",
-                "key":"[ctrl] [c]"
+                "key":"[ctrl] [z]"
             },
             {
                 "val":"stops current command",
-                "key":"[ctrl] [z]"
+                "key":"[ctrl] [c]"
             },
             {
                 "val":"log out of current session",


### PR DESCRIPTION
Linux cheatsheet: corrected background & stop command shortcut.

Linux cheat sheet IA page: https://duck.co/ia/view/linux_cheat_sheet