### PR TITLE
Bash Primary Expressions: Use title/subtitle layout

### DIFF
--- a/share/goodie/bash_primary_expressions/content.handlebars
+++ b/share/goodie/bash_primary_expressions/content.handlebars
@@ -1,8 +1,8 @@
-The Bash expression <pre>{{intro}}</pre> results to 
 {{#each results}}
     {{#if text}}
-        {{text}}
+        <b>{{text}}</b>
     {{else}}
         <pre>{{value}}</pre>
     {{/if}}
-{{/each}}
+{{/each}}<br/>
+Bash expression: <pre>{{intro}}</pre>


### PR DESCRIPTION
**Fixes #2299.**
Used a title/subtitle layout as outlined by @moollaza in the issue description.

https://duck.co/ia/view/bash_primary_expressions