### PR TITLE
CaesarCipher: Add 'How to decode?' response

### DIFF
--- a/lib/DDG/Goodie/CaesarCipher.pm
+++ b/lib/DDG/Goodie/CaesarCipher.pm
@@ -4,9 +4,9 @@ package DDG::Goodie::CaesarCipher;
 use strict;
 use DDG::Goodie;
 
-triggers start => "caesar cipher", "caesar",
-                  "ceasar", "ceasar cipher",
-                  "shift cipher";
+triggers startend => "caesar cipher", "caesar",
+                     "ceasar", "ceasar cipher",
+                     "shift cipher";
 
 zci is_cached => 1;
 zci answer_type => "caesar_cipher";
@@ -15,8 +15,54 @@ my @alphabet = ('a' ... 'z');
 
 my $string_alphabet = join '', @alphabet;
 
+sub build_infobox_element {
+    my $query = shift;
+    my @split = split ' ', $query;
+    return {
+        label => $query,
+        url   => 'https://duckduckgo.com/?q=' . (join '+', @split) . '&ia=answer',
+    };
+}
+
+my $infobox = [ { heading => "Example Queries", },
+                build_infobox_element('caesar cipher 2 text'),
+                build_infobox_element('shift cipher -2 vgzv'),
+                build_infobox_element('caesar cipher 33 secret'),
+                build_infobox_element('caesar cipher -7 zljyla'),
+              ];
+
+my @description_pars = split "\n\n",
+    share('description.txt')->slurp();
+
+my $decode_response = {
+          id   => 'caesar_cipher',
+          name => 'Answer',
+          data => {
+              title            => "How to decode the caesar cipher",
+              infoboxData      => $infobox,
+              description_pars => \@description_pars,
+          },
+          templates => {
+              group   => 'info',
+              moreAt  => 0,
+              options => {
+                  content      => 'DDH.caesar_cipher.content',
+                  chompContent => 1,
+              },
+          },
+      };
+
+sub wants_decode {
+    my $query = shift;
+    return $query =~ /^how to ((de|en)(code|crypt)|use)( (a|the))?|decoder?$/;
+}
+
 handle remainder => sub {
-    return unless $_ =~ /(\-?\d+)\s+([[:ascii:]]+)$/;
+    my $remainder = shift;
+    my $wants_decode = wants_decode($remainder);
+    return "Caesar Cipher", structured_answer => $decode_response if $wants_decode;
+
+    return unless $remainder =~ /(\-?\d+)\s+([[:ascii:]]+)$/;
     my ($shift_val, $to_cipher) = ($1, $2);
 
     my $amount = $shift_val % 26;

--- a/lib/DDG/Goodie/CaesarCipher.pm
+++ b/lib/DDG/Goodie/CaesarCipher.pm
@@ -43,9 +43,12 @@ my $decode_response = {
               infoboxData      => $infobox,
               description_pars => \@description_pars,
           },
+          meta => {
+              sourceUrl  => 'https://en.wikipedia.org/wiki/Caesar_cipher',
+              sourceName => 'Wikipedia',
+          },
           templates => {
               group   => 'info',
-              moreAt  => 0,
               options => {
                   content      => 'DDH.caesar_cipher.content',
                   chompContent => 1,

--- a/lib/DDG/Goodie/CaesarCipher.pm
+++ b/lib/DDG/Goodie/CaesarCipher.pm
@@ -4,9 +4,10 @@ package DDG::Goodie::CaesarCipher;
 use strict;
 use DDG::Goodie;
 
-triggers startend => "caesar cipher", "caesar",
-                     "ceasar", "ceasar cipher",
+triggers startend => "caesar cipher",
+                     "ceasar cipher",
                      "shift cipher";
+triggers start => 'caesar', 'ceasar';
 
 zci is_cached => 1;
 zci answer_type => "caesar_cipher";

--- a/lib/DDG/Goodie/CaesarCipher.pm
+++ b/lib/DDG/Goodie/CaesarCipher.pm
@@ -55,7 +55,7 @@ my $decode_response = {
 
 sub wants_decode {
     my $query = shift;
-    return $query =~ /^how to ((de|en)(code|crypt)|use)( (a|the))?|decoder?$/;
+    return $query =~ /^how to ((de|en)(code|crypt)|use)( (a|the))?|decoder?$/i;
 }
 
 sub perform_caesar {

--- a/lib/DDG/Goodie/CaesarCipher.pm
+++ b/lib/DDG/Goodie/CaesarCipher.pm
@@ -58,13 +58,8 @@ sub wants_decode {
     return $query =~ /^how to ((de|en)(code|crypt)|use)( (a|the))?|decoder?$/;
 }
 
-handle remainder => sub {
-    my $remainder = shift;
-    my $wants_decode = wants_decode($remainder);
-    return "Caesar Cipher", structured_answer => $decode_response if $wants_decode;
-
-    return unless $remainder =~ /(\-?\d+)\s+([[:ascii:]]+)$/;
-    my ($shift_val, $to_cipher) = ($1, $2);
+sub perform_caesar {
+    my ($to_cipher, $shift_val) = @_;
 
     my $amount = $shift_val % 26;
     # This creates the cipher by shifting the alphabet.
@@ -80,6 +75,18 @@ handle remainder => sub {
         }
         $result .= $char;
     }
+    return $result;
+}
+
+handle remainder => sub {
+    my $remainder = shift;
+    my $wants_decode = wants_decode($remainder);
+    return "Caesar Cipher", structured_answer => $decode_response if $wants_decode;
+
+    return unless $remainder =~ /(\-?\d+)\s+([[:ascii:]]+)$/;
+    my ($shift_val, $to_cipher) = ($1, $2);
+
+    my $result = perform_caesar($to_cipher, $shift_val);
 
     return "$result",
       structured_answer => {

--- a/lib/DDG/Goodie/CaesarCipher.pm
+++ b/lib/DDG/Goodie/CaesarCipher.pm
@@ -55,7 +55,7 @@ my $decode_response = {
 
 sub wants_decode {
     my $query = shift;
-    return $query =~ /^how to ((de|en)(code|crypt)|use)( (a|the))?|decoder?$/i;
+    return $query =~ /^how to ((de|en)(code|crypt)|use)( (a|the))?|(de|en)(coder?|crypt(er)?)$/i;
 }
 
 sub perform_caesar {

--- a/share/goodie/caesar_cipher/content.handlebars
+++ b/share/goodie/caesar_cipher/content.handlebars
@@ -1,0 +1,3 @@
+{{#each description_pars}}
+    <p>{{this}}</p>
+{{/each}}

--- a/share/goodie/caesar_cipher/description.txt
+++ b/share/goodie/caesar_cipher/description.txt
@@ -1,0 +1,19 @@
+The Caesar cipher (named after Julius
+Caesar), is one of the most basic ciphers. It is a form of
+substitution cipher in which each letter of the alphabet
+is replaced with another letter a fixed number of places
+before or after it.
+
+If you are given the key for a Caesar cipher, then
+decrypting the message is easy: first take 26 away from
+the key until you are left with a number between 0 and
+25 (add 26 each time for negative keys), then shift each
+letter by the key in the opposite direction. For example,
+if you had the text "zljyla", and you knew the key was 33,
+then taking 26 away from 33 you get 7 - which is between 0
+and 25. Replacing each letter of the message with that 7
+places before it you get the decrypted message "secret".
+
+If you don't know the key you can perform frequency
+analysis on the encrypted message or just try every
+possible key (there's only 26 combinations!).

--- a/share/goodie/caesar_cipher/description.txt
+++ b/share/goodie/caesar_cipher/description.txt
@@ -1,19 +1,17 @@
-The Caesar cipher (named after Julius
-Caesar), is one of the most basic ciphers. It is a form of
-substitution cipher in which each letter of the alphabet
-is replaced with another letter a fixed number of places
+The Caesar cipher (named after Julius Caesar) is one of the most basic
+ciphers. It is a form of substitution cipher in which each letter of
+the alphabet is replaced with another letter a fixed number of places
 before or after it.
 
-If you are given the key for a Caesar cipher, then
-decrypting the message is easy: first take 26 away from
-the key until you are left with a number between 0 and
-25 (add 26 each time for negative keys), then shift each
-letter by the key in the opposite direction. For example,
-if you had the text "zljyla", and you knew the key was 33,
-then taking 26 away from 33 you get 7 - which is between 0
-and 25. Replacing each letter of the message with that 7
-places before it you get the decrypted message "secret".
+If you are given the key for a Caesar cipher, then decrypting the
+message is easy: first take 26 away from the key until you are left
+with a number between 0 and 25 (add 26 each time for negative keys),
+then shift each letter by the resulting number in the opposite
+direction. For example, if you had the text "zljyla", and you knew the
+key was 33, then taking 26 away from 33 you get 7 - which is between 0
+and 25. Replacing each letter of the message with that 7 places before
+it you get the decrypted message "secret".
 
-If you don't know the key you can perform frequency
-analysis on the encrypted message or just try every
-possible key (there's only 26 combinations!).
+If you don't know the key you can perform frequency analysis on the
+encrypted message or just try every possible key (there's only 26
+combinations!).

--- a/t/CaesarCipher.t
+++ b/t/CaesarCipher.t
@@ -12,9 +12,12 @@ my $decode_response = {
           id   => 'caesar_cipher',
           name => 'Answer',
           data => '-ANY-', # We only need to check it is the right template.
+          meta => {
+              sourceUrl  => 'https://en.wikipedia.org/wiki/Caesar_cipher',
+              sourceName => 'Wikipedia',
+          },
           templates => {
               group   => 'info',
-              moreAt  => 0,
               options => {
                   content      => 'DDH.caesar_cipher.content',
                   chompContent => 1,

--- a/t/CaesarCipher.t
+++ b/t/CaesarCipher.t
@@ -62,6 +62,7 @@ ddg_goodie_test(
     'caesar cipher'               => undef,
     # Decoding information tests
     'how to decode a caesar cipher?'   => decode_test(),
+    'How to decode a Caesar cipher?'   => decode_test(),
     'how to use a shift cipher'        => decode_test(),
     'how to encrypt the caesar cipher' => decode_test(),
     'caesar cipher decoder'            => decode_test(),

--- a/t/CaesarCipher.t
+++ b/t/CaesarCipher.t
@@ -66,6 +66,8 @@ ddg_goodie_test(
     'how to use a shift cipher'        => decode_test(),
     'how to encrypt the caesar cipher' => decode_test(),
     'caesar cipher decoder'            => decode_test(),
+    'shift cipher encrypter'           => decode_test(),
+    'shift cipher decrypt'             => decode_test(),
     'how to decode caesar'             => undef,
 );
 

--- a/t/CaesarCipher.t
+++ b/t/CaesarCipher.t
@@ -8,6 +8,24 @@ use DDG::Test::Goodie;
 zci answer_type => 'caesar_cipher';
 zci is_cached   => 1;
 
+my $decode_response = {
+          id   => 'caesar_cipher',
+          name => 'Answer',
+          data => '-ANY-', # We only need to check it is the right template.
+          templates => {
+              group   => 'info',
+              moreAt  => 0,
+              options => {
+                  content      => 'DDH.caesar_cipher.content',
+                  chompContent => 1,
+              },
+          },
+      };
+
+sub decode_response {
+    return "Caesar Cipher", structured_answer => $decode_response;
+}
+
 sub build_structured_answer {
     my ($result, $amount, $to_cipher) = @_;
     return "$result",
@@ -26,6 +44,7 @@ sub build_structured_answer {
 }
 
 sub build_test { test_zci(build_structured_answer(@_)) }
+sub decode_test { test_zci(decode_response()) }
 
 ddg_goodie_test(
     [qw( DDG::Goodie::CaesarCipher )],
@@ -41,6 +60,12 @@ ddg_goodie_test(
     'shift cipher 7 Mxlm mxqm'    => build_test('Test text', 7, 'Mxlm mxqm'),
     'caesar cipher hello'         => undef,
     'caesar cipher'               => undef,
+    # Decoding information tests
+    'how to decode a caesar cipher?'   => decode_test(),
+    'how to use a shift cipher'        => decode_test(),
+    'how to encrypt the caesar cipher' => decode_test(),
+    'caesar cipher decoder'            => decode_test(),
+    'how to decode caesar'             => undef,
 );
 
 done_testing;


### PR DESCRIPTION
I was looking at related queries for `caesar cipher`:

![screenshot from 2016-02-27 10 56 27](https://cloud.githubusercontent.com/assets/8598426/13372583/276cb0e2-dd41-11e5-8cbd-8450b21f16b0.png)

And it turns out people want to know how to decrypt it!

So I've added a new response for queries like `caesar cipher decoder`:

![screenshot from 2016-02-27 10 58 12](https://cloud.githubusercontent.com/assets/8598426/13372591/4b7af246-dd41-11e5-934c-3a93a32a0dee.png)

Which gives an overview of the cipher as well as some example triggers:

![screenshot from 2016-02-27 10 58 20](https://cloud.githubusercontent.com/assets/8598426/13372593/5fe3c2e4-dd41-11e5-8869-43e4c5bdc65d.png)

---
[IA Page](https://duck.co/ia/view/caesar_cipher)