### PR TITLE
Fix typo

### DIFF
--- a/share/goodie/cheat_sheets/json/windows-command-prompt.json
+++ b/share/goodie/cheat_sheets/json/windows-command-prompt.json
@@ -30,7 +30,7 @@
             },
             {
                 "key": "[F2] [Z]",
-                "val": "Repeat part of the pevious command, up to character z"
+                "val": "Repeat part of the previous command, up to character z"
             },
             {
                 "key": "[F3]",


### PR DESCRIPTION
There was a small typo. This PR fixes that.

IA Page: [https://duck.co/ia/view/windows_command_prompt_cheat_sheet](https://duck.co/ia/view/windows_command_prompt_cheat_sheet)