### PR TITLE
Colorado Cheat Sheet: Fix broken link

### DIFF
--- a/share/goodie/cheat_sheets/json/colorado-14ers.json
+++ b/share/goodie/cheat_sheets/json/colorado-14ers.json
@@ -3,8 +3,8 @@
     "name":"Colorado 14ers",
     "description":"Colorado mountains over 14,000 feet",
     "metadata":{
-        "sourceName":"14ers.com",
-        "sourceUrl":"http://14ers.com"
+        "sourceName":"Wikipedia",
+        "sourceUrl":"https://en.wikipedia.org/wiki/List_of_Colorado_fourteeners"
     },
     "aliases":["colorado fourteeners", "co 14ers", "co fourteeners"],
     "template_type":"reference",


### PR DESCRIPTION
This PR fixes the broken link of Colorado cheat sheet.

IA Page: [https://duck.co/ia/view/colorado_14ers_cheat_sheet](https://duck.co/ia/view/colorado_14ers_cheat_sheet)