### PR TITLE
Conversions: now supports speed!

### DIFF
--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -47,6 +47,9 @@ my %plural_exceptions = (
     'electrical horsepower'  => 'electrical horsepower',
     'pounds force'           => 'pounds force',
     '坪'                     => '坪',
+    'km/h'                   => 'km/h',
+    'mph'                    => 'mph',
+    
 );
 my %singular_exceptions = reverse %plural_exceptions;
 

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -50,6 +50,7 @@ my %plural_exceptions = (
     'km/h'                   => 'km/h',
     'mph'                    => 'mph',
     'm/s'                    => 'm/s',    
+    'ft/s'                   => 'ft/s',
 );
 my %singular_exceptions = reverse %plural_exceptions;
 

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -49,7 +49,7 @@ my %plural_exceptions = (
     '坪'                     => '坪',
     'km/h'                   => 'km/h',
     'mph'                    => 'mph',
-    
+    'm/s'                    => 'm/s',    
 );
 my %singular_exceptions = reverse %plural_exceptions;
 

--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -1294,6 +1294,7 @@ aliases:
   - metre/second
   - meters/second
   - metres/second
+  - mps
 factor: 1
 type: speed
 unit: m/s

--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -1295,6 +1295,7 @@ aliases:
   - metre/second
   - meters/second
   - metres/second
+  - mps
 factor: 1
 type: speed
 unit: m/s

--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -1281,6 +1281,7 @@ unit: yobibyte
 aliases:
   - mi/h
   - miles per hour
+  - mile per hour
 factor: 2.237
 type: speed
 unit: mph

--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -1325,6 +1325,7 @@ unit: km/h
 aliases:
   - knots
   - kt
+  - nmi/h
 factor: 1.944
 type: speed
 unit: knot

--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -1277,3 +1277,54 @@ aliases:
 factor: 1.03397576569129e-25
 type: digital
 unit: yobibyte
+---
+aliases:
+  - mi/h
+  - miles per hour
+factor: 2.237
+type: speed
+unit: mph
+---
+aliases:
+  - meters per second
+  - metres per second
+  - meter per second
+  - metre per second
+  - meter/second
+  - metre/second
+  - meters/second
+  - metres/second
+factor: 1
+type: speed
+unit: m/s
+---
+aliases:
+  - feet per second
+  - foot per second
+  - feet/sec
+  - feet/second
+  - foot/sec
+  - foot/second
+  - fps
+  - ft/sec
+  - ft/second
+factor: 3.281
+type: speed
+unit: ft/s
+---
+aliases:
+  - kilometer per hour
+  - kilometre per hour
+  - kph
+  - kilometers per hour
+  - kilometres per hour
+factor: 3.6
+type: speed
+unit: km/h
+---
+aliases:
+  - knots
+  - kt
+factor: 1.944
+type: speed
+unit: knot

--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -1294,7 +1294,6 @@ aliases:
   - metre/second
   - meters/second
   - metres/second
-  - mps
 factor: 1
 type: speed
 unit: m/s
@@ -1317,6 +1316,7 @@ aliases:
   - kilometer per hour
   - kilometre per hour
   - kph
+  - kmph
   - kilometers per hour
   - kilometres per hour
 factor: 3.6

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -2529,6 +2529,42 @@ ddg_goodie_test(
             physical_quantity => 'digital'
         })
     ),
+    '50 mph in kph' => test_zci(
+        '50 mph = 80.465 km/h',
+        structured_answer => make_answer({
+            markup_input => '50',
+            raw_input => '50',
+            from_unit => 'mph',
+            styled_output => '80.465',
+            raw_answer => '80.465',
+            to_unit => 'km/h',
+            physical_quantity => 'speed'
+        })
+    ),
+    '10 metres per second to feet per second' => test_zci(
+        '10 m/s = 32.810 ft/s',
+        structured_answer => make_answer({
+            markup_input => '10',
+            raw_input => '10',
+            from_unit => 'm/s',
+            styled_output => '32.810',
+            raw_answer => '32.810',
+            to_unit => 'ft/s',
+            physical_quantity => 'speed'
+        })
+    ),
+    '10 km/h to mph' => test_zci(
+        '10 km/h = 6.214 mph',
+        structured_answer => make_answer({
+            markup_input => '10',
+            raw_input => '10',
+            from_unit => 'km/h',
+            styled_output => '6.214',
+            raw_answer => '6.214',
+            to_unit => 'mph',
+            physical_quantity => 'speed'    
+        })
+    ),
 
     # Intentionally untriggered
     '5 inches in 5 meters'            => undef,

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -2577,6 +2577,19 @@ ddg_goodie_test(
             physical_quantity => 'speed'    
         })
     ),
+    '0.6214 mph to kph' => test_zci(
+        '0.6214 mph = 1 km/h',
+        structured_answer => make_answer({
+            markup_input => '0.6214',
+            raw_input => '0.6214',
+            from_unit => 'mph',
+            styled_output => '1',
+            raw_answer => '1',
+            to_unit => 'km/h',
+            physical_quantity => 'speed'    
+        })
+    ),
+    
 
     # Intentionally untriggered
     '5 inches in 5 meters'            => undef,

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -2589,6 +2589,19 @@ ddg_goodie_test(
             physical_quantity => 'speed'    
         })
     ),
+    '1 mps in mph' => test_zci(
+        '1 m/s = 2.237 mph',
+        structured_answer => make_answer({
+            markup_input => '1',
+            raw_input => '1',
+            from_unit => 'm/s',
+            styled_output => '2.237',
+            raw_answer => '2.237',
+            to_unit => 'mph',
+            physical_quantity => 'speed'    
+        })
+    ),
+    
     
 
     # Intentionally untriggered

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -2601,6 +2601,18 @@ ddg_goodie_test(
             physical_quantity => 'speed'    
         })
     ),
+    '1 ft/s in m/s' => test_zci(
+        '1 ft/s = 0.305 m/s',
+        structured_answer => make_answer({
+            markup_input => '1',
+            raw_input => '1',
+            from_unit => 'ft/s',
+            styled_output => '0.305',
+            raw_answer => '0.305',
+            to_unit => 'm/s',
+            physical_quantity => 'speed'    
+        })
+    ),
     
     
 

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -2565,6 +2565,18 @@ ddg_goodie_test(
             physical_quantity => 'speed'    
         })
     ),
+    '1 km/h to mph' => test_zci(
+        '1 km/h = 0.621 mph',
+        structured_answer => make_answer({
+            markup_input => '1',
+            raw_input => '1',
+            from_unit => 'km/h',
+            styled_output => '0.621',
+            raw_answer => '0.621',
+            to_unit => 'mph',
+            physical_quantity => 'speed'    
+        })
+    ),
 
     # Intentionally untriggered
     '5 inches in 5 meters'            => undef,


### PR DESCRIPTION
Currently the supported units are:
* m/s
* ft/s
* mph
* km/h
* knots

Will hopefully fix: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/2729
and partially address: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/689

Suggestions for new units welcome, however I don't want to go too berzerk on this as the number of combinations is huge and I'd rather solve it for everything.

cc @duckduckgo/community-leaders @moollaza @tagawa 

--------
https://duck.co/ia/view/conversions