### PR TITLE
Fix Potential XSS: HTML Encode title/subtile for URLEncode and URLDecode

### DIFF
--- a/lib/DDG/Goodie/URLDecode.pm
+++ b/lib/DDG/Goodie/URLDecode.pm
@@ -37,8 +37,8 @@ handle query_raw => sub {
 
     return $text, structured_answer => {
         data => {
-            title => $decoded,
-            subtitle => $subtitle
+            title => html_enc($decoded),
+            subtitle => html_enc($subtitle)
         },
         templates => {
             group => 'text',

--- a/lib/DDG/Goodie/URLEncode.pm
+++ b/lib/DDG/Goodie/URLEncode.pm
@@ -27,8 +27,8 @@ handle remainder => sub {
 
     return $text, structured_answer => {
         data => {
-            title => $encoded_url,
-            subtitle => $subtitle
+            title => html_enc($encoded_url),
+            subtitle => html_enc($subtitle)
         },
         templates => {
             group => 'text',

--- a/t/URLDecode.t
+++ b/t/URLDecode.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use utf8;
 use Test::More;
+use HTML::Entities;
 use DDG::Test::Goodie;
 
 zci answer_type => 'decoded_url';
@@ -15,8 +16,8 @@ sub build_answer {
 
     return sprintf("URL Decoded: %s",$answer) , structured_answer => {
         data => {
-            title => $answer,
-            subtitle => "URL decode: $sub"
+            title => encode_entities($answer),
+            subtitle => "URL decode: " . encode_entities($sub)
         },
         templates => {
             group => 'text',

--- a/t/URLEncode.t
+++ b/t/URLEncode.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use utf8;
 use Test::More;
+use HTML::Entities;
 use DDG::Test::Goodie;
 
 zci answer_type => 'encoded_url';
@@ -15,8 +16,8 @@ sub build_answer {
 
     return sprintf("Percent-encoded URL: %s",$answer) , structured_answer => {
         data => {
-            title => $answer,
-            subtitle => "URL percent-encode: $sub"
+            title => encode_entities($answer),
+            subtitle => "URL percent-encode: " . encode_entities($sub)
         },
         templates => {
             group => 'text',


### PR DESCRIPTION
Reported on IRC: These are breaking in production: 

https://duckduckgo.com/?q=url+decode+https%253A%252F%252Fduckduckgo.com%252F%3C%2Fscript%3E%3E

/cc @cngarrison @zachthompson 

---

/https://duck.co/ia/view/urldecode
Maintainer: @mintsoft 

/https://duck.co/ia/view/urlencode
Maintainer: @nishanths
