### PR TITLE
remove ID and Name from Goodie template Perl

### DIFF
--- a/template/lib/DDG/Goodie/Example.pm
+++ b/template/lib/DDG/Goodie/Example.pm
@@ -35,15 +35,6 @@ handle <: $ia_handler :> => sub {
     return "plain text response",
         structured_answer => {
 
-            # ID - Must be unique and match Instant Answer page
-            # E.g. https://duck.co/ia/view/calculator has `id => 'calculator'``
-            id => '<: $ia_id :>',
-
-            # Name - Used for Answer Bar Tab
-            # Value should be chosen from existing Instant Answer topics
-            # see http://docs.duckduckhack.com/frontend-reference/display-reference.html#name-string-required
-            name => 'Answer',
-
             data => {
               title => "My Instant Answer Title",
               subtitle => "My Subtitle",


### PR DESCRIPTION
We recently removed the `id` and `name` from all Goodies in the repo as the IA Pages already define this information.

This PR removes those elements from the template Perl file used by DuckPAN for the `duckpan new` command.

/cc @duckduckgo/community-leaders 

Let's keep an eye out for any lingering `id` and `name` in Goodies and point them out in any in-progress PR;s 