### PR TITLE
CheatSheets: Improve file name ID check

### DIFF
--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -15,11 +15,17 @@ use List::Util qw(first);
 my $json_dir = "share/goodie/cheat_sheets/json";
 my $json;
 
-sub file_name_to_id {
-    my $file_name = shift;
-    $file_name =~ s/\.json//;
-    $file_name =~ s/-/_/g;
-    return $file_name . "_cheat_sheet";
+sub file_name_id_match {
+    my ($file_name, $id) = @_;
+    my $check_id = $file_name =~ s/\.json//r;
+    $check_id =~ s/-/_/g;
+    $check_id .= '_cheat_sheet';
+    return 0 unless $check_id eq $id;
+    # Check the inverse to make sure no weird cases get through.
+    my $check_file = $id =~ s/_cheat_sheet//r;
+    $check_file =~ s/_/-/g;
+    $check_file .= '.json';
+    return $check_file eq $file_name;
 }
 
 # Iterate over all Cheat Sheet JSON files...
@@ -50,7 +56,7 @@ foreach my $path (glob("$json_dir/*.json")){
 
     ### ID tests ###
     if (my $cheat_id = $json->{id}) {
-        $temp_pass = $cheat_id eq file_name_to_id($file_name);
+        $temp_pass = file_name_id_match($file_name, $cheat_id);
         push(@tests, {msg => "Invalid file name ($file_name) for ID ($cheat_id)", critical => 1, pass => $temp_pass});
     }
 

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -87,8 +87,7 @@ foreach my $path (glob("$json_dir/*.json")){
         if (my $custom = $triggers_yaml->{custom_triggers}->{$cheat_id}) {
             # Duplicate triggers
             foreach my $trigger (flat_triggers($custom)) {
-                $temp_pass = $triggers{$trigger} ? 0 : 1;
-                $triggers{$trigger} = 1;
+                $temp_pass = $triggers{$trigger}++ ? 0 : 1;
                 push(@tests, {msg => "trigger '$trigger' already in use", critical => 1, pass => $temp_pass});
             }
             # Re-adding category

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -10,7 +10,7 @@ use Test::More;
 use Term::ANSIColor;
 use JSON;
 use IO::All;
-use List::Util qw(first);
+use List::Util qw(first none);
 use YAML::XS qw(LoadFile);
 
 my $json_dir = "share/goodie/cheat_sheets/json";
@@ -25,6 +25,7 @@ sub flat_triggers {
     if (my $triggers = $data->{triggers}) {
         return map { @{$_} } (values $triggers);
     }
+    return ();
 }
 
 sub check_trigger_existing {
@@ -86,6 +87,12 @@ foreach my $path (glob("$json_dir/*.json")){
             foreach my $trigger (flat_triggers($custom)) {
                 $temp_pass = check_trigger_existing($trigger);
                 push(@tests, {msg => "trigger '$trigger' already in use", critical => 1, pass => $temp_pass});
+            }
+            my $template_type = $json->{template_type};
+            # Re-adding category
+            foreach my $category (@{$custom->{additional_categories}}) {
+                $temp_pass = none { $_ eq $category } @{$triggers_yaml->{template_map}{$template_type}};
+                push(@tests, {msg => "Category '$category' already assigned", critical => 1, pass => $temp_pass});
             }
         }
     }

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -30,13 +30,6 @@ sub flat_triggers {
     return ();
 }
 
-sub check_trigger_existing {
-    my $trigger = shift;
-    return 0 if $triggers{$trigger};
-    $triggers{$trigger} = 1;
-    return 1;
-}
-
 sub file_name_id_match {
     my ($file_name, $id) = @_;
     my $check_id = $file_name =~ s/\.json//r;
@@ -94,7 +87,8 @@ foreach my $path (glob("$json_dir/*.json")){
         if (my $custom = $triggers_yaml->{custom_triggers}->{$cheat_id}) {
             # Duplicate triggers
             foreach my $trigger (flat_triggers($custom)) {
-                $temp_pass = check_trigger_existing($trigger);
+                $temp_pass = $triggers{$trigger} ? 0 : 1;
+                $triggers{$trigger} = 1;
                 push(@tests, {msg => "trigger '$trigger' already in use", critical => 1, pass => $temp_pass});
             }
             # Re-adding category

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -25,7 +25,7 @@ my $template_map = $triggers_yaml->{template_map};
 sub flat_triggers {
     my $data = shift;
     if (my $triggers = $data->{triggers}) {
-        return map { @{$_} } (values $triggers);
+        return map { @$_ } values $triggers;
     }
     return ();
 }

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -30,17 +30,11 @@ sub flat_triggers {
     return ();
 }
 
-sub file_name_id_match {
-    my ($file_name, $id) = @_;
-    my $check_id = $file_name =~ s/\.json//r;
-    $check_id =~ s/-/_/g;
-    $check_id .= '_cheat_sheet';
-    return 0 unless $check_id eq $id;
-    # Check the inverse to make sure no weird cases get through.
-    my $check_file = $id =~ s/_cheat_sheet//r;
-    $check_file =~ s/_/-/g;
-    $check_file .= '.json';
-    return $check_file eq $file_name;
+sub id_to_file_name {
+    my $id = shift;
+    return unless $id =~ s/_cheat_sheet//;
+    $id =~ s/_/-/g;
+    return $id . '.json';
 }
 
 # Iterate over all Cheat Sheet JSON files...
@@ -71,7 +65,7 @@ foreach my $path (glob("$json_dir/*.json")){
 
     ### ID tests ###
     if (my $cheat_id = $json->{id}) {
-        $temp_pass = file_name_id_match($file_name, $cheat_id);
+        $temp_pass = id_to_file_name($cheat_id) eq $file_name;
         push(@tests, {msg => "Invalid file name ($file_name) for ID ($cheat_id)", critical => 1, pass => $temp_pass});
     }
 


### PR DESCRIPTION
@moollaza I've added in the reverse check to make sure weird cases don't make it through.

/cc @zachthompson 

Fixes #2685.

Adds some new tests:

* ***Critical*** if a trigger is specified that is already in use.
* ***Critical*** if a category is specified that is already assigned via the `template_type`.
* ***Critical*** if a `template_type` is used that is not present in the `template_map`.

---
IA Page: https://duck.co/ia/view/cheat_sheets