### PR TITLE
Bible books: Fixed typos

### DIFF
--- a/share/goodie/cheat_sheets/json/bible-books.json
+++ b/share/goodie/cheat_sheets/json/bible-books.json
@@ -88,7 +88,7 @@
             },
             {
                 "key": "Ezra",
-                "val": "280 Verses, 10Chapters"
+                "val": "280 Verses, 10 Chapters"
             },
             {
                 "key": "Nehemiah",


### PR DESCRIPTION
Fixed typos in Bible books cheat sheet.

IA Page: https://duck.co/ia/view/bible_books_cheat_sheet