### PR TITLE
Viml Cheat Sheet: switch to terminal template

### DIFF
--- a/share/goodie/cheat_sheets/json/viml.json
+++ b/share/goodie/cheat_sheets/json/viml.json
@@ -9,7 +9,7 @@
     "aliases": [
         "vim language", "vim scripting", "vim script"
     ],
-    "template_type": "code",
+    "template_type": "terminal",
     "section_order": [
         "Variable Scope",
         "Data Types",


### PR DESCRIPTION
Switching to `terminal` template to better handle long `key` strings

IA Page: https://duck.co/ia/view/viml_cheat_sheet