### PR TITLE
Fixes #2697: 12:00 now parsed as Noon if am not specified

### DIFF
--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -97,7 +97,7 @@ handle query => sub {
           # Optional spaces between tokens
           \s*
           # AM/PM
-          (?<american>(?:A|(?<pm>P))\.?M\.?)?
+          (?<american>(?:(?<am>A)|(?<pm>P))\.?M\.?)?
         # Spaces between tokens
         \s* \b
         # Optional "from" indicator for input timezone
@@ -117,7 +117,7 @@ handle query => sub {
 
     my ($hours, $minutes, $seconds) = map { $_ // 0 } ($+{'h'}, $+{'m'}, $+{'s'});
     my $american        = $+{'american'};
-    my $pm              = ($+{'pm'} && $hours != 12) ? 12 : (!$+{'pm'} && $hours == 12) ? -12 : 0;
+    my $pm              = ($+{'pm'} && $hours != 12) ? 12 : ($+{'am'} && $hours == 12) ? -12 : 0;
 
     my $input = {};
     my $output = {};

--- a/t/TimezoneConverter.t
+++ b/t/TimezoneConverter.t
@@ -173,6 +173,14 @@ ddg_goodie_test(
             result => '17:00 BST',
         },
     ),  
+    '12:00 GMT in PST' =>
+        test_zci('4:00 PST',
+        structured_answer => {
+            input => ['12:00 GMT to PST (UTC-8)'],
+            operation => 'Convert Timezone',
+            result => '4:00 PST',
+        },
+    ),
     
     # Intentional non-answers
     '12 in binary' => undef,


### PR DESCRIPTION
Fixes #2697
https://duck.co/ia/view/timezone_converter
![gmtpst](https://cloud.githubusercontent.com/assets/1518025/13529363/12e478e6-e21c-11e5-8285-f28228633599.jpg)
