### PR TITLE
Conversions: Tests for weird 999 problem

### DIFF
--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -1655,11 +1655,19 @@ ddg_goodie_test(
         }
     ),
     'how many megabytes in a gigabyte?' => test_zci(
-        '1 gigabyte = 1000 megabytes',
+        '1 gigabyte = 1,000 megabytes',
         structured_answer => {
             input => ['1 gigabyte'],
             operation => 'convert',
-            result => '1000 megabytes'
+            result => '1,000 megabytes'
+        }
+    ),
+    '1 gigabyte in megabytes' => test_zci(
+        '1 gigabyte = 1,000 megabytes',
+        structured_answer => {
+            input => ['1 gigabyte'],
+            operation => 'convert',
+            result => '1,000 megabytes'
         }
     ),
 

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -1654,6 +1654,14 @@ ddg_goodie_test(
             result => '4 * 10<sup>-9</sup> millimeters'
         }
     ),
+    'how many megabytes in a gigabyte?' => test_zci(
+        '1 gigabyte = 1000 megabytes',
+        structured_answer => {
+            input => ['1 gigabyte'],
+            operation => 'convert',
+            result => '1000 megabytes'
+        }
+    ),
 
     # Intentionally untriggered
     '5 inches in 5 meters'            => undef,


### PR DESCRIPTION
Currently on production this answer is wrong:
![999](https://cloud.githubusercontent.com/assets/978048/13196792/fd5290d0-d7d0-11e5-8d39-279fd282cb7b.png)

On my older version of `Math::BigFloat` it had the same behaviour, however updating the dependency fixes it. It's probably worth having these tests in anyway