### PR TITLE
Improve Cheat Sheet Rendering: Add support for new line and tab

### DIFF
--- a/share/goodie/cheat_sheets/cheat_sheets.js
+++ b/share/goodie/cheat_sheets/cheat_sheets.js
@@ -51,7 +51,9 @@ DDH.cheat_sheets.build = function(ops) {
                 .replace(/\\\[/g, "<lbr>")
                 .replace(/\\\{/g, "<lcbr>")
                 .replace(/\\\]/g, "<rbr>")
-                .replace(/\\\}/g, "<rcbr>");
+                .replace(/\\\}/g, "<rcbr>")
+                .replace(/\n/g, "\\n") //escape new line
+                .replace(/\t/g, "\\t"); //escape tab
 
         // no spaces
         // OR
@@ -79,6 +81,8 @@ DDH.cheat_sheets.build = function(ops) {
                 .replace(/<bks>/g,  "\\")
                 // re-replace escaped brackets
                 .replace(/<lbr>/g,  "[")
+                .replace(/\\n/g,  "<br>") //replace \\n with new line break
+                .replace(/\\t/g,  "&nbsp;&nbsp;") //replace \\t with two blank space
                 .replace(/<lcbr>/g, "{")
                 .replace(/<rbr>/g,  "]")
                 .replace(/<rcbr>/g, "}");

--- a/share/goodie/cheat_sheets/cheat_sheets.js
+++ b/share/goodie/cheat_sheets/cheat_sheets.js
@@ -52,6 +52,7 @@ DDH.cheat_sheets.build = function(ops) {
                 .replace(/\\\{/g, "<lcbr>")
                 .replace(/\\\]/g, "<rbr>")
                 .replace(/\\\}/g, "<rcbr>")
+                .replace(/\\n/g,"<nwln>")
                 .replace(/\n/g, "\\n") //escape new line
                 .replace(/\t/g, "\\t"); //escape tab
 
@@ -83,6 +84,7 @@ DDH.cheat_sheets.build = function(ops) {
                 .replace(/<lbr>/g,  "[")
                 .replace(/\\n/g,  "<br>") //replace \\n with new line break
                 .replace(/\\t/g,  "&nbsp;&nbsp;") //replace \\t with two blank space
+                .replace(/<nwln>/g,"\\n") //replace <nwln> with \\n
                 .replace(/<lcbr>/g, "{")
                 .replace(/<rbr>/g,  "]")
                 .replace(/<rcbr>/g, "}");

--- a/share/goodie/cheat_sheets/cheat_sheets.js
+++ b/share/goodie/cheat_sheets/cheat_sheets.js
@@ -52,6 +52,7 @@ DDH.cheat_sheets.build = function(ops) {
                 .replace(/\\\{/g, "<lcbr>")
                 .replace(/\\\]/g, "<rbr>")
                 .replace(/\\\}/g, "<rcbr>")
+                .replace(/\\t/g,"<tab>")
                 .replace(/\\n/g,"<nwln>")
                 .replace(/\n/g, "\\n") //escape new line
                 .replace(/\t/g, "\\t"); //escape tab
@@ -85,6 +86,7 @@ DDH.cheat_sheets.build = function(ops) {
                 .replace(/\\n/g,  "<br>") //replace \\n with new line break
                 .replace(/\\t/g,  "&nbsp;&nbsp;") //replace \\t with two blank space
                 .replace(/<nwln>/g,"\\n") //replace <nwln> with \\n
+                .replace(/<tab>/g,"\\t") //replace <tab> with \\t
                 .replace(/<lcbr>/g, "{")
                 .replace(/<rbr>/g,  "]")
                 .replace(/<rcbr>/g, "}");


### PR DESCRIPTION
This PR adds support for `\n` and `\t` to cheat sheets.

Fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/2097

Java Cheat sheet after this fix:

<img width="1436" alt="screen shot 2016-02-27 at 2 28 56 am" src="https://cloud.githubusercontent.com/assets/915277/13365586/dcaa45a0-dcfb-11e5-842f-fabc84e64850.png">
