### PR TITLE
New Slack Mac Cheat Sheet

### DIFF
--- a/share/goodie/cheat_sheets/json/slack-mac.json
+++ b/share/goodie/cheat_sheets/json/slack-mac.json
@@ -1,0 +1,161 @@
+{
+  "id": "slack_cheat_sheet_mac",
+  "name": "Slack",
+  "description": "Slack is a team collaboration tool",
+  "metadata": {
+    "sourceName": "Slack",
+    "sourceUrl": "https://get.slack.help/hc/en-us/articles/201374536-Slack-keyboard-shortcuts"
+  },
+  "section_order": [
+    "Navigation",
+    "Switching teams",
+    "Marking messages read or unread",
+    "Message shortcuts",
+    "Files & snippets"
+  ],
+  "template_type": "keyboard",
+  "sections": {
+    "Navigation": [
+      {
+        "key": "[⌘] [/]",
+        "val": "Open a quick list of keyboard shortcuts"
+      },
+      {
+        "key": "[⌘] [+] or [⌘] [-]",
+        "val": "Increase or decrease font size (Windows)"
+      },
+      {
+        "key": "[⌘] [k]",
+        "val": "Open quick switcher"
+      },
+      {
+        "key": "[Alt] [↑]",
+        "val": "Previous channel/DM"
+      },
+      {
+        "key": "[Alt] [↓]",
+        "val": "Next channel/DM"
+      },
+      {
+        "key": "[Alt] [Shift] [↑]",
+        "val": "Previous channel/DM with unread messages"
+      },
+      {
+        "key": "[Alt] [Shift] [↓]",
+        "val": "Next channel/DM with unread messages"
+      },
+      {
+        "key": "[Alt] [←]",
+        "val": "Previous channel in your history"
+      },
+      {
+        "key": "[Alt] [→]",
+        "val": "Next channel in your history"
+      },
+      {
+        "key": "[⌘] [,]",
+        "val": "Open Preferences"
+      },
+      {
+        "key": "[⌘] [.]",
+        "val": "Toggle right pane open or closed"
+      },
+      {
+        "key": "[⌘] [Shift] [I]",
+        "val": "Open Channel info pane"
+      },
+      {
+        "key": "[⌘] [Shift] [M]",
+        "val": "Open Recent Mentions"
+      },
+      {
+        "key": "[⌘] [Shift] [E]",
+        "val": "Open Team Directory"
+      },
+      {
+        "key": "[⌘] [Shift] [S]",
+        "val": "Open Starred Items"
+      }
+    ],
+    "Switching teams": [
+      {
+        "key": "[⌘] [Shift] [\\[]",
+        "val": "Switch to previous team"
+      },
+      {
+        "key": "[⌘] [Shift] [\\]]",
+        "val": "Switch to next team"
+      },
+      {
+        "key": "[⌘] [number]",
+        "val": "Switch to specific team"
+      }
+    ],
+    "Marking messages read or unread": [
+      {
+        "key": "[Esc]",
+        "val": "Mark all messages in current channel or DM as read"
+      },
+      {
+        "key": "[Shift] [Esc]",
+        "val": "Mark all messages in all channels and DMs as read"
+      },
+      {
+        "key": "[Alt] and click on message",
+        "val": "Set a message as your oldest unread message"
+      }
+    ],
+    "Message shortcuts": [
+      {
+        "key": "[↑] in empty messag field",
+        "val": "Edit your last message in the current channel"
+      },
+      {
+        "key": "[Page Up] or [Page Down], [Home] or [End]",
+        "val": "Scroll through your messages (toggle this in Preferences)"
+      },
+      {
+        "key": "[Tab]",
+        "val": "Reprint the last slash command you entered"
+      },
+      {
+        "key": "[character] [Tab] or [@character] [Tab]",
+        "val": "Autocomplete @username beginning with [character]"
+      },
+      {
+        "key": "[#channel] [Tab]",
+        "val": "Autocomplete channel beginning with [character]"
+      },
+      {
+        "key": "[:channel] [Tab]",
+        "val": "Autocomplete emoji beginning with [character]"
+      },
+      {
+        "key": "[Shift] [↑] in input field",
+        "val": "Highlight text to the beginning of the current line"
+      },
+      {
+        "key": "[Shift] [↓] in input field",
+        "val": "Highlight text to the end of the current line"
+      },
+      {
+        "key": "[Shift] [Enter] in input field",
+        "val": "Create a new line"
+      }
+    ],
+    "Files & snippets": [
+      {
+        "key": "[⌘] [U]",
+        "val": "Upload a file"
+      },
+      {
+        "key": "[⌘] [Shift] [Enter]",
+        "val": "Create a new Snippet"
+      },
+      {
+        "key": "[Shift] [⌘] [V]",
+        "val": "Paste your clipboard contents as a new text Snippet"
+      }
+    ]
+  }
+}

--- a/share/goodie/cheat_sheets/json/slack-mac.json
+++ b/share/goodie/cheat_sheets/json/slack-mac.json
@@ -1,5 +1,5 @@
 {
-  "id": "slack_cheat_sheet_mac",
+  "id": "slack_mac_cheat_sheet",
   "name": "Slack",
   "description": "Slack is a team collaboration tool",
   "metadata": {

--- a/share/goodie/cheat_sheets/json/slack.json
+++ b/share/goodie/cheat_sheets/json/slack.json
@@ -107,7 +107,7 @@
     ],
     "Message shortcuts": [
       {
-        "key": "[↑] in empty messag field",
+        "key": "[↑] in empty message field",
         "val": "Edit your last message in the current channel"
       },
       {

--- a/share/goodie/cheat_sheets/json/slack.json
+++ b/share/goodie/cheat_sheets/json/slack.json
@@ -107,7 +107,7 @@
     ],
     "Message shortcuts": [
       {
-        "key": "[↑] in empty message field",
+        "key": "[↑] in empty messag field",
         "val": "Edit your last message in the current channel"
       },
       {


### PR DESCRIPTION
New Slack Cheat Sheet containing keyboard shortcuts for Mac.

IA Page: https://duck.co/ia/view/slack_mac_cheat_sheet