### PR TITLE
Cheatsheet HTML: Added article and address tag

### DIFF
--- a/share/goodie/cheat_sheets/json/html.json
+++ b/share/goodie/cheat_sheets/json/html.json
@@ -65,6 +65,14 @@
             {
                 "key": "<nav>",
                 "val": "Represents a section of a page that links to other pages or to parts within the page"
+            },
+            {
+                "key": "<article>",
+                "val": "Specifies independent, self-contained content"
+            },
+            {
+                "key": "<address>",
+                "val": "Defines the contact information for the author/owner of a document or an article"
             }
         ],
         "Text Content": [

--- a/share/goodie/cheat_sheets/json/html.json
+++ b/share/goodie/cheat_sheets/json/html.json
@@ -65,14 +65,6 @@
             {
                 "key": "<nav>",
                 "val": "Represents a section of a page that links to other pages or to parts within the page"
-            },
-            {
-                "key": "<article>",
-                "val": "Specifies independent, self-contained content"
-            },
-            {
-                "key": "<address>",
-                "val": "Defines the contact information for the author/owner of a document or an article"
             }
         ],
         "Text Content": [
@@ -103,6 +95,14 @@
             {
                 "key": "<ul>",
                 "val": "Represents an unordered list of items, typically displayed with a bullet"
+            },
+            {
+                "key": "<article>",
+                "val": "Specifies independent, self-contained content"
+            },
+            {
+                "key": "<address>",
+                "val": "Defines the contact information for the author/owner of a document or an article"
             }
         ],
         "Inline Text Semantics": [

--- a/share/goodie/cheat_sheets/json/html.json
+++ b/share/goodie/cheat_sheets/json/html.json
@@ -65,6 +65,10 @@
             {
                 "key": "<nav>",
                 "val": "Represents a section of a page that links to other pages or to parts within the page"
+            },
+            {
+                "key": "<article>",
+                "val": "Specifies independent, self-contained content"
             }
         ],
         "Text Content": [
@@ -95,10 +99,6 @@
             {
                 "key": "<ul>",
                 "val": "Represents an unordered list of items, typically displayed with a bullet"
-            },
-            {
-                "key": "<article>",
-                "val": "Specifies independent, self-contained content"
             },
             {
                 "key": "<address>",


### PR DESCRIPTION
Added article and address tag to HTML cheat sheet in Content Sectioning.

IA page: https://duck.co/ia/view/html_cheat_sheet