### PR TITLE
ES6 cheat sheet: Added var, return and new constructor syntax information

### DIFF
--- a/share/goodie/cheat_sheets/json/es6.json
+++ b/share/goodie/cheat_sheets/json/es6.json
@@ -34,7 +34,7 @@
             },
             {
                 "val": "Declares a variable, optionally initializing it to a value",
-                "key": "var index = 0;"
+                "key": "\\[= value1 \\[, varname2 ... \\[, varnameN\\]\\]\\];"
             }
         ],
         "Template Strings": [

--- a/share/goodie/cheat_sheets/json/es6.json
+++ b/share/goodie/cheat_sheets/json/es6.json
@@ -31,6 +31,10 @@
             {
                 "val": "Declares a block scope local variable, optionally initializing it to a value",
                 "key": "let index = 0;"
+            },
+            {
+                "val": "Declares a variable, optionally initializing it to a value",
+                "key": "var index = 0;"
             }
         ],
         "Template Strings": [
@@ -93,6 +97,10 @@
             {
                 "val": "The rest parameter syntax allows us to represent an indefinite number of arguments as an array",
                 "key": "function(a, b, ...theArgs) \\{ \\}"
+            },
+            {
+                "val": "Specifies the value to be returned by a function",
+                "key": "return \\[\\[expression\\]\\];"
             }
         ],
         "Arrays": [
@@ -175,6 +183,10 @@
             {
                 "val": "The new.target property detects whether a function or constructor was called using the new operator",
                 "key": "new.target"
+            },
+            {
+                "val": "The new operator creates an instance of a user-defined object type or of one of the built-in object types that has a constructor function",
+                "key": "new constructor\\[(\\[arguments\\])\\]"
             }
         ],
         "Iterations": [


### PR DESCRIPTION
ES6 cheat sheet: Added var, return and new constructor syntax information

IA Page: https://duck.co/ia/view/es6_cheat_sheet