### PR TITLE
CheatSheets: Improve test phrasing and reports

### DIFF
--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -14,7 +14,6 @@ use List::Util qw(first none);
 use YAML::XS qw(LoadFile);
 
 my $json_dir = "share/goodie/cheat_sheets/json";
-my $json;
 
 my $triggers_yaml = LoadFile('share/goodie/cheat_sheets/triggers.yaml');
 
@@ -65,13 +64,15 @@ foreach my $path (glob("$json_dir/*.json")){
     my ($name) = $path =~ /.+\/(.+)\.json$/;
     my $defaultName = $name =~ s/-/ /gr;
     my @tests;
+    my $json;
 
     ### File tests ###
     my $temp_pass = (my $content < io($path))? 1 : 0;
     push(@tests, {msg => 'file content can be read', critical => 1, pass => $temp_pass});
 
-    $temp_pass = ($json = decode_json($content))? 1 : 0;
-    push(@tests, {msg => 'content is valid JSON', critical => 1, pass => $temp_pass});
+    $temp_pass = (eval { $json = decode_json($content) })? 1 : 0;
+    push(@tests, {msg => 'invalid JSON', critical => 1, pass => $temp_pass});
+    goto PRINT_RESULTS unless $json; # No point continuing if we cannot read the JSON
 
     ### Headers tests ###
     $temp_pass = (exists $json->{id} && $json->{id})? 1 : 0;
@@ -210,6 +211,8 @@ foreach my $path (glob("$json_dir/*.json")){
             }
         }
     }
+
+    PRINT_RESULTS:
 
     my $result = print_results($name, \@tests);
 

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -98,8 +98,9 @@ foreach my $path (@test_paths) {
 
     if ($cheat_id) {
         ### ID tests ###
-        $temp_pass = id_to_file_name($cheat_id) eq $file_name;
-        push(@tests, {msg => "Invalid file name ($file_name) for ID ($cheat_id)", critical => 1, pass => $temp_pass});
+        my $base_name = $file_name =~ s#.+/(.+\.json)#$1#r;
+        $temp_pass = id_to_file_name($cheat_id) eq $base_name;
+        push(@tests, {msg => "Invalid file name ($base_name) for ID ($cheat_id)", critical => 1, pass => $temp_pass});
 
         $temp_pass = $cheat_id =~ /_cheat_sheet$/;
         push(@tests, {msg => "ID ($cheat_id) does not end with '_cheat_sheet'", critical => 1, pass => $temp_pass});

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -204,13 +204,13 @@ foreach my $path (glob("$json_dir/*.json")){
                 if ($val =~ /\(\[.*\]\/\[.+\]\)/g) {
                     push(@tests, {msg => "keys ([a]/[b]) should have white spaces: $val from  $name", critical => 0, pass => 0});
                 }
-                push(@tests, {msg => "No trailing white space in the value: $val from: $name",  critical => 0, pass => 0}) if $val =~ /\s"$/;
+                push(@tests, {msg => "Trailing whitespace in value '$val'",  critical => 0, pass => 0}) if $val =~ /\s$/;
             }
             if (my $key = $entry->{key}) {
                 if ($key =~ /\(\[.*\]\/\[.+\]\)/g) {
                     push(@tests, {msg => "keys ([a]/[b]) should have white spaces: $key from  $name", critical => 0, pass => 0});
                 }
-                push(@tests, {msg => "No trailing white space in the value: $key from: $name", critical => 0, pass => 0}) if $key =~ /\s"$/;
+                push(@tests, {msg => "Trailing whitespace in key '$key'", critical => 0, pass => 0}) if $key =~ /\s$/;
             }
         }
     }

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -224,6 +224,7 @@ foreach my $path (glob("$json_dir/*.json")){
 sub print_results {
     my ($name, $tests) = @_;
 
+    my $expected_max_length = 30;
     my @failures = grep { !$_->{pass} && !$_->{skip} } @$tests;
     # 'green' => pass; 'yellow' => some warnings; 'red' => any critical
     my $total_color = !@failures ? 'green' :
@@ -231,7 +232,9 @@ sub print_results {
     my %result = (pass => 1, msg => $name . ' is build safe');
     # We report the number of failures or a pass
     my $overall_msg = @failures ? @failures . ' FAILURE' . ($#failures ? 'S' : '') : 'PASS';
-    diag colored([$total_color], "Testing " . $name . "........... " . $overall_msg);
+    # Attempt to keep the test reports aligned (mostly)
+    my $dots = join '', map { '.' } (1..$expected_max_length - length $name);
+    diag colored([$total_color], "Testing " . $name . $dots . ' ' . $overall_msg);
     for my $test (@failures) {
         my $temp_msg = $test->{msg};
 

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -236,12 +236,17 @@ sub print_results {
 
     my $expected_max_length = 30;
     my @failures = grep { !$_->{pass} && !$_->{skip} } @$tests;
+    my @warnings = grep { !$_->{critical} } @failures;
+    my @critical = grep {  $_->{critical} } @failures;
     # 'green' => pass; 'yellow' => some warnings; 'red' => any critical
     my $total_color = !@failures ? 'green' :
         ((any { $_->{critical} } @failures) ? 'red' : 'yellow');
     my %result = (pass => 1, msg => $name . ' is build safe');
     # We report the number of failures or a pass
-    my $overall_msg = @failures ? @failures . ' FAILURE' . ($#failures ? 'S' : '') : 'PASS';
+    my $warning_msg  = @warnings ? (@warnings . ' WARNING' . ($#warnings ? 'S' : '')) : '';
+    my $critical_msg = @critical ? (@critical . ' FAILURE' . ($#critical ? 'S' : '')) : '';
+    my $overall_msg  = @failures ? join ', ', grep { $_ } ($warning_msg, $critical_msg)
+                                 : 'PASS';
     # Attempt to keep the test reports aligned (mostly)
     my $dots = join '', map { '.' } (1..$expected_max_length - length $name);
     diag colored([$total_color], "Testing " . $name . $dots . ' ' . $overall_msg);

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -12,6 +12,7 @@ use JSON::MaybeXS;
 use IO::All;
 use List::Util qw(first none all any);
 use YAML::XS qw(LoadFile);
+use File::Find::Rule;
 
 my $json_dir = "share/goodie/cheat_sheets/json";
 
@@ -56,9 +57,11 @@ sub check_aliases_for_triggers {
     return;
 }
 
+my @fnames = @ARGV ? map { "$_.json" } @ARGV : ("*.json");
+my @test_paths = File::Find::Rule->file()->name(@fnames)->in($json_dir);
+
 # Iterate over all Cheat Sheet JSON files...
-foreach my $path (glob("$json_dir/*.json")){
-    next if $ARGV[0] && $path ne  "$json_dir/$ARGV[0].json";
+foreach my $path (@test_paths) {
 
     my ($file_name) = $path =~ /$json_dir\/(.+)/;
     my ($name) = $path =~ /.+\/(.+)\.json$/;

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -98,6 +98,9 @@ foreach my $path (glob("$json_dir/*.json")){
         $temp_pass = id_to_file_name($cheat_id) eq $file_name;
         push(@tests, {msg => "Invalid file name ($file_name) for ID ($cheat_id)", critical => 1, pass => $temp_pass});
 
+        $temp_pass = $cheat_id =~ /_cheat_sheet$/;
+        push(@tests, {msg => "ID ($cheat_id) does not end with '_cheat_sheet'", critical => 1, pass => $temp_pass});
+
         ### Trigger tests ###
         if (my $custom = $triggers_yaml->{custom_triggers}->{$cheat_id}) {
             %categories = map { $_ => 1 } @{$custom->{additional_categories}};

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -200,7 +200,7 @@ foreach my $path (glob("$json_dir/*.json")){
                 if ($val =~ /\(\[.*\]\/\[.+\]\)/g) {
                     push(@tests, {msg => "keys ([a]/[b]) should have white spaces: $val from  $name", critical => 0, pass => 0});
                 }
-               push(@tests, {msg => "No trailing white space in the value: $val from: $name",  critical => 0, pass => 0}) if $val =~ /\s"$/;
+                push(@tests, {msg => "No trailing white space in the value: $val from: $name",  critical => 0, pass => 0}) if $val =~ /\s"$/;
             }
             if (my $key = $entry->{key}) {
                 if ($key =~ /\(\[.*\]\/\[.+\]\)/g) {

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -196,6 +196,9 @@ foreach my $path (@test_paths) {
             next;
         }
         my $entry_count = 0;
+        my $val_type = $template_type eq 'language' ? 'trn'
+                     : $template_type eq 'links' ? 'link'
+                     : 'val';
         foreach my $entry (@$section_contents) {
             # Only show it when it fails, otherwise it clutters the output
             push(@tests, {msg => "No key specified for entry $entry_count in the '$section_name' section", critical => 1, pass => 0}) unless exists $entry->{key};
@@ -204,11 +207,11 @@ foreach my $path (@test_paths) {
             $entry_count++;
 
             # spacing in keys ([a]/[b])'
-            if (my $val = $entry->{val}) {
+            if (my $val = $entry->{$val_type}) {
                 if ($val =~ /\(\[.+\]\/\[.+\]\)/g) {
                     push(@tests, {msg => "No spacing around keys in '$val' (use ([a] / [b]) rather than ([a]/[b]))", critical => 0, pass => 0});
                 }
-                push(@tests, {msg => "Trailing whitespace in value '$val'",  critical => 0, pass => 0}) if $val =~ /\s$/;
+                push(@tests, {msg => "Trailing whitespace in $val_type '$val'",  critical => 0, pass => 0}) if $val =~ /\s$/;
             }
             if (my $key = $entry->{key}) {
                 if ($key =~ /\(\[.*\]\/\[.+\]\)/g) {

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -10,7 +10,7 @@ use Test::More;
 use Term::ANSIColor;
 use JSON::MaybeXS;
 use IO::All;
-use List::Util qw(first none all any);
+use List::Util qw(first none all any max);
 use YAML::XS qw(LoadFile);
 use File::Find::Rule;
 
@@ -59,6 +59,8 @@ sub check_aliases_for_triggers {
 
 my @fnames = @ARGV ? map { "$_.json" } @ARGV : ("*.json");
 my @test_paths = File::Find::Rule->file()->name(@fnames)->in($json_dir);
+
+my $max_name_len = max map { $_ =~ /.+\/(.+)\.json$/; length $1 } @test_paths;
 
 # Iterate over all Cheat Sheet JSON files...
 foreach my $path (@test_paths) {
@@ -234,7 +236,6 @@ foreach my $path (@test_paths) {
 sub print_results {
     my ($name, $tests) = @_;
 
-    my $expected_max_length = 30;
     my @failures = grep { !$_->{pass} && !$_->{skip} } @$tests;
     my @warnings = grep { !$_->{critical} } @failures;
     my @critical = grep {  $_->{critical} } @failures;
@@ -248,7 +249,7 @@ sub print_results {
     my $overall_msg  = @failures ? join ', ', grep { $_ } ($warning_msg, $critical_msg)
                                  : 'PASS';
     # Attempt to keep the test reports aligned (mostly)
-    my $dots = join '', map { '.' } (1..$expected_max_length - length $name);
+    my $dots = join '', map { '.' } (1..$max_name_len - length $name);
     diag colored([$total_color], "Testing " . $name . $dots . ' ' . $overall_msg);
     for my $test (@failures) {
         my $temp_msg = $test->{msg};

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -98,7 +98,7 @@ foreach my $path (@test_paths) {
 
     if ($cheat_id) {
         ### ID tests ###
-        my $base_name = $file_name =~ s#.+/(.+\.json)#$1#r;
+        my $base_name = $file_name =~ s/.+\/(.+\.json)/$1/r;
         $temp_pass = id_to_file_name($cheat_id) eq $base_name;
         push(@tests, {msg => "Invalid file name ($base_name) for ID ($cheat_id)", critical => 1, pass => $temp_pass});
 


### PR DESCRIPTION
@zachthompson As promised! This improves the general phrasing of the tests as well as improve the way the tests are reported. There's a bit more info in my commit messages, but you can easily see the new structure through the Travis log.

* Improves phrasing of existing tests

* Improves structure of test reports

* Fixes an issue wherein cheat sheets within directories under `json/` were not being tested

* Allows multiple cheat sheets to be tested via arguments

---
https://duck.co/ia/view/cheat_sheets