### PR TITLE
Safari cheat sheet: Added new section Page Management with some shortcuts

### DIFF
--- a/share/goodie/cheat_sheets/json/safari.json
+++ b/share/goodie/cheat_sheets/json/safari.json
@@ -7,7 +7,7 @@
         "sourceUrl": "https://support.apple.com/kb/PH21483"
     },
     "template_type": "keyboard",
-    "section_order" : ["Tab Management" , "Window Management" , "Bookmarks"],
+    "section_order" : ["Tab Management" , "Window Management", "Page Management", "Bookmarks"],
     "sections":{
         "Tab Management":[{
               "key":"[⌘] [T]",
@@ -49,6 +49,16 @@
            },{
               "key":"[⌘] [Shift] [N]",
               "val":"Open new Private window"
+           }],
+          "Page Management":[{
+              "key":"[⌘] [+]",
+              "val":"Zoom in"
+           },{
+              "key":"[⌘] [-]",
+              "val":"Zoom out"
+           },{
+              "key":"[⌘] [0]",
+              "val":"Default size"
            }],
          "Bookmarks":[{
               "key":"[Option] [⌘] [1]",


### PR DESCRIPTION
Added new section Page Management to Safari cheat sheet with some keyboard shortcuts.

IA Page: https://duck.co/ia/view/safari_cheat_sheet