### PR TITLE
Emacs Idris Mode cheat sheet: Added a command and fixed typos

### DIFF
--- a/share/goodie/cheat_sheets/json/emacs-idris-mode.json
+++ b/share/goodie/cheat_sheets/json/emacs-idris-mode.json
@@ -3,7 +3,7 @@
     "name": "Idris-Mode for Emacs",
     "description": "Shortcuts for the Idris-mode of the Emacs editor",
     "metadata": {
-        "sourceName": "GiHub",
+        "sourceName": "GitHub",
         "sourceUrl": "https://github.com/idris-hackers/idris-mode#interactive-editing"
     },
     "template_type": "keyboard",
@@ -106,6 +106,10 @@
             {
                 "key": "[C-c], [C-SPC]",
                 "val": "Complete"
+            },
+            {
+                "key": "[M-x]",
+                "val": "To start idris-repl"
             }
         ],
         "Loading Keys": [
@@ -119,7 +123,7 @@
             },
             {
                 "key": "[C-c], [C-p]",
-                "val": "Load Line Backword"
+                "val": "Load Line Backward"
             }
         ],
         "Manipulate Active Terms": [
@@ -159,11 +163,11 @@
             },
             {
                 "key": "[C-c], [C-b], [i]",
-                "val": "Install Idris Pacakage"
+                "val": "Install Idris Package"
             },
             {
                 "key": "[C-c], [C-b], [C-i]",
-                "val": "Install Idris Pacakage"
+                "val": "Install Idris Package"
             },
             {
                 "key": "[C-c], [C-f]",

--- a/share/goodie/cheat_sheets/json/emacs-idris-mode.json
+++ b/share/goodie/cheat_sheets/json/emacs-idris-mode.json
@@ -108,8 +108,8 @@
                 "val": "Complete"
             },
             {
-                "key": "[M-x]",
-                "val": "To start idris-repl"
+                "key": "[C-h] [m]",
+                "val": "Help for the current modes is available"
             }
         ],
         "Loading Keys": [

--- a/share/goodie/cheat_sheets/json/emacs-idris-mode.json
+++ b/share/goodie/cheat_sheets/json/emacs-idris-mode.json
@@ -108,7 +108,7 @@
                 "val": "Complete"
             },
             {
-                "key": "[C-h] [m]",
+                "key": "[C-h], [m]",
                 "val": "Help for the current modes is available"
             }
         ],


### PR DESCRIPTION
Emacs Idris Mode cheat sheet: Added a command and fixed typos

IA Page: https://duck.co/ia/view/emacs_idris_mode_cheat_sheet