### PR TITLE
ES6 cheatsheet: Removed en-US in source URL

### DIFF
--- a/share/goodie/cheat_sheets/json/es6.json
+++ b/share/goodie/cheat_sheets/json/es6.json
@@ -4,7 +4,7 @@
     "description": "ECMAScript6 (Javascript 2015 specification) syntax and information",
     "metadata": {
         "sourceName": "Mozilla",
-        "sourceUrl": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference"
+        "sourceUrl": "https://developer.mozilla.org/docs/Web/JavaScript/Reference"
     },
     "aliases": [
         "ecmascript6",


### PR DESCRIPTION
This allows the page to automatically redirect for the user's locale.
Suggested by an [eagle-eyed user on Twitter](https://twitter.com/Sphinx_Twitt/status/702029361348743168).