### PR TITLE
Currency Cheatsheet: Added currency of Brunei and Azerbaijan

### DIFF
--- a/share/goodie/cheat_sheets/json/currency.json
+++ b/share/goodie/cheat_sheets/json/currency.json
@@ -13,7 +13,7 @@
         "Europe",
         "North America",
         "South America",
-        "Antartica",
+        "Antarctica",
         "Oceania"
     ],
     "aliases": [
@@ -321,7 +321,7 @@
                 "val": "$ (Cook Islands Dollar)"
             }
         ],
-        "Antartica": [
+        "Antarctica": [
             {
                 "key": "French Southern Territories",
                 "val": "€ (Euro)"

--- a/share/goodie/cheat_sheets/json/currency.json
+++ b/share/goodie/cheat_sheets/json/currency.json
@@ -93,6 +93,10 @@
                 "val": "৳ (Taka)"
             },
             {
+                "key": "Brunei",
+                "val": "$ (Darussalam Dollar)"
+            },
+            {
                 "key": "China",
                 "val": "¥ (Renminbi or Yuan)"
             },
@@ -133,6 +137,10 @@
             {
                 "key": "Austria",
                 "val": "€ (Euro)"
+            },
+            {
+                "key": "Azerbaijan",
+                "val": "ман (Manat)"
             },
             {
                 "key": "Belgium",


### PR DESCRIPTION
Added currency of Brunei and Azerbaijan to Currency cheatsheet.

IA Page: https://duck.co/ia/view/currency_cheat_sheet