### PR TITLE
New Django Model Cheat Sheet

### DIFF
--- a/share/goodie/cheat_sheets/json/django-model.json
+++ b/share/goodie/cheat_sheets/json/django-model.json
@@ -1,6 +1,6 @@
 {
     "id": "django_model_cheat_sheet",
-    "name": "Django Model Cheat Sheet",
+    "name": "Django Model",
     "description": "An overview of django model and relationship types.",
 
     "metadata": {
@@ -24,113 +24,113 @@
         "Field Types": [
             {
                 "key": "AutoField",
-                "val": "An IntegerField that automatically increments according to available IDs."
+                "val": "An IntegerField that automatically increments according to available IDs"
             },
             {
-                "key": "BigInt­ege­rField",
+                "key": "BigIntegerField",
                 "val": "A 64 bit integer, much like an IntegerField except that it is guaranteed to fit numbers from -9223372036854775808 to 9223372036854775807."
             },
             {
-                "key": "Binary­Field",
-                "val": "A field to store raw binary data. It only supports bytes assignment."
+                "key": "BinaryField",
+                "val": "A field to store raw binary data. It only supports bytes assignment"
             },
             {
-                "key": "Boolea­nField",
-                "val": "A true/false field."
+                "key": "BooleanField",
+                "val": "A true/false field"
             },
             {
                 "key": "CharField",
-                "val": "A string field, for small- to large-sized strings."
+                "val": "A string field, for small- to large-sized strings"
             },
             {
-                "key": "CommaS­epa­rat­edI­nte­ger­Field",
-                "val": "A field of integers separated by commas."
+                "key": "CommaSeparatedIntegerField",
+                "val": "A field of integers separated by commas"
             },
             {
                 "key": "DateField",
-                "val": "A date, represented in Python by a datetime.date instance."
+                "val": "A date, represented in Python by a datetime.date instance"
             },
             {
-                "key": "DateTi­meField",
-                "val": "A date and time, represented in Python by a datetime.datetime instance."
+                "key": "DateTimeField",
+                "val": "A date and time, represented in Python by a datetime.datetime instance"
             },
             {
-                "key": "Decima­lField",
+                "key": "DecimalField",
                 "val": "A fixed-precision decimal number, represented in Python by a Decimal instance."
             },
             {
                 "key": "DurationField",
-                "val": "A field for storing periods of time - modeled in Python by timedelta."
+                "val": "A field for storing periods of time - modeled in Python by timedelta"
             },
             {
                 "key": "EmailField",
-                "val": "A CharField that checks that the value is a valid email address."
+                "val": "A CharField that checks that the value is a valid email address"
             },
             {
                 "key": "FileField",
-                "val": "A file-upload field."
+                "val": "A file-upload field"
             }
         ],
 
         "Field Types Cont.": [
             {
                 "key": "FloatField",
-                "val": "A floating-point number represented in Python by a float instance."
+                "val": "A floating-point number represented in Python by a float instance"
             },
             {
                 "key": "ImageField",
-                "val": "Inherits all attributes and methods from FileField, but also validates that the uploaded object is a valid image."
+                "val": "Inherits all attributes and methods from FileField, but also validates that the uploaded object is a valid image"
             },
             {
-                "key": "Intege­rField",
-                "val": "An integer. Values from -2147483648 to 2147483647 are safe in all databases supported by Django."
+                "key": "IntegerField",
+                "val": "An integer. Values from -2147483648 to 2147483647 are safe in all databases supported by Django"
             },
             {
-                "key": "Generi­cIP­Add­res­sField",
-                "val": "An IPv4 or IPv6 address, in string format (e.g. 192.0.2.30 or 2a02:42fe::4)."
+                "key": "GenericIPAddressField",
+                "val": "An IPv4 or IPv6 address, in string format (e.g. 192.0.2.30 or 2a02:42fe::4)"
             },
             {
-                "key": "NullBo­ole­anField",
-                "val": "Like a BooleanField, but allows NULL as one of the options."
+                "key": "NullBooleanField",
+                "val": "Like a BooleanField, but allows NULL as one of the options"
             },
             {
-                "key": "Positi­veI­nte­ger­Field",
-                "val": "Like an IntegerField, but must be either positive or zero (0). Values from 0 to 2147483647 are safe in all databases supported by Django."
+                "key": "PositiveIntegerField",
+                "val": "Like an IntegerField, but must be either positive or zero (0). Values from 0 to 2147483647 are safe in all databases supported by Django"
             },
             {
-                "key": "Positi­veS­mal­lIn­teg­erField",
-                "val": "Like a PositiveIntegerField, but only allows values under a certain (database-dependent) point. Values from 0 to 32767 are safe in all databases supported by Django."
+                "key": "PositiveSmallIntegerField",
+                "val": "Like a PositiveIntegerField, but only allows values under a certain (database-dependent) point. Values from 0 to 32767 are safe in all databases supported by Django"
             },
             {
                 "key": "SlugField",
-                "val": "A slug is a short label for something, containing only letters, numbers, underscores or hyphens. They’re generally used in URLs."
+                "val": "A slug is a short label for something, containing only letters, numbers, underscores or hyphens. They’re generally used in URLs"
             },
             {
-                "key": "SmallI­nte­ger­Field",
-                "val": "Like an IntegerField, but only allows values under a certain (database-dependent) point. Values from -32768 to 32767 are safe in all databases supported by Django."
+                "key": "SmallIntegerField",
+                "val": "Like an IntegerField, but only allows values under a certain (database-dependent) point. Values from -32768 to 32767 are safe in all databases supported by Django"
             },
             {
                 "key": "TextField",
-                "val": "A large text field. The default form widget for this field is a Textarea."
+                "val": "A large text field. The default form widget for this field is a Textarea"
             },
             {
                 "key": "TimeField",
-                "val": "A time, represented in Python by a datetime.time instance. Accepts the same auto-population options as DateField."
+                "val": "A time, represented in Python by a datetime.time instance. Accepts the same auto-population options as DateField"
             }
         ],
 
         "Relationship Types": [
             {
                 "key": "ForeignKey",
-                "val": "A many-to-one relationship. Requires a positional argument: the class to which the model is related."
+                "val": "A many-to-one relationship. Requires a positional argument: the class to which the model is related"
             },
             {
-                "key": "ManyTo­Man­yField",
-                "val": "A many-to-many relationship. Requires a positional argument: the class to which the model is related, which works exactly the same as it does for ForeignKey, including recursive and lazy relationships."
+                "key": "ManyToManyField",
+                "val": "A many-to-many relationship. Requires a positional argument: the class to which the model is related, which works exactly the same as it does for ForeignKey, including recursive and lazy relationships"
             },
             {
-                "key": "OneToO­neField",
-                "val": "A one-to-one relationship. Conceptually, this is similar to a ForeignKey with unique=True, but the “reverse” side of the relation will directly return a single object."
+                "key": "OneToOneField",
+                "val": "A one-to-one relationship. Conceptually, this is similar to a ForeignKey with unique=True, but the “reverse” side of the relation will directly return a single object"
             }
         ]
     }

--- a/share/goodie/cheat_sheets/json/django-model.json
+++ b/share/goodie/cheat_sheets/json/django-model.json
@@ -1,0 +1,137 @@
+{
+    "id": "django_model_cheat_sheet",
+    "name": "Django Model Cheat Sheet",
+    "description": "An overview of django model and relationship types.",
+
+    "metadata": {
+        "sourceName": "Django Documentation",
+        "sourceUrl" : "https://docs.djangoproject.com/en/1.9/ref/models/fields/"
+    },
+
+    "aliases": [
+        "django orm"
+    ],
+
+    "template_type": "terminal",
+
+    "section_order": [
+        "Field Types",
+        "Field Types Cont.",
+        "Relationship Types"
+    ],
+
+    "sections": {
+        "Field Types": [
+            {
+                "key": "AutoField",
+                "val": "An IntegerField that automatically increments according to available IDs."
+            },
+            {
+                "key": "BigInt­ege­rField",
+                "val": "A 64 bit integer, much like an IntegerField except that it is guaranteed to fit numbers from -9223372036854775808 to 9223372036854775807."
+            },
+            {
+                "key": "Binary­Field",
+                "val": "A field to store raw binary data. It only supports bytes assignment."
+            },
+            {
+                "key": "Boolea­nField",
+                "val": "A true/false field."
+            },
+            {
+                "key": "CharField",
+                "val": "A string field, for small- to large-sized strings."
+            },
+            {
+                "key": "CommaS­epa­rat­edI­nte­ger­Field",
+                "val": "A field of integers separated by commas."
+            },
+            {
+                "key": "DateField",
+                "val": "A date, represented in Python by a datetime.date instance."
+            },
+            {
+                "key": "DateTi­meField",
+                "val": "A date and time, represented in Python by a datetime.datetime instance."
+            },
+            {
+                "key": "Decima­lField",
+                "val": "A fixed-precision decimal number, represented in Python by a Decimal instance."
+            },
+            {
+                "key": "DurationField",
+                "val": "A field for storing periods of time - modeled in Python by timedelta."
+            },
+            {
+                "key": "EmailField",
+                "val": "A CharField that checks that the value is a valid email address."
+            },
+            {
+                "key": "FileField",
+                "val": "A file-upload field."
+            }
+        ],
+
+        "Field Types Cont.": [
+            {
+                "key": "FloatField",
+                "val": "A floating-point number represented in Python by a float instance."
+            },
+            {
+                "key": "ImageField",
+                "val": "Inherits all attributes and methods from FileField, but also validates that the uploaded object is a valid image."
+            },
+            {
+                "key": "Intege­rField",
+                "val": "An integer. Values from -2147483648 to 2147483647 are safe in all databases supported by Django."
+            },
+            {
+                "key": "Generi­cIP­Add­res­sField",
+                "val": "An IPv4 or IPv6 address, in string format (e.g. 192.0.2.30 or 2a02:42fe::4)."
+            },
+            {
+                "key": "NullBo­ole­anField",
+                "val": "Like a BooleanField, but allows NULL as one of the options."
+            },
+            {
+                "key": "Positi­veI­nte­ger­Field",
+                "val": "Like an IntegerField, but must be either positive or zero (0). Values from 0 to 2147483647 are safe in all databases supported by Django."
+            },
+            {
+                "key": "Positi­veS­mal­lIn­teg­erField",
+                "val": "Like a PositiveIntegerField, but only allows values under a certain (database-dependent) point. Values from 0 to 32767 are safe in all databases supported by Django."
+            },
+            {
+                "key": "SlugField",
+                "val": "A slug is a short label for something, containing only letters, numbers, underscores or hyphens. They’re generally used in URLs."
+            },
+            {
+                "key": "SmallI­nte­ger­Field",
+                "val": "Like an IntegerField, but only allows values under a certain (database-dependent) point. Values from -32768 to 32767 are safe in all databases supported by Django."
+            },
+            {
+                "key": "TextField",
+                "val": "A large text field. The default form widget for this field is a Textarea."
+            },
+            {
+                "key": "TimeField",
+                "val": "A time, represented in Python by a datetime.time instance. Accepts the same auto-population options as DateField."
+            }
+        ],
+
+        "Relationship Types": [
+            {
+                "key": "ForeignKey",
+                "val": "A many-to-one relationship. Requires a positional argument: the class to which the model is related."
+            },
+            {
+                "key": "ManyTo­Man­yField",
+                "val": "A many-to-many relationship. Requires a positional argument: the class to which the model is related, which works exactly the same as it does for ForeignKey, including recursive and lazy relationships."
+            },
+            {
+                "key": "OneToO­neField",
+                "val": "A one-to-one relationship. Conceptually, this is similar to a ForeignKey with unique=True, but the “reverse” side of the relation will directly return a single object."
+            }
+        ]
+    }
+}

--- a/share/goodie/cheat_sheets/json/django-model.json
+++ b/share/goodie/cheat_sheets/json/django-model.json
@@ -28,7 +28,7 @@
             },
             {
                 "key": "BigIntegerField",
-                "val": "A 64 bit integer, much like an IntegerField except that it is guaranteed to fit numbers from -9223372036854775808 to 9223372036854775807."
+                "val": "A 64 bit integer, much like an IntegerField except that it is guaranteed to fit numbers from -9223372036854775808 to 9223372036854775807"
             },
             {
                 "key": "BinaryField",
@@ -56,7 +56,7 @@
             },
             {
                 "key": "DecimalField",
-                "val": "A fixed-precision decimal number, represented in Python by a Decimal instance."
+                "val": "A fixed-precision decimal number, represented in Python by a Decimal instance"
             },
             {
                 "key": "DurationField",


### PR DESCRIPTION
## Django Model Cheat Sheet

### Description
The essential fields types and relationships of the data being stored when working with the Django Object Relational Mapper (ORM).

### Data Source
https://docs.djangoproject.com/en/1.9/topics/db/models/

### Example Queries
django models cheat sheet

### Screenshots 

![screen shot 2016-03-18 at 21 02 59](https://cloud.githubusercontent.com/assets/8960296/13892091/fb88696e-ed4c-11e5-9ec6-fa793a1a1645.png)
![screen shot 2016-03-18 at 21 04 02](https://cloud.githubusercontent.com/assets/8960296/13892092/fcd0fce6-ed4c-11e5-89ed-1c69b9dbad73.png)

### References

https://duck.co/ia/view/django_model_cheat_sheet