### PR TITLE
support "dices" spelling for dice trigger

### DIFF
--- a/lib/DDG/Goodie/Dice.pm
+++ b/lib/DDG/Goodie/Dice.pm
@@ -4,6 +4,7 @@ package DDG::Goodie::Dice;
 
 use strict;
 use DDG::Goodie;
+use Lingua::EN::Numericalize;
 
 triggers start => "roll", "throw";
 
@@ -34,6 +35,9 @@ sub set_num_dice {
     my $num_dice = $_[0];
     my $num_dice_default = $_[1];
     if(defined($num_dice)){
+        if ($num_dice =~ /^[a-zA-Z]+$/) {
+            return str2nbr($num_dice);
+        }
         if ($num_dice ne ''){
             return $num_dice;
         }else{
@@ -76,12 +80,16 @@ handle remainder_lc => sub {
     my $heading = "Random Dice Roll";
     my $total; # total of all dice rolls
     foreach (@values) {
-        if ($_ =~ /^(?:a? ?die|(\d{0,2})\s*dic?es?)$/) {
-            # ex. 'a die', '2 dice', '5dice'
+        if ($_ =~ /^(?:a? ?die|(\d{0,2}|[a-zA-Z]+)\s*dic?es?)$/) {
+            # ex. 'a die', '2 dice', '5dice', 'five dice'
             my @output;
             my $sum = 0;
             my $number_of_dice = set_num_dice($1, 2); # set number of dice, default 2
             my $number_of_faces = 6; # number of utf8_dice
+
+            if ($number_of_dice !~ /^\d+$/) {
+                return;
+            }
             for (1 .. $number_of_dice) { # for all rolls
                 my $roll = roll_die( $number_of_faces ); # roll the die
                 $sum += $roll; # track sum

--- a/lib/DDG/Goodie/Dice.pm
+++ b/lib/DDG/Goodie/Dice.pm
@@ -35,7 +35,7 @@ sub set_num_dice {
     my $num_dice = $_[0];
     my $num_dice_default = $_[1];
     if(defined($num_dice)){
-        if ($num_dice =~ /^[a-zA-Z]+$/) {
+        if ($num_dice =~ /^[a-zA-Z\s\-]+$/) {
             return str2nbr($num_dice);
         }
         if ($num_dice ne ''){
@@ -80,7 +80,7 @@ handle remainder_lc => sub {
     my $heading = "Random Dice Roll";
     my $total; # total of all dice rolls
     foreach (@values) {
-        if ($_ =~ /^(?:a? ?die|(\d{0,2}|[a-zA-Z]+)\s*dic?es?)$/) {
+        if ($_ =~ /^(?:a? ?die|(\d{0,2}|[a-zA-Z\s\-]+)\s*dic?es?)$/) {
             # ex. 'a die', '2 dice', '5dice', 'five dice'
             my @output;
             my $sum = 0;

--- a/lib/DDG/Goodie/Dice.pm
+++ b/lib/DDG/Goodie/Dice.pm
@@ -76,7 +76,7 @@ handle remainder_lc => sub {
     my $heading = "Random Dice Roll";
     my $total; # total of all dice rolls
     foreach (@values) {
-        if ($_ =~ /^(?:a? ?die|(\d{0,2})\s*dic?e)$/) {
+        if ($_ =~ /^(?:a? ?die|(\d{0,2})\s*dic?es?)$/) {
             # ex. 'a die', '2 dice', '5dice'
             my @output;
             my $sum = 0;

--- a/t/Dice.t
+++ b/t/Dice.t
@@ -105,6 +105,39 @@ ddg_goodie_test(
             }
        }
     ),
+
+    # Query with numbers as words
+    "roll five dice" => test_zci(
+        qr/., ., ., ., .$/,
+        structured_answer => {
+            id => 'dice',
+            name => 'Answer',
+            data => '-ANY-',
+            templates => {
+                group => 'text',
+                options => {
+                    subtitle_content => 'DDH.dice.subtitle_content'
+                }
+            }
+       }
+    ),
+    "roll seven dices" => test_zci(
+        qr/., ., ., ., .$/,
+        structured_answer => {
+            id => 'dice',
+            name => 'Answer',
+            data => '-ANY-',
+            templates => {
+                group => 'text',
+                options => {
+                    subtitle_content => 'DDH.dice.subtitle_content'
+                }
+            }
+       }
+    ),
+    # Invalid numeric words
+    "roll foo dice" => undef,
+
     "throw 1d20" => test_zci(
         qr/^\d{1,2}$/,
         structured_answer => {

--- a/t/Dice.t
+++ b/t/Dice.t
@@ -30,6 +30,20 @@ ddg_goodie_test(
             }
        }
     ),
+    'throw dices' => test_zci(
+        qr/^., .$/,
+        structured_answer => {
+            id => 'dice',
+            name => 'Answer',
+            data => '-ANY-',
+            templates => {
+                group => 'text',
+                options => {
+                    subtitle_content => 'DDH.dice.subtitle_content'
+                }
+            }
+       }
+    ),
     'roll dice' => test_zci(
         qr/^., .$/,
         structured_answer => {

--- a/t/Dice.t
+++ b/t/Dice.t
@@ -121,6 +121,34 @@ ddg_goodie_test(
             }
        }
     ),
+    "roll twenty five dice" => test_zci(
+        qr/., ., ., ., .$/,
+        structured_answer => {
+            id => 'dice',
+            name => 'Answer',
+            data => '-ANY-',
+            templates => {
+                group => 'text',
+                options => {
+                    subtitle_content => 'DDH.dice.subtitle_content'
+                }
+            }
+       }
+    ),
+    "roll fifty-four dice" => test_zci(
+        qr/., ., ., ., .$/,
+        structured_answer => {
+            id => 'dice',
+            name => 'Answer',
+            data => '-ANY-',
+            templates => {
+                group => 'text',
+                options => {
+                    subtitle_content => 'DDH.dice.subtitle_content'
+                }
+            }
+       }
+    ),
     "roll seven dices" => test_zci(
         qr/., ., ., ., .$/,
         structured_answer => {


### PR DESCRIPTION
fixes #1255

I didn't include the part about converting "two" into 2, as I wouldn't know where to stop (one, two, three, ten, twenty???)