### PR TITLE
HTTP Status Codes: fix typo in cheat sheet

### DIFF
--- a/share/goodie/cheat_sheets/json/http-status-codes.json
+++ b/share/goodie/cheat_sheets/json/http-status-codes.json
@@ -2,7 +2,15 @@
     "id": "http_status_codes_cheat_sheet",
     "name": "HTTP Status Codes",
     "description": "Informational, Success and Error Codes returned by HTTP",
-    "aliases": ["http status code", "http error code", "http error codes", "http response codes", "http response code", "http response status codes", "http response status code"],
+    "aliases": [
+        "http status code",
+        "http error code",
+        "http error codes",
+        "http response codes",
+        "http response code",
+        "http response status codes",
+        "http response status code"
+    ],
     "metadata": {
         "sourceName": "Cheatography",
         "sourceUrl": "http://www.cheatography.com/kstep/cheat-sheets/http-status-codes/"
@@ -155,7 +163,7 @@
             "val": "Locked",
             "key": "423"
         }, {
-            "val": "Failed Dependancy",
+            "val": "Failed Dependency",
             "key": "424"
         }, {
             "val": "Unordered Collection",


### PR DESCRIPTION
This PR fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/2482

IA Page: [https://duck.co/ia/view/http_status_codes_cheat_sheet](https://duck.co/ia/view/http_status_codes_cheat_sheet)