### PR TITLE
Asciidoc cheatsheet: Changed emphasis syntax

### DIFF
--- a/share/goodie/cheat_sheets/json/asciidoc.json
+++ b/share/goodie/cheat_sheets/json/asciidoc.json
@@ -47,15 +47,15 @@
         ],
         "Emphasis" : [
             {
-                "key": "__text__",
+                "key": "_text_",
                 "val": "Displays the text in italics"
             },
             {
-                "key": "**text**",
+                "key": "*text*",
                 "val": "Displays the text in bold"
             },
             {
-                "key": "**__text__**",
+                "key": "*_text_*",
                 "val": "Displays the text in bold and italics"
             },
             {
@@ -63,8 +63,8 @@
                 "val": "Adds strikethrough effect to the text"
             },
             {
-                "key": "\\[line-through\\]**text**",
-                "val": "Adds strikethrough effect to the text and bolts it"
+                "key": "\\[line-through\\]*text*",
+                "val": "Adds strikethrough effect to the text and makes it bold"
             }
         ],
         "Lists" : [


### PR DESCRIPTION
Following a Twitter comment and checking in the [Asciidoc user guide](http://asciidoc.org/userguide.html#X46), this looks like better syntax.

---
IA Page: https://duck.co/ia/view/asciidoc_cheat_sheet