### PR TITLE
Windows 10 Cheat Sheet: Fix typo

### DIFF
--- a/share/goodie/cheat_sheets/json/microsoft-windows-ten.json
+++ b/share/goodie/cheat_sheets/json/microsoft-windows-ten.json
@@ -24,7 +24,7 @@
             "val" : "Snap current window to the left side of the screen",
             "key" : "[Win] [←]"
         },{
-            "val" : "Snap current window the the right side of the screen",
+            "val" : "Snap current window to the right side of the screen",
             "key" : "[Win] [→]"
         },{
             "val" : "Snap current window to the top of the screen",


### PR DESCRIPTION
Fix duplicate `the`.

------
IA Page:  http://duck.co/ia/view/microsoft_windows_ten_cheat_sheet
[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @ghostpirate