### PR TITLE
add working link to i3wm cheatsheet

### DIFF
--- a/share/goodie/cheat_sheets/json/i3.json
+++ b/share/goodie/cheat_sheets/json/i3.json
@@ -4,7 +4,7 @@
     "description": "Window manager for Linux",
     "metadata": {
         "sourceName": "i3wm",
-        "sourceUrl": "https://i3wm.org/docs/refcard.pdf"
+        "sourceUrl": "https://i3wm.org/docs/refcard.html"
     },
     "template_type": "keyboard",
     "section_order": [


### PR DESCRIPTION
The URL in i3.json is 404ing, so I replaced it with a working link.

To see the 404ing link in action, [search for "i3 cheatsheet"](https://duckduckgo.com/?q=i3+cheatsheet&t=ffsb&ia=cheatsheet) and click on the ["More at i3wm"](https://i3wm.org/docs/refcard.pdf) link.

---
IA Page: https://duck.co/ia/view/i3_cheat_sheet
Maintainer: @goromlagche