### PR TITLE
Conversions: Corrected alias of microsecond

### DIFF
--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -542,7 +542,7 @@ aliases:
   - microseconds
   - microsec
   - microsecs
-  - us
+  - µs
 factor: 86400000000
 type: duration
 unit: microsecond


### PR DESCRIPTION
Corrected alias of microsecond in Conversion.

IA Page: https://duck.co/ia/view/conversions