### PR TITLE
Golang Cheat Sheet: Fix typo

### DIFF
--- a/share/goodie/cheat_sheets/json/golang.json
+++ b/share/goodie/cheat_sheets/json/golang.json
@@ -216,7 +216,7 @@
             "val": "Accessing members"
         }, {
             "key": "func (v Vertex) Abs() float64 \\{<br>&nbsp;&nbsp;&nbsp;&nbsp;return math.Sqrt(v.X*v.X + v.Y*v.Y)<br>\\}",
-            "val": "You can declare methods on structs. The struct you want to declare the method on (the receiving type) comes between the the func keyword and the method name. The struct is copied on each method call."
+            "val": "You can declare methods on structs. The struct you want to declare the method on (the receiving type) comes between the func keyword and the method name. The struct is copied on each method call."
         }, {
             "key": "v.Abs()",
             "val": "Call method"


### PR DESCRIPTION
Fix duplicate `the`.

------
IA Page:  https://duck.co/ia/view/golang_cheat_sheet