### PR TITLE
CheatSheets: Add 'help' trigger to 'reference' category

### DIFF
--- a/share/goodie/cheat_sheets/json/multisim.json
+++ b/share/goodie/cheat_sheets/json/multisim.json
@@ -7,7 +7,7 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/NI_Multisim"
   },
  "aliases": [
-        "multisim syntax", "multisim help", "multisim details"
+        "multisim syntax", "multisim details"
     ],
   "template_type": "reference",
     "section_order": [

--- a/share/goodie/cheat_sheets/triggers.yaml
+++ b/share/goodie/cheat_sheets/triggers.yaml
@@ -81,9 +81,9 @@ categories:
   # Serves as a fairly in-depth reference for a particular topic.
   reference:
     startend:
+      - "help"
       - "quick reference"
       - "reference"
-      - "help"
   # Describes commands that can be entered at a terminal.
   terminal:
     startend:

--- a/share/goodie/cheat_sheets/triggers.yaml
+++ b/share/goodie/cheat_sheets/triggers.yaml
@@ -83,6 +83,7 @@ categories:
     startend:
       - "quick reference"
       - "reference"
+      - "help"
   # Describes commands that can be entered at a terminal.
   terminal:
     startend:


### PR DESCRIPTION
@zachthompson This adds the necessary triggering for the cheat sheets over on duckduckgo/duckduckhack-docs#52.

Any templates using the `reference` category can now trigger with `help` - that is: `code`, `keyboard`, and `reference`.

Fixes #2831

/cc @Spagy @talsraviv 

---
IA Page: https://duck.co/ia/view/cheat_sheets
Maintainer: @zachthompson 

