### PR TITLE
BBCode cheat sheet: Corrected command for making text bold

### DIFF
--- a/share/goodie/cheat_sheets/json/bbcode.json
+++ b/share/goodie/cheat_sheets/json/bbcode.json
@@ -17,7 +17,7 @@
     "sections": {
         "Text Formatting": [
             {
-                "key": "\\[b\\]\\{text\\}\\[b\\]",
+                "key": "\\[b\\]\\{text\\}\\[/b\\]",
                 "val": "Makes {text} bold"
             },
             {


### PR DESCRIPTION
Corrected command for making text bold in BBCode cheat sheet.

IA Page: https://duck.co/ia/view/bbcode_cheat_sheet