### PR TITLE
New Counties of Ireland cheat sheet.

### DIFF
--- a/share/goodie/cheat_sheets/json/counties-of-ireland.json
+++ b/share/goodie/cheat_sheets/json/counties-of-ireland.json
@@ -1,20 +1,26 @@
 {
     "id": "counties_of_ireland_cheat_sheet",
     "name": "Counties Of Ireland",
-    "description": "The 32 Irish counties along with their county town",
+    "description": "The 32 Irish counties (26/ROI, 6/NI) along with their county town",
     "metadata": {
         "sourceName": "Wikipedia",
         "sourceUrl": "https://en.wikipedia.org/wiki/Counties_of_Ireland"
     },
     "aliases": [
-        "irish states"
+        "irish states",
+        "states in ireland",
+        "ireland states",
+        "all ireland states",
+        "irish counties",
+        "counties of ireland",
+        "ireland counties"
     ],
     "template_type": "reference",
     "section_order": [
-        "Connacht",
         "Leinster",
-        "Munster",
-        "Ulster"
+        "Connacht",
+        "Ulster",
+        "Munster"
     ],
     "sections": {
         "Connacht": [
@@ -129,11 +135,11 @@
         ],
         "Ulster": [
             {
-                "key": "Antrim",
+                "key": "Antrim (NI)",
                 "val": "Ballymena"
             },
             {
-                "key": "Armagh",
+                "key": "Armagh (NI)",
                 "val": "Armagh"
             },
             {
@@ -145,15 +151,15 @@
                 "val": "Lifford"
             },
             {
-                "key": "Down",
+                "key": "Down (NI)",
                 "val": "Downpatrick"
             },
             {
-                "key": "Fermanagh",
+                "key": "Fermanagh (NI)",
                 "val": "Enniskillen"
             },
             {
-                "key": "Londonderry / Derry",
+                "key": "Londonderry / Derry (NI)",
                 "val": "Coleraine"
             },
             {
@@ -161,7 +167,7 @@
                 "val": "Monaghan"
             },
             {
-                "key": "Tyrone",
+                "key": "Tyrone (NI)",
                 "val": "Omagh"
             }
         ]

--- a/share/goodie/cheat_sheets/json/counties-of-ireland.json
+++ b/share/goodie/cheat_sheets/json/counties-of-ireland.json
@@ -1,0 +1,169 @@
+{
+    "id": "counties_of_ireland_cheat_sheet",
+    "name": "Counties Of Ireland",
+    "description": "The 32 Irish counties along with their county town",
+    "metadata": {
+        "sourceName": "Wikipedia",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Counties_of_Ireland"
+    },
+    "aliases": [
+        "irish states"
+    ],
+    "template_type": "reference",
+    "section_order": [
+        "Connacht",
+        "Leinster",
+        "Munster",
+        "Ulster"
+    ],
+    "sections": {
+        "Connacht": [
+            {
+                "key": "Galway",
+                "val": "Galway"
+            },
+            {
+                "key": "Leitrim",
+                "val": "Carrick-on-Shannon"
+            },
+            {
+                "key": "Mayo",
+                "val": "Castlebar"
+            },
+            {
+                "key": "Roscommon",
+                "val": "Roscommon"
+            },
+            {
+                "key": "Sligo",
+                "val": "Sligo"
+            }
+        ],
+        "Leinster": [
+            {
+                "key": "Carlow",
+                "val": "Carlow"
+            },
+            {
+                "key": "Dublin",
+                "val": "Dublin"
+            },
+            {
+                "key": "Kildare",
+                "val": "Naas"
+            },
+            {
+                "key": "Kilkenny",
+                "val": "Kilkenny"
+            },
+            {
+                "key": "Laois",
+                "val": "Portlaoise"
+            },
+            {
+                "key": "Longford",
+                "val": "Longford"
+            },
+            {
+                "key": "Louth",
+                "val": "Dundalk"
+            },
+            {
+                "key": "Meath",
+                "val": "Navan"
+            },
+            {
+                "key": "Offaly",
+                "val": "Tullamore"
+            },
+            {
+                "key": "Westmeath",
+                "val": "Mullingar"
+            },
+            {
+                "key": "Wexford",
+                "val": "Wexford"
+            },
+            {
+                "key": "Wicklow",
+                "val": "Wicklow"
+            },
+            {
+                "key": "Dún Laoghaire–Rathdown",
+                "val": "Dún Laoghaire"
+            },
+            {
+                "key": "Fingal",
+                "val": "Swords"
+            },
+            {
+                "key": "South Dublin",
+                "val": "Tallaght"
+            }
+        ],
+        "Munster": [
+            {
+                "key": "Clare",
+                "val": "Ennis"
+            },
+            {
+                "key": "Cork",
+                "val": "Cork"
+            },
+            {
+                "key": "Kerry",
+                "val": "Tralee"
+            },
+            {
+                "key": "Limerick",
+                "val": "Limerick"
+            },
+            {
+                "key": "Tipperary",
+                "val": "Nenagh"
+            },
+            {
+                "key": "Waterford",
+                "val": "Dungarvan"
+            }
+        ],
+        "Ulster": [
+            {
+                "key": "Antrim",
+                "val": "Ballymena"
+            },
+            {
+                "key": "Armagh",
+                "val": "Armagh"
+            },
+            {
+                "key": "Cavan",
+                "val": "Cavan"
+            },
+            {
+                "key": "Donegal",
+                "val": "Lifford"
+            },
+            {
+                "key": "Down",
+                "val": "Downpatrick"
+            },
+            {
+                "key": "Fermanagh",
+                "val": "Enniskillen"
+            },
+            {
+                "key": "Londonderry / Derry",
+                "val": "Coleraine"
+            },
+            {
+                "key": "Monaghan",
+                "val": "Monaghan"
+            },
+            {
+                "key": "Tyrone",
+                "val": "Omagh"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Ireland Counties Cheat Sheet

https://duck.co/ia/view/counties_of_ireland

### Description
Ireland traditionally has 32 counties (states) split over 4 provinces; Connacht, Leinster, Munster and Ulster. This IA will list out the counties by their respective province.

### Data Source
https://en.wikipedia.org/wiki/Counties_of_Ireland

### Example Queries 
counties of ireland, ireland counties, irish counties