### PR TITLE
C string formatting cheat sheet: Added two more specifiers

### DIFF
--- a/share/goodie/cheat_sheets/json/c-string-formatting.json
+++ b/share/goodie/cheat_sheets/json/c-string-formatting.json
@@ -67,6 +67,14 @@
         "val": "Use shortest representation, %E or %F"
         },
         {
+        "key": "hi",
+        "val": "Signed Integer(Short)"
+        },
+        {
+        "key": "hu",
+        "val": "Unsigned Integer(Short)"
+        },
+        {
         "key": "a",
         "val": "Hexadecimal floating point, lowercase"
         },


### PR DESCRIPTION
Added two more specifiers to c string formatting cheat sheet.

IA Page: https://duck.co/ia/view/c_string_formatting_cheat_sheet