### PR TITLE
Remove redundant and/or irrelevant aliases from cheat sheets

### DIFF
--- a/share/goodie/cheat_sheets/json/chrome.json
+++ b/share/goodie/cheat_sheets/json/chrome.json
@@ -7,10 +7,7 @@
         "sourceUrl": "https://support.google.com/chrome/answer/157179?hl=en"
     },
     "aliases": [
-        "google chrome",
-        "chrome keyboard shortcuts",
-        "google chrome keyboard shortcuts",
-        "chrome shortcuts"
+        "google chrome"
     ],
     "template_type": "keyboard",
     "section_order": [  

--- a/share/goodie/cheat_sheets/json/common-escape-sequences.json
+++ b/share/goodie/cheat_sheets/json/common-escape-sequences.json
@@ -9,7 +9,14 @@
   },
 
   "aliases": [
-    "common escape sequence", "common escape seq", "python escape sequences", "java escape sequences", "javascript escape sequences", "c escape sequences", "c++ escape sequences", "c# escape sequences"
+    "common escape sequence",
+    "common escape seq",
+    "python escape sequences",
+    "java escape sequences",
+    "javascript escape sequences",
+    "c escape sequences",
+    "c++ escape sequences",
+    "c# escape sequences"
   ],
 
   "template_type": "keyboard",

--- a/share/goodie/cheat_sheets/json/drush.json
+++ b/share/goodie/cheat_sheets/json/drush.json
@@ -6,9 +6,6 @@
         "sourceName": "Drush Commands",
         "sourceUrl": "http://drushcommands.com"
     },
-    "aliases": [
-        "drush commands"
-    ],
     "template_type": "terminal",
     "section_order": [
         "Project manager commands",

--- a/share/goodie/cheat_sheets/json/duckduckgo.json
+++ b/share/goodie/cheat_sheets/json/duckduckgo.json
@@ -8,8 +8,8 @@
         "Move around"
     ],
      "aliases": [
-        "duck duck go shortcuts",
-        "ddg shortcuts"
+        "duck duck go",
+        "ddg"
     ],
     "sections": {
         "Open results": [

--- a/share/goodie/cheat_sheets/json/game-of-life.json
+++ b/share/goodie/cheat_sheets/json/game-of-life.json
@@ -9,7 +9,9 @@
     },
 
     "aliases": [
-        "gol", "conways game", "conway's game"
+        "gol",
+        "conways game",
+        "conway's game"
     ],
 
     "template_type": "reference",

--- a/share/goodie/cheat_sheets/json/jira.json
+++ b/share/goodie/cheat_sheets/json/jira.json
@@ -13,10 +13,6 @@
         "Agile",
         "Issue Actions"
     ],
-    "aliases": [
-        "jira shortcuts",
-        "jira keyboard shortcuts"
-    ],
     "sections": {
         "Global": [
             {

--- a/share/goodie/cheat_sheets/json/language/arabic.json
+++ b/share/goodie/cheat_sheets/json/language/arabic.json
@@ -8,7 +8,7 @@
    },
 
    "aliases": [
-       "arabic phrases", "english to arabic", "basic arabic phrases", "basic arabic"
+       "english to arabic"
    ],
 
    "template_type": "language",

--- a/share/goodie/cheat_sheets/json/language/arabic.json
+++ b/share/goodie/cheat_sheets/json/language/arabic.json
@@ -7,10 +7,6 @@
       "sourceUrl" : "http://www.linguanaut.com/english_arabic.htm"
    },
 
-   "aliases": [
-       "english to arabic"
-   ],
-
    "template_type": "language",
    "section_order" : [
       "Basics",

--- a/share/goodie/cheat_sheets/json/language/armenian.json
+++ b/share/goodie/cheat_sheets/json/language/armenian.json
@@ -9,8 +9,7 @@
     },
 
     "aliases": [
-        "armo",
-        "english to armenian"
+        "armo"
     ],
 
     "template_type": "language",

--- a/share/goodie/cheat_sheets/json/language/armenian.json
+++ b/share/goodie/cheat_sheets/json/language/armenian.json
@@ -9,7 +9,8 @@
     },
 
     "aliases": [
-        "armenian phrases", "armo phrases", "english to armenian", "basic armenian phrases", "basic armenian"
+        "armo",
+        "english to armenian"
     ],
 
     "template_type": "language",

--- a/share/goodie/cheat_sheets/json/language/assamese.json
+++ b/share/goodie/cheat_sheets/json/language/assamese.json
@@ -7,7 +7,7 @@
       "sourceUrl" : "http://www.omniglot.com/language/phrases/assamese.php"
    },
    "aliases": [
-       "assamese phrases", "english to assamese", "basic assamese phrases", "basic assamese"
+       "english to assamese"
    ],
    "template_type": "language",
    "section_order" : [

--- a/share/goodie/cheat_sheets/json/language/assamese.json
+++ b/share/goodie/cheat_sheets/json/language/assamese.json
@@ -6,9 +6,6 @@
       "sourceName" : "Omniglot",
       "sourceUrl" : "http://www.omniglot.com/language/phrases/assamese.php"
    },
-   "aliases": [
-       "english to assamese"
-   ],
    "template_type": "language",
    "section_order" : [
       "Basics",

--- a/share/goodie/cheat_sheets/json/language/bengali.json
+++ b/share/goodie/cheat_sheets/json/language/bengali.json
@@ -7,7 +7,7 @@
       "sourceUrl" : "http://www.omniglot.com/language/phrases/bengali.php"
    },
    "aliases": [
-       "Bengali phrases", "english to bengali", "basic bengali phrases", "basic bengali"
+       "english to bengali"
    ],
    "template_type": "language",
    "section_order" : [

--- a/share/goodie/cheat_sheets/json/language/bengali.json
+++ b/share/goodie/cheat_sheets/json/language/bengali.json
@@ -6,9 +6,6 @@
       "sourceName" : "Omniglot",
       "sourceUrl" : "http://www.omniglot.com/language/phrases/bengali.php"
    },
-   "aliases": [
-       "english to bengali"
-   ],
    "template_type": "language",
    "section_order" : [
       "Basics",

--- a/share/goodie/cheat_sheets/json/language/bulgarian.json
+++ b/share/goodie/cheat_sheets/json/language/bulgarian.json
@@ -5,9 +5,6 @@
       "sourceName" : "Linguanaut",
       "sourceUrl" : "http://www.linguanaut.com/english_bulgarian.htm"
    },
-   "aliases": [
-       "english to bulgarian"
-   ],
    "template_type": "language",
    "section_order" : [
       "Basics",

--- a/share/goodie/cheat_sheets/json/language/bulgarian.json
+++ b/share/goodie/cheat_sheets/json/language/bulgarian.json
@@ -6,7 +6,7 @@
       "sourceUrl" : "http://www.linguanaut.com/english_bulgarian.htm"
    },
    "aliases": [
-       "bulgarian phrases", "english to bulgarian", "basic bulgarian phrases", "basic bulgarian"
+       "english to bulgarian"
    ],
    "template_type": "language",
    "section_order" : [

--- a/share/goodie/cheat_sheets/json/language/cantonese.json
+++ b/share/goodie/cheat_sheets/json/language/cantonese.json
@@ -7,7 +7,7 @@
         "sourceUrl": "http://www.linguanaut.com/english_cantonese.htm"
     },
 	"aliases": [
-        "cantonese words", "cantonese phrases", "basic cantonese words", "basic cantonese phrases", "basic cantonese"
+        "cantonese words"
     ],
     "template_type": "language",
     "section_order" : [

--- a/share/goodie/cheat_sheets/json/language/czech.json
+++ b/share/goodie/cheat_sheets/json/language/czech.json
@@ -5,9 +5,6 @@
       "sourceName" : "Local Lingo",
       "sourceUrl" : "http://www.locallingo.com/czech/phrases/"
    },
-   "aliases": [
-       "english to czech"
-   ],
    "template_type": "language",
    "section_order" : [
       "Basics",

--- a/share/goodie/cheat_sheets/json/language/czech.json
+++ b/share/goodie/cheat_sheets/json/language/czech.json
@@ -6,7 +6,7 @@
       "sourceUrl" : "http://www.locallingo.com/czech/phrases/"
    },
    "aliases": [
-       "czech phrases", "english to czech", "basic czech phrases", "basic czech"
+       "english to czech"
    ],
    "template_type": "language",
    "section_order" : [

--- a/share/goodie/cheat_sheets/json/language/dutch.json
+++ b/share/goodie/cheat_sheets/json/language/dutch.json
@@ -5,9 +5,6 @@
       "sourceName" : "Dummies",
       "sourceUrl" : "http://www.dummies.com/how-to/content/dutch-for-dummies-cheat-sheet.html"
    },
-   "aliases": [
-       "english to dutch"
-   ],
    "template_type": "language",
    "section_order" : [
       "Basics",

--- a/share/goodie/cheat_sheets/json/language/dutch.json
+++ b/share/goodie/cheat_sheets/json/language/dutch.json
@@ -6,7 +6,7 @@
       "sourceUrl" : "http://www.dummies.com/how-to/content/dutch-for-dummies-cheat-sheet.html"
    },
    "aliases": [
-       "dutch phrases", "english to dutch", "basic dutch phrases", "basic dutch"
+       "english to dutch"
    ],
    "template_type": "language",
    "section_order" : [

--- a/share/goodie/cheat_sheets/json/language/french.json
+++ b/share/goodie/cheat_sheets/json/language/french.json
@@ -6,9 +6,6 @@
         "sourceName": "Linguanaut",
         "sourceUrl": "http://www.linguanaut.com/english_french.htm"
     },
-    "aliases": [
-        "english to french"
-    ],
     "template_type": "language",
     "section_order": ["Basics", "Getting Help", "Travelling", "Etiquette", "Going out for dinner"],
     "sections": {

--- a/share/goodie/cheat_sheets/json/language/french.json
+++ b/share/goodie/cheat_sheets/json/language/french.json
@@ -6,7 +6,9 @@
         "sourceName": "Linguanaut",
         "sourceUrl": "http://www.linguanaut.com/english_french.htm"
     },
-    "aliases": ["french phrases", "english to french", "basic french phrases", "basic french"],
+    "aliases": [
+        "english to french"
+    ],
     "template_type": "language",
     "section_order": ["Basics", "Getting Help", "Travelling", "Etiquette", "Going out for dinner"],
     "sections": {

--- a/share/goodie/cheat_sheets/json/language/german.json
+++ b/share/goodie/cheat_sheets/json/language/german.json
@@ -6,7 +6,7 @@
       "sourceUrl" : "http://www.linguanaut.com/english_german.htm"
    },
    "aliases": [
-       "german phrases", "english to german", "basic german phrases", "basic german"
+       "english to german"
    ],
    "template_type": "language",
    "section_order" : [

--- a/share/goodie/cheat_sheets/json/language/german.json
+++ b/share/goodie/cheat_sheets/json/language/german.json
@@ -5,9 +5,6 @@
       "sourceName" : "Linguanaut",
       "sourceUrl" : "http://www.linguanaut.com/english_german.htm"
    },
-   "aliases": [
-       "english to german"
-   ],
    "template_type": "language",
    "section_order" : [
       "Basics",

--- a/share/goodie/cheat_sheets/json/language/hindi.json
+++ b/share/goodie/cheat_sheets/json/language/hindi.json
@@ -7,7 +7,6 @@
         "sourceUrl": "http://www.linguanaut.com/english_hindi.htm"
     },
     "aliases": [
-        "english to hindi",
         "useful hindi"
     ],
     "template_type": "language",

--- a/share/goodie/cheat_sheets/json/language/hindi.json
+++ b/share/goodie/cheat_sheets/json/language/hindi.json
@@ -7,7 +7,8 @@
         "sourceUrl": "http://www.linguanaut.com/english_hindi.htm"
     },
     "aliases": [
-        "hindi phrases", "english to hindi", "basic hindi phrases", "basic hindi", "useful hindi phrases"
+        "english to hindi",
+        "useful hindi"
     ],
     "template_type": "language",
     "section_order": [

--- a/share/goodie/cheat_sheets/json/language/kannada.json
+++ b/share/goodie/cheat_sheets/json/language/kannada.json
@@ -9,7 +9,6 @@
     },
 
     "aliases": [
-       "english to kannada",
        "basic kannada"
     ],
 

--- a/share/goodie/cheat_sheets/json/language/malayalam.json
+++ b/share/goodie/cheat_sheets/json/language/malayalam.json
@@ -7,9 +7,7 @@
       "sourceUrl" : "http://www.pravasimalayalam.com/index.shtml"
    },
    "aliases": [
-       "english to malayalam",
-       "kairali",
-       "english to kairali"
+       "kairali"
    ],
    "template_type": "language",
    "section_order" : [

--- a/share/goodie/cheat_sheets/json/language/malayalam.json
+++ b/share/goodie/cheat_sheets/json/language/malayalam.json
@@ -7,15 +7,9 @@
       "sourceUrl" : "http://www.pravasimalayalam.com/index.shtml"
    },
    "aliases": [
-       "malayalam phrases",
        "english to malayalam",
-       "basic malayalam phrases",
-       "basic malayalam",
        "kairali",
-       "kairali phrases",
-       "english to kairali",
-       "basic kairali phrases",
-       "basic kairali"
+       "english to kairali"
    ],
    "template_type": "language",
    "section_order" : [

--- a/share/goodie/cheat_sheets/json/language/marathi.json
+++ b/share/goodie/cheat_sheets/json/language/marathi.json
@@ -6,9 +6,6 @@
       "sourceName" : "Omniglot",
       "sourceUrl" : "http://www.omniglot.com/language/phrases/marathi.php"
    },
-   "aliases": [
-       "english to marathi"
-   ],
    "template_type": "language",
    "section_order" : [
       "Etiquette",

--- a/share/goodie/cheat_sheets/json/language/marathi.json
+++ b/share/goodie/cheat_sheets/json/language/marathi.json
@@ -7,8 +7,7 @@
       "sourceUrl" : "http://www.omniglot.com/language/phrases/marathi.php"
    },
    "aliases": [
-       "marathi phrases", "english to marathi",
-       "basic marathi phrases", "basic marathi"
+       "english to marathi"
    ],
    "template_type": "language",
    "section_order" : [

--- a/share/goodie/cheat_sheets/json/language/minionese.json
+++ b/share/goodie/cheat_sheets/json/language/minionese.json
@@ -7,7 +7,7 @@
         "sourceUrl" : "http://minionpedia.wikia.com/wiki/Dictionary"
     },
     "aliases": [
-        "minionese", "minion language"
+        "minion language"
     ],
     "template_type": "language",
     "section_order": [

--- a/share/goodie/cheat_sheets/json/language/polish.json
+++ b/share/goodie/cheat_sheets/json/language/polish.json
@@ -5,7 +5,9 @@
         "sourceName": "Mówić po polsku",
         "sourceUrl": "http://mowicpopolsku.com"
     },
-    "aliases": ["polish phrases", "english to polish", "basic polish phrases", "basic polish"],
+    "aliases": [
+        "english to polish"
+    ],
     "template_type": "language",
     "section_order": ["Greeting & Farewell", "General Conversation", "Communication", "Introducing Yourself"],
     "description": "Basic Polish phrases",

--- a/share/goodie/cheat_sheets/json/language/polish.json
+++ b/share/goodie/cheat_sheets/json/language/polish.json
@@ -5,9 +5,6 @@
         "sourceName": "Mówić po polsku",
         "sourceUrl": "http://mowicpopolsku.com"
     },
-    "aliases": [
-        "english to polish"
-    ],
     "template_type": "language",
     "section_order": ["Greeting & Farewell", "General Conversation", "Communication", "Introducing Yourself"],
     "description": "Basic Polish phrases",

--- a/share/goodie/cheat_sheets/json/language/portuguese.json
+++ b/share/goodie/cheat_sheets/json/language/portuguese.json
@@ -6,7 +6,9 @@
         "sourceName": "dummies",
         "sourceUrl": "http://www.dummies.com/how-to/content/portuguese-for-dummies-cheat-sheet.html"
     },
-    "aliases": ["portuguese phrases", "english to portuguese", "basic portuguese phrases", "basic portuguese"],
+    "aliases": [
+        "english to portuguese"
+    ],
     "template_type": "reference",
     "section_order": ["Basics", "Getting Help", "Travelling", "Etiquette", "Going out for dinner"],
     "sections": {

--- a/share/goodie/cheat_sheets/json/language/portuguese.json
+++ b/share/goodie/cheat_sheets/json/language/portuguese.json
@@ -6,9 +6,6 @@
         "sourceName": "dummies",
         "sourceUrl": "http://www.dummies.com/how-to/content/portuguese-for-dummies-cheat-sheet.html"
     },
-    "aliases": [
-        "english to portuguese"
-    ],
     "template_type": "reference",
     "section_order": ["Basics", "Getting Help", "Travelling", "Etiquette", "Going out for dinner"],
     "sections": {

--- a/share/goodie/cheat_sheets/json/language/slovak.json
+++ b/share/goodie/cheat_sheets/json/language/slovak.json
@@ -6,7 +6,7 @@
       "sourceUrl" : "http://www.linguanaut.com/english_slovak.htm"
    },
    "aliases": [
-       "slovak phrases", "english to slovak", "basic slovak phrases", "basic slovak"
+       "english to slovak"
    ],
    "template_type": "language",
    "section_order" : [

--- a/share/goodie/cheat_sheets/json/language/slovak.json
+++ b/share/goodie/cheat_sheets/json/language/slovak.json
@@ -5,9 +5,6 @@
       "sourceName" : "Linguanaut",
       "sourceUrl" : "http://www.linguanaut.com/english_slovak.htm"
    },
-   "aliases": [
-       "english to slovak"
-   ],
    "template_type": "language",
    "section_order" : [
       "Basics",

--- a/share/goodie/cheat_sheets/json/language/tamil.json
+++ b/share/goodie/cheat_sheets/json/language/tamil.json
@@ -6,9 +6,6 @@
     "sourceName": "Linguanaut",
     "sourceUrl": "http://www.linguanaut.com/english_tamil.html"
   },
-  "aliases": [
-    "english to tamil"
-  ],
   "template_type": "language",
   "section_order": [
     "Etiquette",

--- a/share/goodie/cheat_sheets/json/language/tamil.json
+++ b/share/goodie/cheat_sheets/json/language/tamil.json
@@ -7,10 +7,7 @@
     "sourceUrl": "http://www.linguanaut.com/english_tamil.html"
   },
   "aliases": [
-    "tamil phrases",
-    "english to tamil",
-    "basic tamil phrases",
-    "basic tamil"
+    "english to tamil"
   ],
   "template_type": "language",
   "section_order": [

--- a/share/goodie/cheat_sheets/json/mainframe.json
+++ b/share/goodie/cheat_sheets/json/mainframe.json
@@ -9,8 +9,7 @@
     },
     "aliases": [
         "main frame",
-        "mainframe cli",
-        "main frame commands"
+        "mainframe cli"
     ],
     "section_order": [
 	"Job Entry Subsystem 2 (JES2)",
@@ -124,7 +123,7 @@
             {
                 "key": "D ASM",
                 "val": "Display Page Data Set Information"
-            }, 
+            },
             {
                 "key": "D IPLINFO",
                 "val": "Display IPL information"

--- a/share/goodie/cheat_sheets/json/openstack.json
+++ b/share/goodie/cheat_sheets/json/openstack.json
@@ -9,8 +9,7 @@
     },
     "aliases": [
         "open stack",
-        "open stack cli",
-        "open stack commands"
+        "open stack cli"
     ],
     "template_type" : "terminal",
     "section_order": [


### PR DESCRIPTION
This removes a bunch of invalid, incorrect, redundant etc... aliases.

As @mintsoft points out, some of the triggers thrown away will reduce functionality until #2170 is merged, so we might want to wait for that.
