### PR TITLE
Emacs Idris Cheat Sheet: Add names, types and docstring search command

### DIFF
--- a/share/goodie/cheat_sheets/json/emacs-idris-mode.json
+++ b/share/goodie/cheat_sheets/json/emacs-idris-mode.json
@@ -96,6 +96,10 @@
             {
                 "key": "M-p",
                 "val": "Previous Error"
+            },
+            {
+                "key": "[C-c] [C-h] [a]",
+                "val": "Search names, types, and docstrings for a given string"
             }
         ],
         "General": [


### PR DESCRIPTION
IA Page: https://duck.co/ia/view/emacs_idris_mode_cheat_sheet