### PR TITLE
Conversions: Using unescaped HTML handlebars

### DIFF
--- a/share/goodie/conversions/content.handlebars
+++ b/share/goodie/conversions/content.handlebars
@@ -1,5 +1,5 @@
 <div class='zci__conversions-controls'>
-    <h3 class='zci__caption zci__result'>{{styled_output}} {{right_unit}}</h3>
+    <h3 class='zci__caption zci__result'>{{{styled_output}}} {{right_unit}}</h3>
     <h4 class='zci__subheader'>
         <span class='zci__operation tx-clr--lt2'>Convert:</span>
         <span class='zci__input'>{{markup_input}} {{left_unit}}</span>

--- a/share/goodie/conversions/content.handlebars
+++ b/share/goodie/conversions/content.handlebars
@@ -2,6 +2,6 @@
     <h3 class='zci__caption zci__result'>{{{styled_output}}} {{right_unit}}</h3>
     <h4 class='zci__subheader'>
         <span class='zci__operation tx-clr--lt2'>Convert:</span>
-        <span class='zci__input'>{{markup_input}} {{left_unit}}</span>
+        <span class='zci__input'>{{{markup_input}}} {{left_unit}}</span>
     </h4>
 </div>


### PR DESCRIPTION
@GuiltyDolphin I can't really test it from here as I can't get to my instance of `duckpan server`; however this should resolve the HTML issue (https://github.com/duckduckgo/zeroclickinfo-goodies/pull/2044#issuecomment-194817807).

cc @moollaza 

----------
IA Page: http://duck.co/ia/view/conversions