### PR TITLE
Braille: fix for bad triggers #2771

### DIFF
--- a/lib/DDG/Goodie/Braille.pm
+++ b/lib/DDG/Goodie/Braille.pm
@@ -34,7 +34,7 @@ handle query_raw => sub {
       structured_answer => {
           data => {
               title    => $response,
-              subtitle => 'Translate "' . $query . '" to ' . $type,
+              subtitle => 'Braille translation: ' . html_enc($query),
           },
           templates => {
               group => 'text',

--- a/lib/DDG/Goodie/Braille.pm
+++ b/lib/DDG/Goodie/Braille.pm
@@ -7,7 +7,7 @@ use DDG::Goodie;
 use Convert::Braille;
 use utf8;
 
-triggers query_raw => qr/\p{Braille}|( in|to){1} braille$|^braille:/i;
+triggers query_raw => qr/\p{Braille}|( in| to){1} braille$|^braille:/i;
 
 zci is_cached => 1;
 
@@ -16,26 +16,29 @@ my $braille_space = '⠀';    # the braille unicode space (U+2800)
 handle query_raw => sub {
 
     my $query = $_;
-    $query =~ s/( in|to){1} braille$|^braille: //;
+    $query =~ s/( in| to){1} braille$|^braille:\s?//;
     return unless $query;
 
-    my $result;
+    my $response;
     my $type;
 
     if ($query =~ /\p{Braille}/) {
-        $result = join(" ", map { lc(brailleDotsToAscii($_)) } split(/$braille_space/, $query));
+        $response = join(" ", map { lc(brailleDotsToAscii($_)) } split(/$braille_space/, $query));
         $type = "Ascii/Unicode";
     } else {
-        $result = join($braille_space, map { brailleAsciiToUnicode(uc $_) } split(/\s/, $query));
+        $response = join($braille_space, map { brailleAsciiToUnicode(uc $_) } split(/\s/, $query));
         $type = "Braille";
     }
 
-    return answer => $result,
-      answer_type => $type,
+    return $response,
       structured_answer => {
-        input     => [$query],
-        operation => 'Braille translation',
-        result    => html_enc($result),
+          data => {
+              title    => $response,
+              subtitle => 'Translate "' . $query . '" to ' . $type,
+          },
+          templates => {
+              group => 'text',
+          },
       };
 };
 

--- a/t/Braille.t
+++ b/t/Braille.t
@@ -11,12 +11,12 @@ zci answer_type => 'braille';
 zci is_cached   => 1;
 
 sub build_structured_answer {
-    my ($query, $response, $type) = @_;
+    my ($query, $response) = @_;
     return $response,
         structured_answer => {
             data => {
                 title    => $response,
-                subtitle => 'Translate "' . $query . '" to ' . $type,
+                subtitle => 'Braille translation: ' . $query,
             },
             templates => {
                 group => 'text',
@@ -29,14 +29,14 @@ sub build_test { test_zci(build_structured_answer(@_)) }
 ddg_goodie_test(
     [qw( DDG::Goodie::Braille)],
     # Ascii/Unicode -> Braille
-    'hello in braille'                => build_test('hello', '⠓⠑⠇⠇⠕', 'Braille'),
-    'hello to braille'                => build_test('hello', '⠓⠑⠇⠇⠕', 'Braille'),
-    'translate to braille to braille' => build_test('translate to braille', '⠞⠗⠁⠝⠎⠇⠁⠞⠑⠀⠞⠕⠀⠃⠗⠁⠊⠇⠇⠑', 'Braille'),
-    'braille: asdf k'                 => build_test('asdf k', '⠁⠎⠙⠋⠀⠅', 'Braille'),
+    'hello in braille'                => build_test('hello', '⠓⠑⠇⠇⠕'),
+    'hello to braille'                => build_test('hello', '⠓⠑⠇⠇⠕'),
+    'translate to braille to braille' => build_test('translate to braille', '⠞⠗⠁⠝⠎⠇⠁⠞⠑⠀⠞⠕⠀⠃⠗⠁⠊⠇⠇⠑'),
+    'braille: asdf k'                 => build_test('asdf k', '⠁⠎⠙⠋⠀⠅'),
     # Braille -> Ascii/Unicode
-    '⠓⠑⠀⠇⠇⠕'                       => build_test('⠓⠑⠀⠇⠇⠕', 'he llo', 'Ascii/Unicode'),
-    '⠞⠗⠁⠝⠎⠇⠁⠞⠑⠀⠞⠕⠀⠃⠗⠁⠊⠇⠇⠑'  => build_test('⠞⠗⠁⠝⠎⠇⠁⠞⠑⠀⠞⠕⠀⠃⠗⠁⠊⠇⠇⠑', 'translate to braille', 'Ascii/Unicode'),
-    '⠁⠎⠙⠋⠀⠅'                       => build_test('⠁⠎⠙⠋⠀⠅', 'asdf k', 'Ascii/Unicode'),
+    '⠓⠑⠀⠇⠇⠕'                       => build_test('&#x2813;&#x2811;&#x2800;&#x2807;&#x2807;&#x2815;', 'he llo'),
+    '⠞⠗⠁⠝⠎⠇⠁⠞⠑⠀⠞⠕⠀⠃⠗⠁⠊⠇⠇⠑'   => build_test('&#x281E;&#x2817;&#x2801;&#x281D;&#x280E;&#x2807;&#x2801;&#x281E;&#x2811;&#x2800;&#x281E;&#x2815;&#x2800;&#x2803;&#x2817;&#x2801;&#x280A;&#x2807;&#x2807;&#x2811;', 'translate to braille'),
+    '⠁⠎⠙⠋⠀⠅'                       => build_test('&#x2801;&#x280E;&#x2819;&#x280B;&#x2800;&#x2805;', 'asdf k'),
     # Invalid Queries
     'braille asdf k'                  => undef,
     'how long to learn braille'       => undef,

--- a/t/Braille.t
+++ b/t/Braille.t
@@ -10,62 +10,37 @@ use utf8;
 zci answer_type => 'braille';
 zci is_cached   => 1;
 
+sub build_structured_answer {
+    my ($query, $response, $type) = @_;
+    return $response,
+        structured_answer => {
+            data => {
+                title    => $response,
+                subtitle => 'Translate "' . $query . '" to ' . $type,
+            },
+            templates => {
+                group => 'text',
+            }
+        },
+}
+
+sub build_test { test_zci(build_structured_answer(@_)) }
+
 ddg_goodie_test(
     [qw( DDG::Goodie::Braille)],
-    'hello in braille' => test_zci(
-        "⠓⠑⠇⠇⠕ (Braille)",
-        structured_answer => {
-            input     => ['hello'],
-            operation => 'Braille translation',
-            result    => '&#x2813;&#x2811;&#x2807;&#x2807;&#x2815;'
-        }
-    ),
-    '⠓⠑⠇⠇⠕' => test_zci(
-        "hello (Braille)",
-        structured_answer => {
-            input     => ['&#x2813;&#x2811;&#x2807;&#x2807;&#x2815;'],
-            operation => 'Braille translation',
-            result    => 'hello'
-        }
-    ),
-    'translate to braille translate to braille' => test_zci(
-        "⠞⠗⠁⠝⠎⠇⠁⠞⠑⠀⠞⠕⠀⠃⠗⠁⠊⠇⠇⠑ (Braille)",
-        structured_answer => {
-            input     => ['translate to braille'],
-            operation => 'Braille translation',
-            result =>
-              '&#x281E;&#x2817;&#x2801;&#x281D;&#x280E;&#x2807;&#x2801;&#x281E;&#x2811;&#x2800;&#x281E;&#x2815;&#x2800;&#x2803;&#x2817;&#x2801;&#x280A;&#x2807;&#x2807;&#x2811;'
-        }
-    ),
-    '⠞⠗⠁⠝⠎⠇⠁⠞⠑⠀⠞⠕⠀⠃⠗⠁⠊⠇⠇⠑' => test_zci(
-        "translate to braille (Braille)",
-        structured_answer => {
-            input => [
-                '&#x281E;&#x2817;&#x2801;&#x281D;&#x280E;&#x2807;&#x2801;&#x281E;&#x2811;&#x2800;&#x281E;&#x2815;&#x2800;&#x2803;&#x2817;&#x2801;&#x280A;&#x2807;&#x2807;&#x2811;'
-            ],
-            operation => 'Braille translation',
-            result    => 'translate to braille'
-          }
-
-    ),
-    'braille asdf k' => test_zci(
-        "⠁⠎⠙⠋⠀⠅ (Braille)",
-        structured_answer => {
-            input     => ['asdf k'],
-            operation => 'Braille translation',
-            result    => '&#x2801;&#x280E;&#x2819;&#x280B;&#x2800;&#x2805;'
-          }
-
-    ),
-    '⠁⠎⠙⠋⠀⠅' => test_zci(
-        "asdf k (Braille)",
-        structured_answer => {
-            input     => ['&#x2801;&#x280E;&#x2819;&#x280B;&#x2800;&#x2805;'],
-            operation => 'Braille translation',
-            result    => 'asdf k'
-          }
-
-    ),
+    # Ascii/Unicode -> Braille
+    'hello in braille'                => build_test('hello', '⠓⠑⠇⠇⠕', 'Braille'),
+    'hello to braille'                => build_test('hello', '⠓⠑⠇⠇⠕', 'Braille'),
+    'translate to braille to braille' => build_test('translate to braille', '⠞⠗⠁⠝⠎⠇⠁⠞⠑⠀⠞⠕⠀⠃⠗⠁⠊⠇⠇⠑', 'Braille'),
+    'braille: asdf k'                 => build_test('asdf k', '⠁⠎⠙⠋⠀⠅', 'Braille'),
+    # Braille -> Ascii/Unicode
+    '⠓⠑⠀⠇⠇⠕'                       => build_test('⠓⠑⠀⠇⠇⠕', 'he llo', 'Ascii/Unicode'),
+    '⠞⠗⠁⠝⠎⠇⠁⠞⠑⠀⠞⠕⠀⠃⠗⠁⠊⠇⠇⠑'  => build_test('⠞⠗⠁⠝⠎⠇⠁⠞⠑⠀⠞⠕⠀⠃⠗⠁⠊⠇⠇⠑', 'translate to braille', 'Ascii/Unicode'),
+    '⠁⠎⠙⠋⠀⠅'                       => build_test('⠁⠎⠙⠋⠀⠅', 'asdf k', 'Ascii/Unicode'),
+    # Invalid Queries
+    'braille asdf k'                  => undef,
+    'how long to learn braille'       => undef,
+    'braille to braille is good'      => undef,
 );
 
 done_testing;


### PR DESCRIPTION
Fixes: #2771. Use specified triggers to avoid bad triggers. Also add types to show the result is in Braille or ASCII/Unicode. Removed `html_enc()` for `structured_answer->input` since it will show raw braille code instead of braille string.

https://duck.co/ia/view/braille