### PR TITLE
New Counties of Northern Ireland cheat sheet.

### DIFF
--- a/share/goodie/cheat_sheets/json/counties-of-ni.json
+++ b/share/goodie/cheat_sheets/json/counties-of-ni.json
@@ -1,0 +1,44 @@
+{
+    "id": "counties_of_northern_ireland_cheat_sheet",
+    "name": "Counties in Northern Ireland",
+    "description": "The 6 counties of Northern Ireland along with their county town",
+    "metadata": {
+        "sourceName": "Wikipedia",
+        "sourceUrl": "https://en.wikipedia.org/wiki/Counties_of_Northern_Ireland"
+    },
+    "aliases": [
+        "northern irish states"
+    ],
+    "template_type": "reference",
+    "section_order": [
+        "Northern Ireland"
+    ],
+    "sections": {
+        "Northern Ireland": [
+            {
+                "key": "Antrim",
+                "val": "Ballymena"
+            },
+            {
+                "key": "Armagh",
+                "val": "Armagh"
+            },
+            {
+                "key": "Down",
+                "val": "Downpatrick"
+            },
+            {
+                "key": "Fermanagh",
+                "val": "Enniskillen"
+            },
+            {
+                "key": "Londonderry / Derry",
+                "val": "Coleraine"
+            },
+            {
+                "key": "Tyrone",
+                "val": "Omagh"
+            }
+        ]
+    }
+}

--- a/share/goodie/cheat_sheets/json/counties-of-ni.json
+++ b/share/goodie/cheat_sheets/json/counties-of-ni.json
@@ -7,7 +7,11 @@
         "sourceUrl": "https://en.wikipedia.org/wiki/Counties_of_Northern_Ireland"
     },
     "aliases": [
-        "northern irish states"
+        "northern irish states",
+        "ni states",
+        "ni counties",
+        "northern irish counties",
+        "n irish counties"
     ],
     "template_type": "reference",
     "section_order": [


### PR DESCRIPTION
## Counties Of Northern Ireland

https://duck.co/ia/view/counties_of_ni_cheat_sheet

### Description
Northern Ireland has six counties; Antrim, Armagh, Down, Fermanagh, Londonderry / Derry and Tyrone. This IA lists them along with their county town.

### Data Source
https://en.wikipedia.org/wiki/Counties_of_Northern_Ireland

### Example Queries
counties of northern ireland, northern ireland counties, ni counties