### PR TITLE
Adobe Bracket: Add missing shortcuts

### DIFF
--- a/share/goodie/cheat_sheets/json/adobe-brackets.json
+++ b/share/goodie/cheat_sheets/json/adobe-brackets.json
@@ -6,7 +6,11 @@
         "sourceName": "GitHub",
         "sourceUrl": "https://github.com/adobe/brackets/wiki/Brackets-Shortcuts"
     },
-    "aliases": ["brackets", "brackets editor", "adobe brackets editor"],
+    "aliases": [
+        "brackets",
+        "brackets editor",
+        "adobe brackets editor"
+    ],
     "template_type": "keyboard",
     "section_order": [
         "Editing",
@@ -82,6 +86,9 @@
             "val": "Copy selected text",
             "key": "[Ctrl] [C]"
         }, {
+            "val": "Collapse current",
+            "key": "[Ctrl] [Alt] [C]"
+        }, {
             "val": "Duplicate",
             "key": "[Ctrl] [D]"
         }, {
@@ -109,6 +116,9 @@
             "val": "Redo",
             "key": "[Ctrl] ( [Y] / [Shift] [Z] )"
         }, {
+            "val": "To Lower Case",
+            "key": "[Ctrl] [L]"
+        }, {
             "val": "Unindent",
             "key": "[Ctrl] [\\]]"
         }, {
@@ -129,6 +139,9 @@
         }, {
             "val": "Find previous",
             "key": "[Shift] [F3]"
+        }, {
+            "val": "Go to Definition",
+            "key": "[Ctrl] [T]"
         }, {
             "val": "Show code hints",
             "key": "[Ctrl] [Space]"
@@ -167,7 +180,7 @@
             "val": "Next document",
             "key": "[Ctrl] [Tab]"
         }, {
-            "val": "Next match",
+            "val": "Previous match",
             "key": "[Alt] [↑]"
         }],
         "Debug": [{


### PR DESCRIPTION
Added missing shortcuts and corrected shortcut.

IA Page: [https://duck.co/ia/view/adobe_brackets_cheat_sheet](https://duck.co/ia/view/adobe_brackets_cheat_sheet)