### PR TITLE
New Republic of Ireland counties cheat sheet - goodie

### DIFF
--- a/share/goodie/cheat_sheets/counties-of-ireland.json
+++ b/share/goodie/cheat_sheets/counties-of-ireland.json
@@ -1,0 +1,169 @@
+{
+    "id": "counties_of_ireland_cheat_sheet",
+    "name": "Counties Of Ireland",
+    "description": "The 32 Irish counties along with their county town",
+    "metadata": {
+        "sourceName": "Wikipedia",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Counties_of_Ireland"
+    },
+    "aliases": [
+        "irish states"
+    ],
+    "template_type": "reference",
+    "section_order": [
+        "Connacht",
+        "Leinster",
+        "Munster",
+        "Ulster"
+    ],
+    "sections": {
+        "Connacht": [
+            {
+                "key": "Galway",
+                "val": "Galway"
+            },
+            {
+                "key": "Leitrim",
+                "val": "Carrick-on-Shannon"
+            },
+            {
+                "key": "Mayo",
+                "val": "Castlebar"
+            },
+            {
+                "key": "Roscommon",
+                "val": "Roscommon"
+            },
+            {
+                "key": "Sligo",
+                "val": "Sligo"
+            }
+        ],
+        "Leinster": [
+            {
+                "key": "Carlow",
+                "val": "Carlow"
+            },
+            {
+                "key": "Dublin",
+                "val": "Dublin"
+            },
+            {
+                "key": "Kildare",
+                "val": "Naas"
+            },
+            {
+                "key": "Kilkenny",
+                "val": "Kilkenny"
+            },
+            {
+                "key": "Laois",
+                "val": "Portlaoise"
+            },
+            {
+                "key": "Longford",
+                "val": "Longford"
+            },
+            {
+                "key": "Louth",
+                "val": "Dundalk"
+            },
+            {
+                "key": "Meath",
+                "val": "Navan"
+            },
+            {
+                "key": "Offaly",
+                "val": "Tullamore"
+            },
+            {
+                "key": "Westmeath",
+                "val": "Mullingar"
+            },
+            {
+                "key": "Wexford",
+                "val": "Wexford"
+            },
+            {
+                "key": "Wicklow",
+                "val": "Wicklow"
+            },
+            {
+                "key": "Dún Laoghaire–Rathdown",
+                "val": "Dún Laoghaire"
+            },
+            {
+                "key": "Fingal",
+                "val": "Swords"
+            },
+            {
+                "key": "South Dublin",
+                "val": "Tallaght"
+            }
+        ],
+        "Munster": [
+            {
+                "key": "Clare",
+                "val": "Ennis"
+            },
+            {
+                "key": "Cork",
+                "val": "Cork"
+            },
+            {
+                "key": "Kerry",
+                "val": "Tralee"
+            },
+            {
+                "key": "Limerick",
+                "val": "Limerick"
+            },
+            {
+                "key": "Tipperary",
+                "val": "Nenagh"
+            },
+            {
+                "key": "Waterford",
+                "val": "Dungarvan"
+            }
+        ],
+        "Ulster": [
+            {
+                "key": "Antrim",
+                "val": "Ballymena"
+            },
+            {
+                "key": "Armagh",
+                "val": "Armagh"
+            },
+            {
+                "key": "Cavan",
+                "val": "Cavan"
+            },
+            {
+                "key": "Donegal",
+                "val": "Lifford"
+            },
+            {
+                "key": "Down",
+                "val": "Downpatrick"
+            },
+            {
+                "key": "Fermanagh",
+                "val": "Enniskillen"
+            },
+            {
+                "key": "Londonderry / Derry",
+                "val": "Coleraine"
+            },
+            {
+                "key": "Monaghan",
+                "val": "Monaghan"
+            },
+            {
+                "key": "Tyrone",
+                "val": "Omagh"
+            }
+        ]
+    }
+}

--- a/share/goodie/cheat_sheets/json/counties-of-ni.json
+++ b/share/goodie/cheat_sheets/json/counties-of-ni.json
@@ -1,0 +1,44 @@
+{
+    "id": "counties_of_northern_ireland_cheat_sheet",
+    "name": "Counties in Northern Ireland",
+    "description": "The 6 counties of Northern Ireland along with their county town",
+    "metadata": {
+        "sourceName": "Wikipedia",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Counties_of_Northern_Ireland"
+    },
+    "aliases": [
+        "northern irish states"
+    ],
+    "template_type": "reference",
+    "section_order": [
+        "Northern Ireland"
+    ],
+    "sections": {
+        "Northern Ireland": [
+            {
+                "key": "Antrim",
+                "val": "Ballymena"
+            },
+            {
+                "key": "Armagh",
+                "val": "Armagh"
+            },
+            {
+                "key": "Down",
+                "val": "Downpatrick"
+            },
+            {
+                "key": "Fermanagh",
+                "val": "Enniskillen"
+            },
+            {
+                "key": "Londonderry / Derry",
+                "val": "Coleraine"
+            },
+            {
+                "key": "Tyrone",
+                "val": "Omagh"
+            }
+        ]
+    }
+}

--- a/share/goodie/cheat_sheets/json/counties_of_roi.json
+++ b/share/goodie/cheat_sheets/json/counties_of_roi.json
@@ -1,0 +1,145 @@
+{
+    "id": "counties_of_roi_cheat_sheet",
+    "name": "Counties in the Republic of Ireland",
+    "description": "The 26 counties in the Republic of Ireland along with their county town",
+    "metadata": {
+        "sourceName": "Wikipedia",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Counties_of_Ireland"
+    },
+    "aliases": [
+        "irish states"
+    ],
+    "template_type": "reference",
+    "section_order": [
+        "Connacht",
+        "Leinster",
+        "Munster",
+        "Ulster"
+    ],
+    "sections": {
+        "Connacht": [
+            {
+                "key": "Galway",
+                "val": "Galway"
+            },
+            {
+                "key": "Leitrim",
+                "val": "Carrick-on-Shannon"
+            },
+            {
+                "key": "Mayo",
+                "val": "Castlebar"
+            },
+            {
+                "key": "Roscommon",
+                "val": "Roscommon"
+            },
+            {
+                "key": "Sligo",
+                "val": "Sligo"
+            }
+        ],
+        "Leinster": [
+            {
+                "key": "Carlow",
+                "val": "Carlow"
+            },
+            {
+                "key": "Dublin",
+                "val": "Dublin"
+            },
+            {
+                "key": "Kildare",
+                "val": "Naas"
+            },
+            {
+                "key": "Kilkenny",
+                "val": "Kilkenny"
+            },
+            {
+                "key": "Laois",
+                "val": "Portlaoise"
+            },
+            {
+                "key": "Longford",
+                "val": "Longford"
+            },
+            {
+                "key": "Louth",
+                "val": "Dundalk"
+            },
+            {
+                "key": "Meath",
+                "val": "Navan"
+            },
+            {
+                "key": "Offaly",
+                "val": "Tullamore"
+            },
+            {
+                "key": "Westmeath",
+                "val": "Mullingar"
+            },
+            {
+                "key": "Wexford",
+                "val": "Wexford"
+            },
+            {
+                "key": "Wicklow",
+                "val": "Wicklow"
+            },
+            {
+                "key": "Dún Laoghaire–Rathdown",
+                "val": "Dún Laoghaire"
+            },
+            {
+                "key": "Fingal",
+                "val": "Swords"
+            },
+            {
+                "key": "South Dublin",
+                "val": "Tallaght"
+            }
+        ],
+        "Munster": [
+            {
+                "key": "Clare",
+                "val": "Ennis"
+            },
+            {
+                "key": "Cork",
+                "val": "Cork"
+            },
+            {
+                "key": "Kerry",
+                "val": "Tralee"
+            },
+            {
+                "key": "Limerick",
+                "val": "Limerick"
+            },
+            {
+                "key": "Tipperary",
+                "val": "Nenagh"
+            },
+            {
+                "key": "Waterford",
+                "val": "Dungarvan"
+            }
+        ],
+        "Ulster": [
+            {
+                "key": "Cavan",
+                "val": "Cavan"
+            },
+            {
+                "key": "Donegal",
+                "val": "Lifford"
+            },
+            {
+                "key": "Monaghan",
+                "val": "Monaghan"
+            }
+        ]
+    }
+}

--- a/share/goodie/cheat_sheets/json/elixir.json
+++ b/share/goodie/cheat_sheets/json/elixir.json
@@ -1,0 +1,187 @@
+{
+    "id": "elixir_cheat_sheet",
+    "name": "Elixir",
+    "description": "List of common Elixir constructs and syntax",
+    "template_type": "code",
+    "section_order": [
+        "Operators",
+        "Sigils",
+        "Types",
+        "Example Functions"
+    ],
+
+    "sections": {
+
+        "Operators": [{
+            "val": "strict test for equality",
+            "key": "==="
+        }, {
+            "val": "strict test for inequality",
+            "key": "!=="
+        }, {
+            "val": "short-circuit operator for logical AND",
+            "key": "and"
+        }, {
+            "val": "short-circuit operator for logical OR",
+            "key": "or"
+        }, {
+            "val": "short-circuit operator for logical NOT",
+            "key": "not"
+        }, {
+            "val": "short-circuit operator for exclusive OR",
+            "key": "xor"
+        }, {
+            "val": "relaxed test for equality",
+            "key": "=="
+        }, {
+            "val": "relaxed test for inequality",
+            "key": "!="
+        }, {
+            "val": "relaxed opeartor for logical AND",
+            "key": "&&"
+        }, {
+            "val": "relaxed opeartor for logical OR",
+            "key": "||"
+        }, {
+            "val": "relaxed opeartor for logical NOT",
+            "key": "!"
+        }, {
+            "val": "greater than",
+            "key": ">"
+        }, {
+            "val": "greater than or equal to",
+            "key": ">="
+        }, {
+            "val": "less than",
+            "key": "<"
+        }, {
+            "val": "less than or equal to",
+            "key": "<="
+        }, {
+            "val": "plus",
+            "key": "+"
+        }, {
+            "val": "minus",
+            "key": "-"
+        }, {
+            "val": "multiply",
+            "key": "*"
+        }, {
+            "val": "divide",
+            "key": "/"
+        }, {
+            "val": "integer divide",
+            "key": "div"
+        }, {
+            "val": "integer modulus",
+            "key": "rem"
+        }, {
+            "val": "binary concatenation",
+            "key": "<>"
+        }, {
+            "val": "list addition (concat)",
+            "key": "++"
+        }, {
+            "val": "list subtraction",
+            "key": "--"
+        }, {
+            "val": "checks membership",
+            "key": "in"
+        }, {
+            "val": "no reassign",
+            "key": "^term"
+        }],
+
+
+      "Types": [{
+            "val": "Integer",
+            "key": "1, 2, 3 0xcafe, 0b100, 10_000"
+        }, {
+            "val": "Float",
+            "key": "1.0, 3.1415, 6.02e23"
+        }, {
+            "val": ":foo, :me@home :elixir",
+            "key": "Atom"
+        }, {
+            "val": "Tuple",
+            "key": "{:ok, 11, 'hi'}"
+        }, {
+            "val": "List",
+            "key": "[1, 2, 3], [head|tail], 'abc'"
+        }, {
+            "val": "Keyword List",
+            "key": "[a: :foo, b: :bar]"
+        }, {
+            "val": "Map (no duplicates)",
+            "key": "%{ key => value }"
+        }, {
+            "val": "Binary",
+            "key": "<< 1, 2 >>, \"string\", #{interpolation}"
+        }, {
+            "val": "Truth",
+            "key": "true, false, nil"
+        }, {
+            "val": "Range",
+            "key": "a..b"
+        }],
+
+     "Sigils": [{
+            "val": "Delimiters",
+            "key": "{}, [], (), //, ||, \"\", ''"
+        }, {
+            "val": "string, no interpolation",
+            "key": "~S"
+        }, {
+            "val": "string, with interpolation",
+            "key": "~s"
+        }, {
+            "val": "character list, no interpolation",
+            "key": "~C"
+        }, {
+            "val": "character list, with interpolation",
+            "key": "~c"
+        }, {
+            "val": "regex, with interpolation",
+            "key": "~R"
+        }, {
+            "val": "regex",
+            "key": "~r"
+        }, {
+            "val": "word list, with interpolation",
+            "key": "~W"
+        }, {
+            "val": "word list, without interpolation",
+            "key": "~w"
+        }],
+
+     "Example Functions": [{
+            "val": "returns the number of Unicode graphemes",
+            "key": "String.length/1"
+        }, {
+            "val": "checks if value exists within a collection",
+            "key": "Enum.member?/2"
+        }, {
+            "val": "returns the contents of a file",
+            "key": "File.read!/1"
+        }, {
+            "val": "outputs item(s) to a device",
+            "key": "IO.puts/2"
+        }, {
+            "val": "returns the jaro distance of two strings",
+            "key": "String.jaro_distance/2"
+        }, {
+            "val": "returns an empty map",
+            "key": "Map.new/0"
+        }, {
+            "val": "puts a new key and value into map",
+            "key": "Map.put/3"
+        }, {
+            "val": "returns a random entry from a collection",
+            "key": "Enum.random/1"
+        }, {
+            "val": "calls erlangs timer module with milliseconds",
+            "key": ":timer.sleep/1"
+        }]
+
+    }
+}


### PR DESCRIPTION
## Counties Of The Republic of Ireland

https://duck.co/ia/view/counties_of_the_republic_of_ireland

### Description
This IA lists the 26 counties of the Republic of Ireland by their province. It is coupled with the county town of that county.

### Data Source

https://en.wikipedia.org/wiki/Counties_of_Ireland

### Example Queries

counties of the republic of ireland, roi counties, republic of ireland counties
