### PR TITLE
CheatSheets: Add 'ignore' attribute

### DIFF
--- a/lib/DDG/Goodie/CheatSheets.pm
+++ b/lib/DDG/Goodie/CheatSheets.pm
@@ -45,12 +45,23 @@ sub generate_triggers {
     my %triggers;
     # This will contain a lookup from triggers to categories and/or files.
     my %trigger_lookup;
+    # This will contain all the ignored phrases and their associated categories.
+    my %ignore_phrases;
 
     while (my ($name, $trigger_setsh) = each %spec_triggers) {
+        my $ignore_phrases = delete $trigger_setsh->{ignore};
         while (my ($trigger_type, $triggersh) = each %$trigger_setsh) {
             foreach my $trigger (@{$triggersh}) {
                 # Add trigger to global triggers.
                 $triggers{$trigger_type}{$trigger} = 1;
+                # Handle ignored components - these will be stripped
+                # from query and not be included in final trigger.
+                if (defined $ignore_phrases) {
+                    my %new_ignore_phrases = map { $_ => 1 }
+                        (keys %{$ignore_phrases{$trigger} || {}},
+                        @$ignore_phrases);
+                    $ignore_phrases{$trigger} = \%new_ignore_phrases;
+                }
                 my %new_triggers = map { $_ => 1}
                     (keys %{$trigger_lookup{$trigger}});
                 if ($name !~ /cheat_sheet$/) {
@@ -65,7 +76,7 @@ sub generate_triggers {
     while (my ($trigger_type, $triggers) = each %triggers) {
         triggers $trigger_type => (keys %{$triggers});
     }
-    return %trigger_lookup;
+    return (\%ignore_phrases, %trigger_lookup);
 }
 
 # Initialize aliases.
@@ -100,13 +111,19 @@ sub get_aliases {
 
 my $aliases = get_aliases();
 
-my %trigger_lookup = generate_triggers($aliases);
+my ($trigger_ignore, %trigger_lookup) = generate_triggers($aliases);
 
 handle remainder => sub {
     my $remainder = shift;
 
     my $trigger = join(' ', split /\s+/o, lc($req->matched_trigger));
     my $lookup = $trigger_lookup{$trigger};
+    if (exists $trigger_ignore->{$trigger}) {
+        foreach my $ignore (keys %{$trigger_ignore->{$trigger}}) {
+            $remainder =~ s/\b$ignore\b//;
+        }
+        $remainder =~ s/^\s*(.+?)\s*$/$1/;
+    }
 
     my $file = $aliases->{join(' ', split /\s+/o, lc($remainder))} or return;
     open my $fh, $file or return;

--- a/lib/DDG/Goodie/CheatSheets.pm
+++ b/lib/DDG/Goodie/CheatSheets.pm
@@ -113,7 +113,7 @@ my $aliases = get_aliases();
 
 my ($trigger_ignore, %trigger_lookup) = generate_triggers($aliases);
 
-handle remainder => sub {
+handle remainder_lc => sub {
     my $remainder = shift;
 
     my $trigger = join(' ', split /\s+/o, lc($req->matched_trigger));
@@ -125,7 +125,7 @@ handle remainder => sub {
         $remainder =~ s/^\s*(.+?)\s*$/$1/;
     }
 
-    my $file = $aliases->{join(' ', split /\s+/o, lc($remainder))} or return;
+    my $file = $aliases->{join(' ', split /\s+/o, $remainder)} or return;
     open my $fh, $file or return;
     my $json = do { local $/; <$fh> };
     my $data = decode_json($json) or return;

--- a/share/goodie/cheat_sheets/triggers.yaml
+++ b/share/goodie/cheat_sheets/triggers.yaml
@@ -66,6 +66,8 @@ categories:
     startend:
       - "phrases"
       - "translations"
+    ignore:
+      - "english to"
   # Shows links to other sites.
   links:
     startend:

--- a/share/goodie/cheat_sheets/triggers.yaml
+++ b/share/goodie/cheat_sheets/triggers.yaml
@@ -36,6 +36,8 @@ categories:
       - "cheat codes"
       - "cheats"
       - "secrets"
+    ignore:
+      - "game"
   # Describes or introduces syntax of a programming language.
   code:
     startend:
@@ -46,6 +48,8 @@ categories:
     startend:
       - "cheat sheet"
       - "cheatsheet"
+    ignore:
+      - "for"
   # Provides a step-by-step guide.
   guide:
     startend:
@@ -61,19 +65,26 @@ categories:
       - "keyboard shortcuts"
       - "keys"
       - "shortcuts"
+    ignore:
+      - "default"
   # Introduces basic translations for a human language.
   language:
     startend:
       - "phrases"
       - "translations"
     ignore:
+      - "basic"
       - "english to"
+      - "language"
   # Shows links to other sites.
   links:
     startend:
       - "links"
       - "sites"
       - "websites"
+    ignore:
+      - "list"
+      - "list of"
   # Shows mathematical equations.
   math:
     startend:
@@ -84,8 +95,9 @@ categories:
   reference:
     startend:
       - "help"
-      - "quick reference"
       - "reference"
+    ignore:
+      - "quick"
   # Describes commands that can be entered at a terminal.
   terminal:
     startend:

--- a/share/goodie/cheat_sheets/triggers.yaml
+++ b/share/goodie/cheat_sheets/triggers.yaml
@@ -48,8 +48,6 @@ categories:
     startend:
       - "cheat sheet"
       - "cheatsheet"
-    ignore:
-      - "for"
   # Provides a step-by-step guide.
   guide:
     startend:

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -63,7 +63,7 @@ my @test_paths = File::Find::Rule->file()->name(@fnames)->in($json_dir);
 my $max_name_len = max map { $_ =~ /.+\/(.+)\.json$/; length $1 } @test_paths;
 
 # Iterate over all Cheat Sheet JSON files...
-foreach my $path (@test_paths) {
+foreach my $path (sort @test_paths) {
 
     my ($file_name) = $path =~ /$json_dir\/(.+)/;
     my ($name) = $path =~ /.+\/(.+)\.json$/;

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -62,8 +62,16 @@ my @test_paths = File::Find::Rule->file()->name(@fnames)->in($json_dir);
 
 my $max_name_len = max map { $_ =~ /.+\/(.+)\.json$/; length $1 } @test_paths;
 
+sub cmp_base {
+    $a =~ qr{/([^/]+)$};
+    my $base1 = $1;
+    $b =~ qr{/([^/]+)$};
+    my $base2 = $1;
+    return $base1 cmp $base2;
+}
+
 # Iterate over all Cheat Sheet JSON files...
-foreach my $path (sort @test_paths) {
+foreach my $path (sort { cmp_base } @test_paths) {
 
     my ($file_name) = $path =~ /$json_dir\/(.+)/;
     my ($name) = $path =~ /.+\/(.+)\.json$/;

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -158,10 +158,10 @@ foreach my $path (sort { cmp_base } @test_paths) {
                 if (my ($alias, $trigger) = check_aliases_for_triggers(\@aliases, $trigger_types)) {
                     push(@tests, {msg => "Alias ($alias) contains a trigger ($trigger) defined in the '$category' category", critical => $critical});
                 }
-                # Warn if they have aliases that contain ignored phrases.
+                # Critical if they have aliases that contain ignored phrases.
                 if ($critical and my $ignored = $trigger_types->{ignore}) {
                     if (my ($alias, $ignore) = check_aliases_for_ignore(\@aliases, $ignored)) {
-                        push (@tests, {msg => "Alias ($alias) contains a phrase ($ignore) that is ignored and may be omitted", critical => 0});
+                        push (@tests, {msg => "Alias ($alias) contains a phrase ($ignore) that is ignored and may be omitted", critical => 1});
                     }
                 }
             }


### PR DESCRIPTION
@zachthompson As discussed previously on #2170, this re-introduces the 'ignore' attribute.

I've gone over the purpose in some detail in he message for my first commit, but the TL;DR is they allow 'fluff' words that are ignored when triggering.

These are specified in the `triggers.yaml` file.

## TO-DO:

- [ ] Add 'global' ignores: These would be phrases that are automatically ignored by any cheat sheet / template using the category - but would apply to *additional triggers*, not just those defined by the category.
- [x] Add tests. The aim would be to have these tests fail if an alias contains a phrase that would be entirely ignored by the triggering. Would like to rebase onto #2740 first.

---
IA Page: https://duck.co/ia/view/cheat_sheets
Maintainer: @zachthompson 