### PR TITLE
Saints Row Cheat sheet: Added two sections Silverlink and DLC

### DIFF
--- a/share/goodie/cheat_sheets/json/saints-row.json
+++ b/share/goodie/cheat_sheets/json/saints-row.json
@@ -13,7 +13,9 @@
    "section_order":[  
       "Player Ability",
       "World",
-      "All Unlockables"
+      "All Unlockables",
+      "Silverlink",
+      "DLC"
    ],
    "sections":{  
       
@@ -135,6 +137,46 @@
          {  
             "val":"Vehicle Smash (smash vehicles easily)",
             "key":"isquishyou"
+         }
+      ],
+      "Silverlink":[
+         {
+            "val":"Golden Gun (one-hit kills)",
+            "key":"goldengun"
+         },
+         {
+            "val":"Rated M++ (everyone killed explodes into blood)",
+            "key":"notrated"
+         },
+         {
+            "val":"Slow Motion ",
+            "key":"slowmo"
+         }
+      ],
+      "DLC":[
+         {
+            "val":"All Super Upgrades",
+            "key":"dlc_sosuper"
+         },
+         {
+            "val":"Infinite Ammo",
+            "key":"dlc_unlimited_ammo"
+         },
+         {
+            "val":"Infinite Clip",
+            "key":"dlc_unlimited_clip"
+         },
+         {
+            "val":"Infinite Mass",
+            "key":"dlc_car_mass"
+         },
+         {
+            "val":"Never Die",
+            "key":"dlc_never_die"
+         },
+         {
+            "val":"Super Power Strength 100%",
+            "key":"dlc_superduper"
          }
       ]
    }


### PR DESCRIPTION
Added two sections Silverlink and DLC to Saints Row Cheat sheet

IA Page: https://duck.co/ia/view/saints_row_cheat_sheet