### PR TITLE
Jira cheat sheet: Corrected shortcut for submit form

### DIFF
--- a/share/goodie/cheat_sheets/json/jira.json
+++ b/share/goodie/cheat_sheets/json/jira.json
@@ -90,7 +90,7 @@
                 "key": "a"
             },
             {
-                "val": "Dock/U­ncock Filters",
+                "val": "Dock/Undock Filters",
                 "key": "["
             },
             {

--- a/share/goodie/cheat_sheets/json/jira.json
+++ b/share/goodie/cheat_sheets/json/jira.json
@@ -25,7 +25,7 @@
             },
             {
                 "val": "Quick Operations",
-                "key": ". "
+                "key": "."
             },
             {
                 "val": "Create Issue",
@@ -61,7 +61,7 @@
             },
             {
                 "val": "Submit Form",
-                "key": "[Ctrl] [s]"
+                "key": "[Alt] [s]"
             },
             {
                 "val": "Help",

--- a/share/goodie/cheat_sheets/json/jira.json
+++ b/share/goodie/cheat_sheets/json/jira.json
@@ -61,7 +61,7 @@
             },
             {
                 "val": "Submit Form",
-                "key": "[Alt] [s]"
+                "key": "[Alt] [S]"
             },
             {
                 "val": "Help",


### PR DESCRIPTION
Corrected the keyboard shortcut for Submit Form and removed unnecessary space at one place.

Jira cheat sheet IA page: https://duck.co/ia/view/jira_cheat_sheet