### PR TITLE
CheatSheets: Add alias trigger tests

### DIFF
--- a/share/goodie/cheat_sheets/json/duckduckgo-syntax.json
+++ b/share/goodie/cheat_sheets/json/duckduckgo-syntax.json
@@ -7,6 +7,9 @@
     "sourceName": "Duck.co",
     "sourceUrl": "https://duck.co/help/results/syntax"
   },
+  "aliases": [
+    "ddg syntax","duck duck go syntax"
+  ],
   "section_order": [
     "Triggers",
     "Go directly to other sites",

--- a/share/goodie/cheat_sheets/json/duckduckgo-syntax.json
+++ b/share/goodie/cheat_sheets/json/duckduckgo-syntax.json
@@ -7,9 +7,6 @@
     "sourceName": "Duck.co",
     "sourceUrl": "https://duck.co/help/results/syntax"
   },
-  "aliases": [
-    "ddg syntax","duck duck go syntax"
-  ],
   "section_order": [
     "Triggers",
     "Go directly to other sites",

--- a/share/goodie/cheat_sheets/json/sql.json
+++ b/share/goodie/cheat_sheets/json/sql.json
@@ -15,9 +15,8 @@
       "SQL Constraints",
       "Scalar Functions"
    ],
-   "aliases":[  
-      "sql statements",
-       "sql commands"
+   "aliases":[
+      "sql statements"
    ],
    "sections":{  
       "Data Definition Language (DDL)":[  

--- a/share/goodie/cheat_sheets/json/sql.json
+++ b/share/goodie/cheat_sheets/json/sql.json
@@ -16,7 +16,8 @@
       "Scalar Functions"
    ],
    "aliases":[
-      "sql statements"
+      "sql statements",
+       "sql commands"
    ],
    "sections":{  
       "Data Definition Language (DDL)":[  

--- a/share/goodie/cheat_sheets/triggers.yaml
+++ b/share/goodie/cheat_sheets/triggers.yaml
@@ -23,6 +23,9 @@
 #
 # Where "trigger_type" is one of start, end, startend, or any.
 #
+# NOTE: The use of 'any' is highly discouraged as it is unstable and
+# may not perform as expected.
+#
 # NOTE: Categories should be in alphabetical (lexical) order (and preferably the
 # triggers and trigger types as well) - this ensures it is as easy as possible
 # to find relevant categories.

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -22,6 +22,10 @@ my %triggers;
 
 my $template_map = $triggers_yaml->{template_map};
 
+my %category_test_whitelist = (
+    duckduckgo_syntax_cheat_sheet => 1,
+);
+
 sub flat_triggers {
     my $data = shift;
     if (my $triggers = $data->{triggers}) {
@@ -141,6 +145,7 @@ foreach my $path (glob("$json_dir/*.json")){
         }
         # Make sure aliases don't contain any category triggers.
         while (my ($category, $trigger_types) = each %{$triggers_yaml->{categories}}) {
+            last if $category_test_whitelist{$cheat_id};
             if (my ($alias, $trigger) = check_aliases_for_triggers(\@aliases, $trigger_types)) {
                 push(@tests, {msg => "alias ($alias) contains a trigger ($trigger) defined in the '$category' category", critical => 1});
             }

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -53,8 +53,6 @@ sub check_aliases_for_triggers {
                     && ($trigger = first { $alias =~ /^$_/ } @triggers))
             ||  ($trigger_type =~ /end$/
                     && ($trigger = first { $alias =~ /$_$/ } @triggers))
-            ||  ($trigger_type eq 'any'
-                    && ($trigger = first { $alias =~ /$_/  } @triggers))
             ) {
                 return ($alias, $trigger);
             }


### PR DESCRIPTION
@zachthompson These ensure the aliases don't contain triggers (prevents aliases like `X cheat sheet`, `X shortcuts` etc...).

* ***Critical*** if an alias contains a trigger defined by a category that is assigned.
* ***Warning*** if an alias contains a trigger defined by a category that is not assigned.
* ***Critical*** if an alias contains a custom trigger.

These check trigger positions (`start`, `startend` etc...).

---
IA Page: https://duck.co/ia/view/cheat_sheets