### PR TITLE
Default port numbers: Added default port numbers for PostgreSQL, Oracle 11g and DB2

### DIFF
--- a/share/goodie/cheat_sheets/json/default-port-numbers.json
+++ b/share/goodie/cheat_sheets/json/default-port-numbers.json
@@ -73,6 +73,15 @@
         }, {
             "val": "Real-time Transport Protocol control protocol (RTCP)",
             "key": "5005"
+        }, {
+            "val": "PostgreSQL",
+            "key": "5432"
+        }, {
+            "val": "Oracle 11g",
+            "key": "1521"
+        }, {
+            "val": "DB2",
+            "key": "50000"
         }]
     }
 }


### PR DESCRIPTION
Default port numbers: Added default port numbers for PostgreSQL, Oracle 11g and DB2

IA Page: https://duck.co/ia/view/default_port_numbers_cheat_sheet