### PR TITLE
C Cheat Sheet: Add octal and hexadecimal escape sequences

### DIFF
--- a/share/goodie/cheat_sheets/json/c.json
+++ b/share/goodie/cheat_sheets/json/c.json
@@ -246,6 +246,14 @@
             {
                 "val": "The “null” byte (backslash-zero)",
                 "key": "\\0"
+            },
+            {
+                "val": "Hexadecimal character code 'nn'",
+                "key": "\xnn"
+            },
+            {
+                "val": "Octal character code 'nn'",
+                "key": "\onn"
             }
         ],
         "Order of Precedence": [

--- a/share/goodie/cheat_sheets/json/c.json
+++ b/share/goodie/cheat_sheets/json/c.json
@@ -249,11 +249,11 @@
             },
             {
                 "val": "Hexadecimal character code 'nn'",
-                "key": "\xnn"
+                "key": "\\xnn"
             },
             {
                 "val": "Octal character code 'nn'",
-                "key": "\onn"
+                "key": "\\onn"
             }
         ],
         "Order of Precedence": [


### PR DESCRIPTION

IA Page: [https://duck.co/ia/view/c_cheat_sheet](https://duck.co/ia/view/c_cheat_sheet)