### PR TITLE
Unix time format cheat sheet: Corrected one key in Time zone section

### DIFF
--- a/share/goodie/cheat_sheets/json/unix-time-format.json
+++ b/share/goodie/cheat_sheets/json/unix-time-format.json
@@ -43,7 +43,7 @@
             "key": "%V"
         }, {
             "val": "week number of year, with Monday as first day of week (00..53)",
-            "key": "%w"
+            "key": "%W"
         }],
         "Month": [{
             "val": "locale's abbreviated month name (e.g., Jan)",


### PR DESCRIPTION
Corrected one key in Time zone section in unix time format cheat sheet.

IA Page: https://duck.co/ia/view/unix_time_format_cheat_sheet