### PR TITLE
Remove bignum from is_cached in PrimeFactors.t

### DIFF
--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -74,7 +74,7 @@ sub commify {
 # Structured answer that will be returned
 sub format_answer {
     my ($plaintext, $title, $subtitle) = @_;
-    
+
     return $plaintext,
     structured_answer => {
         data => {
@@ -118,7 +118,7 @@ handle remainder => sub {
 
         @result = format_answer($plaintext, $answer, $subtitle);
     }
-    
+
     return @result;
 };
 

--- a/t/PrimeFactors.t
+++ b/t/PrimeFactors.t
@@ -9,14 +9,11 @@ use DDG::Test::Goodie;
 
 zci answer_type => "prime_factors";
 
-# Match the promotion in the IA
-use bignum;
 zci is_cached => 1;
-no bignum;
 
 sub build_answer {
     my ($subtitle, $title) = @_;
-    
+
     return structured_answer => {
         data => {
             title => $title,


### PR DESCRIPTION
Cleaning up PrimeFactors IA in preparation for https://github.com/duckduckgo/duckduckgo/pull/172

We no longer need to cast `is_cached` as a `bignum`.

https://duck.co/ia/view/prime_factors
