### PR TITLE
Gnome cheat sheet: Added one keyboard shortcut

### DIFF
--- a/share/goodie/cheat_sheets/json/gnome.json
+++ b/share/goodie/cheat_sheets/json/gnome.json
@@ -115,6 +115,10 @@
                 "key": "[Super] [M]"
             },
             {
+                "val": "Close the message tray",
+                "key": "Esc"
+            },
+            {
                 "val": "Focus the active notification",
                 "key": "[Super] [N]"
             },


### PR DESCRIPTION
Added one keyboard shortcut to Gnome cheat sheet

IA Page: https://duck.co/ia/view/gnome_cheat_sheet