### PR TITLE
Remove ID and name from templates

### DIFF
--- a/template/lib/DDG/Goodie/Example.pm
+++ b/template/lib/DDG/Goodie/Example.pm
@@ -35,15 +35,6 @@ handle <: $ia_handler :> => sub {
     return "plain text response",
         structured_answer => {
 
-            # ID - Must be unique and match Instant Answer page
-            # E.g. https://duck.co/ia/view/calculator has `id => 'calculator'``
-            id => '<: $ia_id :>',
-
-            # Name - Used for Answer Bar Tab
-            # Value should be chosen from existing Instant Answer topics
-            # see http://docs.duckduckhack.com/frontend-reference/display-reference.html#name-string-required
-            name => 'Answer',
-
             data => {
               title => "My Instant Answer Title",
               subtitle => "My Subtitle",

--- a/template/lib/DDG/Goodie/Minimal.pm
+++ b/template/lib/DDG/Goodie/Minimal.pm
@@ -21,15 +21,6 @@ handle <: $ia_handler :> => sub {
     return "plain text response",
         structured_answer => {
 
-            # ID - Must be unique and match Instant Answer page
-            # E.g. https://duck.co/ia/view/calculator has `id => 'calculator'``
-            id => '<: $ia_id :>',
-
-            # Name - Used for Answer Bar Tab
-            # Value should be chosen from existing Instant Answer topics
-            # see https://duck.co/duckduckhack/display_reference#codenamecode-emstringem-required
-            name => 'Answer',
-
             data => {
                 <: $ia_handler :> => \<: $ia_handler_var :>_
             },

--- a/template/share/goodie/example/example.js
+++ b/template/share/goodie/example/example.js
@@ -17,8 +17,6 @@ DDH.<: $ia_id :> = DDH.<: $ia_id :> || {};
 
         return {
 
-            id: '<: $ia_id :>',
-
             meta: {
                 sourceName: "Source Domain",
                 sourceUrl: "https://source.website.com"

--- a/template/t/Example.t
+++ b/template/t/Example.t
@@ -8,12 +8,38 @@ use DDG::Test::Goodie;
 zci answer_type => "<: $ia_id :>";
 zci is_cached   => 1;
 
+# Build a structured answer that should match the response from the
+# Perl file.
+sub build_structured_answer {
+    my @test_params = @_;
+
+    return "plain text response",
+        structured_answer => {
+
+            data => {
+              title => "My Instant Answer Title",
+              subtitle => "My Subtitle",
+              # image => "http://website.com/image.png"
+            },
+
+            templates => {
+                group => "text",
+                # options => {
+                #
+                # }
+            }
+        };
+}
+
+# Use this to build expected results for your tests.
+sub build_test { test_zci(build_structured_answer(@_)) }
+
 ddg_goodie_test(
     [qw( DDG::Goodie::<: $ia_package_name :> )],
     # At a minimum, be sure to include tests for all:
     # - primary_example_queries
     # - secondary_example_queries
-    'example query' => test_zci('query'),
+    'example query' => build_test('query'),
     # Try to include some examples of queries on which it might
     # appear that your answer will trigger, but does not.
     'bad example query' => undef,


### PR DESCRIPTION
@zachthompson @moollaza I've removed the ID and name attributes from the structured answers in the templates.

I have also (you may disagree with this) added a template for building the structured answer response in tests. Seeing as we are removing 'simple' structured answers I feel this is appropriate as it will reduce the visual load of having many structured answer definitions. Additionally it should make it easier to move to a new testing system if desirable in the future.