### PR TITLE
Asciidoc cheatsheet: Changed heading syntax

### DIFF
--- a/share/goodie/cheat_sheets/json/asciidoc.json
+++ b/share/goodie/cheat_sheets/json/asciidoc.json
@@ -29,19 +29,19 @@
                 "val": "Document Title"
             },
             {
-                "key": "== Heading",
+                "key": "= Heading",
                 "val": "H1. Can also be created by putting four or more dashes under Heading"
             },
             {
-                "key": "=== Heading",
+                "key": "== Heading",
                 "val": "H2. Can also be created by putting four or more tildes under Heading"
             },
             {
-                "key": "==== Heading",
+                "key": "=== Heading",
                 "val": "H3. Can also be created by putting four or more carets under Heading"
             },
             {
-                "key": "===== Heading",
+                "key": "==== Heading",
                 "val": "H4. Can also be created by putting four or more pluses under Heading"
             }
         ],


### PR DESCRIPTION
This is to reflect the current Asciidoc syntax, as detailed here: https://github.com/asciidoctor/asciidoctor.org/blob/master/docs/_includes/sections.adoc#titles-as-html-headings

Credit to [Twitter](https://twitter.com/epragt/status/700106790462029824) [commenters](https://twitter.com/mojavelinux/status/700594937205641217).

---
IA Page: https://duck.co/ia/view/asciidoc_cheat_sheet