### PR TITLE
Timediff: Duration between two datetimes in a variety of units

### DIFF
--- a/lib/DDG/Goodie/Timediff.pm
+++ b/lib/DDG/Goodie/Timediff.pm
@@ -6,7 +6,7 @@ use DDG::Goodie;
 with 'DDG::GoodieRole::Dates';
 with 'DDG::GoodieRole::NumberStyler';
 
-triggers any => qw(timediff);
+triggers any => ["timediff", "time difference", "minutes between", "seconds between","hours between", "duration between"];
 
 zci is_cached   => 0;
 zci answer_type => 'timediff';

--- a/lib/DDG/Goodie/Timediff.pm
+++ b/lib/DDG/Goodie/Timediff.pm
@@ -28,6 +28,7 @@ handle remainder => sub {
     return "$duration seconds",
         structured_answer => {
             data => {
+                title => "".date_output_string($dates[0], true)." - ".date_output_string($dates[1], true),
                 record_data => {
                     seconds => $style->for_display($duration),
                     minutes => $style->for_display($duration/60),

--- a/lib/DDG/Goodie/Timediff.pm
+++ b/lib/DDG/Goodie/Timediff.pm
@@ -11,8 +11,8 @@ triggers any => qw(timediff);
 zci is_cached   => 0;
 zci answer_type => 'timediff';
 
-
 my $datestring_regex = datestring_regex();
+my $style = number_style_for("1");
 
 handle remainder => sub {
     my $query = $_;
@@ -22,18 +22,25 @@ handle remainder => sub {
     my @dates = parse_all_datestrings_to_date($1,$2);
     my $duration = abs $dates[0]->epoch - $dates[1]->epoch;
     
+    my %answer = {
+        seconds => $style->for_display($duration),
+        minutes => $style->for_display($duration/60),
+        hours => $style->for_display($duration/3600),
+        days => $style->for_display($duration/86400)
+    };
+    my @keys = sort keys %answer;
+    
     return "$duration seconds",
         structured_answer => {
             data => {
-                seconds => $duration,
-                minutes => $duration/60,
-                hours => $duration/3600,
-                days => $duration/86400
+                record_data => \%answer,
+                record_keys => \@keys,
             },
             templates => {
-                group => 'text',
+                group => 'list',
                 options => {
-                    content => 'DDH.timediff.content'
+                    content => 'record',
+                    moreAt => 0
                 }
             }
         };

--- a/lib/DDG/Goodie/Timediff.pm
+++ b/lib/DDG/Goodie/Timediff.pm
@@ -6,7 +6,9 @@ use DDG::Goodie;
 with 'DDG::GoodieRole::Dates';
 with 'DDG::GoodieRole::NumberStyler';
 
-triggers any => ["timediff", "time difference", "minutes between", "seconds between","hours between", "duration between"];
+my @units = qw(days hours minutes seconds);
+
+triggers any => ["timediff", "duration", "time difference", map {"$_ between"} @units];
 
 zci is_cached   => 0;
 zci answer_type => 'timediff';
@@ -32,7 +34,7 @@ handle remainder => sub {
                     hours   => $style->for_display($duration/3600),
                     days    => $style->for_display($duration/86400)
                 },
-                record_keys => ['days', 'hours', 'minutes', 'seconds'],
+                record_keys => \@units,
             },
             templates => {
                 group => 'list',

--- a/lib/DDG/Goodie/Timediff.pm
+++ b/lib/DDG/Goodie/Timediff.pm
@@ -29,8 +29,8 @@ handle remainder => sub {
                 record_data => {
                     seconds => $style->for_display($duration),
                     minutes => $style->for_display($duration/60),
-                    hours => $style->for_display($duration/3600),
-                    days => $style->for_display($duration/86400)
+                    hours   => $style->for_display($duration/3600),
+                    days    => $style->for_display($duration/86400)
                 },
                 record_keys => ['days', 'hours', 'minutes', 'seconds'],
             },

--- a/lib/DDG/Goodie/Timediff.pm
+++ b/lib/DDG/Goodie/Timediff.pm
@@ -22,19 +22,16 @@ handle remainder => sub {
     my @dates = parse_all_datestrings_to_date($1,$2);
     my $duration = abs $dates[0]->epoch - $dates[1]->epoch;
     
-    my %answer = {
-        seconds => $style->for_display($duration),
-        minutes => $style->for_display($duration/60),
-        hours => $style->for_display($duration/3600),
-        days => $style->for_display($duration/86400)
-    };
-    my @keys = sort keys %answer;
-    
     return "$duration seconds",
         structured_answer => {
             data => {
-                record_data => \%answer,
-                record_keys => \@keys,
+                record_data => {
+                    seconds => $style->for_display($duration),
+                    minutes => $style->for_display($duration/60),
+                    hours => $style->for_display($duration/3600),
+                    days => $style->for_display($duration/86400)
+                },
+                record_keys => ['days', 'hours', 'minutes', 'seconds'],
             },
             templates => {
                 group => 'list',

--- a/lib/DDG/Goodie/Timediff.pm
+++ b/lib/DDG/Goodie/Timediff.pm
@@ -20,6 +20,7 @@ handle remainder => sub {
     return unless $query =~ /^(?:between\s)?($datestring_regex)\s(?:and\s)?($datestring_regex)$/i;
     
     my @dates = parse_all_datestrings_to_date($1,$2);
+    return unless((scalar @dates) == 2);
     my $duration = abs $dates[0]->epoch - $dates[1]->epoch;
     
     return "$duration seconds",

--- a/lib/DDG/Goodie/Timediff.pm
+++ b/lib/DDG/Goodie/Timediff.pm
@@ -1,0 +1,42 @@
+package DDG::Goodie::Timediff;
+# ABSTRACT: provides the duration between dates
+
+use strict;
+use DDG::Goodie;
+with 'DDG::GoodieRole::Dates';
+with 'DDG::GoodieRole::NumberStyler';
+
+triggers any => qw(timediff);
+
+zci is_cached   => 0;
+zci answer_type => 'timediff';
+
+
+my $datestring_regex = datestring_regex();
+
+handle remainder => sub {
+    my $query = $_;
+
+    return unless $query =~ /^(?:between\s)?($datestring_regex)\s(?:and\s)?($datestring_regex)$/i;
+    
+    my @dates = parse_all_datestrings_to_date($1,$2);
+    my $duration = $dates[0]->epoch - $dates[1]->epoch;
+    
+    return "$duration seconds",
+        structured_answer => {
+            data => {
+                seconds => $duration,
+                minutes => $duration/60,
+                hours => $duration/3600,
+                days => $duration/8400
+            },
+            templates => {
+                group => 'text',
+                options => {
+                    content => 'DDH.timediff.content'
+                }
+            }
+        };
+};
+
+1;

--- a/lib/DDG/Goodie/Timediff.pm
+++ b/lib/DDG/Goodie/Timediff.pm
@@ -20,7 +20,7 @@ handle remainder => sub {
     return unless $query =~ /^(?:between\s)?($datestring_regex)\s(?:and\s)?($datestring_regex)$/i;
     
     my @dates = parse_all_datestrings_to_date($1,$2);
-    my $duration = $dates[0]->epoch - $dates[1]->epoch;
+    my $duration = abs $dates[0]->epoch - $dates[1]->epoch;
     
     return "$duration seconds",
         structured_answer => {
@@ -28,7 +28,7 @@ handle remainder => sub {
                 seconds => $duration,
                 minutes => $duration/60,
                 hours => $duration/3600,
-                days => $duration/8400
+                days => $duration/86400
             },
             templates => {
                 group => 'text',

--- a/t/Timediff.t
+++ b/t/Timediff.t
@@ -39,7 +39,7 @@ ddg_goodie_test(
         })
     ),
 	
-	'timediff examples' = > undef,
-	'timediff function' = > undef,
+	'timediff examples' => undef,
+	'timediff function' => undef,
 );
 done_testing;

--- a/t/Timediff.t
+++ b/t/Timediff.t
@@ -7,7 +7,7 @@ use utf8;
 zci answer_type => 'timediff';
 zci is_cached   => 0;
 
-sub make_answer(%){
+sub make_answer {
     my ($input) = @_;
     
     return {
@@ -51,7 +51,37 @@ ddg_goodie_test(
 			days => "2.04166666666667",
         })
     ),
+    
+    'timediff 2016-04-08T20:00:00 2016-04-10T21:00:00' => test_zci(
+        "176400 seconds",
+        structured_answer => make_answer({
+			seconds => "176,400",
+			minutes => "2,940",
+			hours => "49",
+			days => "2.04166666666667",
+        })
+    ),
+    
+    'seconds between Sat, 09 Aug 2014 18:20:00 and Sun, 11 Aug 2014 01:01:08' => test_zci(
+        "110468 seconds",
+        structured_answer => make_answer({
+            seconds => "110,468",
+            minutes => "1,841.13333333333",
+            hours => "30.6855555555556",
+            days => "1.27856481481481",
+        })
+    ),
 	
+    'minutes between Sat, 13 Mar 2010 11:29:05 and Sat, 13 Mar 2010 12:29:05' => test_zci(
+        "3600 seconds",
+        structured_answer => make_answer({
+            seconds => "3,600",
+            minutes => "60",
+            hours => "1",
+            days => "0.0416666666666667",
+        })
+    ),
+    
 	'timediff examples' => undef,
 	'timediff function' => undef,
 );

--- a/t/Timediff.t
+++ b/t/Timediff.t
@@ -20,7 +20,7 @@ sub make_answer(%){
         templates => {
             group => 'text',
             options => {
-                content => 'DDH.conversions.timediff'
+                content => 'DDH.timediff.content'
             }
         }
     };

--- a/t/Timediff.t
+++ b/t/Timediff.t
@@ -4,6 +4,8 @@ use warnings;
 use Test::More;
 use DDG::Test::Goodie;
 use utf8;
+use Test::MockTime qw( :all );
+
 zci answer_type => 'timediff';
 zci is_cached   => 0;
 
@@ -120,4 +122,24 @@ ddg_goodie_test(
 	'timediff examples' => undef,
 	'timediff function' => undef,
 );
+
+set_fixed_time('2015-07-14T22:36:00');
+
+ddg_goodie_test(
+    [qw( DDG::Goodie::Timediff)],
+    'days between 22nd may and 15th jul' => test_zci(
+        '4665600 seconds',
+        structured_answer => make_answer({
+            seconds => "4,665,600",
+            minutes => "77,760",
+            hours => "1,296",
+            days => "54",
+            in1 => "22 May 2015 00:00:00 EDT",
+            in2 => "15 Jul 2015 00:00:00 EDT"
+        }),
+    ),
+);
+
+restore_time();
+
 done_testing;

--- a/t/Timediff.t
+++ b/t/Timediff.t
@@ -82,6 +82,26 @@ ddg_goodie_test(
         })
     ),
     
+    'hours between 13 Mar 2010 11:29:05 and 13 Mar 2010 12:29:05' => test_zci(
+        "3600 seconds",
+        structured_answer => make_answer({
+            seconds => "3,600",
+            minutes => "60",
+            hours => "1",
+            days => "0.0416666666666667",
+        })
+    ),
+    
+    'days between 13/05/2016 and 01/06/2016' => test_zci(
+        "1641600 seconds",
+        structured_answer => make_answer({
+            seconds => "1,641,600",
+            minutes => "27,360",
+            hours => "456",
+            days => "19",
+        })
+    ),
+    
 	'timediff examples' => undef,
 	'timediff function' => undef,
 );

--- a/t/Timediff.t
+++ b/t/Timediff.t
@@ -39,10 +39,10 @@ ddg_goodie_test(
     'timediff 2016-04-11T09:00:00 2016-04-08T18:17:00' => test_zci(
         "225780 seconds",
         structured_answer => make_answer({
-			seconds => "225,780",
-			minutes => "3,763",
-			hours => "62.7166666666667",
-			days => "2.61319444444444",
+            seconds => "225,780",
+            minutes => "3,763",
+            hours => "62.7166666666667",
+            days => "2.61319444444444",
             in1 => "11 Apr 2016 09:00:00 EDT",
             in2 => "08 Apr 2016 18:17:00 EDT"
         })
@@ -50,10 +50,10 @@ ddg_goodie_test(
     'timediff 2016-04-08T20:00:00 2016-04-10T21:00:00' => test_zci(
         "176400 seconds",
         structured_answer => make_answer({
-			seconds => "176,400",
-			minutes => "2,940",
-			hours => "49",
-			days => "2.04166666666667",
+            seconds => "176,400",
+            minutes => "2,940",
+            hours => "49",
+            days => "2.04166666666667",
             in1 => "08 Apr 2016 20:00:00 EDT", 
             in2 => "10 Apr 2016 21:00:00 EDT"
         })
@@ -62,10 +62,10 @@ ddg_goodie_test(
     'timediff 2016-04-08T20:00:00 2016-04-10T21:00:00' => test_zci(
         "176400 seconds",
         structured_answer => make_answer({
-			seconds => "176,400",
-			minutes => "2,940",
-			hours => "49",
-			days => "2.04166666666667",
+            seconds => "176,400",
+            minutes => "2,940",
+            hours => "49",
+            days => "2.04166666666667",
             in1 => "08 Apr 2016 20:00:00 EDT", 
             in2 => "10 Apr 2016 21:00:00 EDT"
         })
@@ -82,7 +82,7 @@ ddg_goodie_test(
             in2 => '11 Aug 2014 01:01:08 EDT'
         })
     ),
-	
+    
     'minutes between Sat, 13 Mar 2010 11:29:05 and Sat, 13 Mar 2010 12:29:05' => test_zci(
         "3600 seconds",
         structured_answer => make_answer({
@@ -119,8 +119,8 @@ ddg_goodie_test(
         })
     ),
     
-	'timediff examples' => undef,
-	'timediff function' => undef,
+    'timediff examples' => undef,
+    'timediff function' => undef,
 );
 
 set_fixed_time('2015-07-14T22:36:00');

--- a/t/Timediff.t
+++ b/t/Timediff.t
@@ -12,6 +12,7 @@ sub make_answer {
     
     return {
         data => {
+            title => "$input->{in1} - $input->{in2}",
             record_data => {
                 days    => $input->{'days'},
                 hours   => $input->{'hours'},
@@ -40,6 +41,8 @@ ddg_goodie_test(
 			minutes => "3,763",
 			hours => "62.7166666666667",
 			days => "2.61319444444444",
+            in1 => "11 Apr 2016 09:00:00 EDT",
+            in2 => "08 Apr 2016 18:17:00 EDT"
         })
     ),
     'timediff 2016-04-08T20:00:00 2016-04-10T21:00:00' => test_zci(
@@ -49,6 +52,8 @@ ddg_goodie_test(
 			minutes => "2,940",
 			hours => "49",
 			days => "2.04166666666667",
+            in1 => "08 Apr 2016 20:00:00 EDT", 
+            in2 => "10 Apr 2016 21:00:00 EDT"
         })
     ),
     
@@ -59,6 +64,8 @@ ddg_goodie_test(
 			minutes => "2,940",
 			hours => "49",
 			days => "2.04166666666667",
+            in1 => "08 Apr 2016 20:00:00 EDT", 
+            in2 => "10 Apr 2016 21:00:00 EDT"
         })
     ),
     
@@ -69,6 +76,8 @@ ddg_goodie_test(
             minutes => "1,841.13333333333",
             hours => "30.6855555555556",
             days => "1.27856481481481",
+            in1 => "09 Aug 2014 18:20:00 EDT",
+            in2 => '11 Aug 2014 01:01:08 EDT'
         })
     ),
 	
@@ -79,6 +88,8 @@ ddg_goodie_test(
             minutes => "60",
             hours => "1",
             days => "0.0416666666666667",
+            in1 => "13 Mar 2010 11:29:05 EST",
+            in2 => "13 Mar 2010 12:29:05 EST"
         })
     ),
     
@@ -89,6 +100,8 @@ ddg_goodie_test(
             minutes => "60",
             hours => "1",
             days => "0.0416666666666667",
+            in1 => "13 Mar 2010 11:29:05 EST",
+            in2 => "13 Mar 2010 12:29:05 EST"
         })
     ),
     
@@ -99,6 +112,8 @@ ddg_goodie_test(
             minutes => "27,360",
             hours => "456",
             days => "19",
+            in1 => "13 May 2016 00:00:00 EDT",
+            in2 => "01 Jun 2016 00:00:00 EDT"
         })
     ),
     

--- a/t/Timediff.t
+++ b/t/Timediff.t
@@ -35,7 +35,16 @@ ddg_goodie_test(
 			seconds => 225780,
 			minutes => 3763,
 			hours => 62.7166666666667,
-			days => 26.8785714285714,
+			days => 2.61319444444444,
+        })
+    ),
+    'timediff 2016-04-08T20:00:00 2016-04-10T21:00:00' => test_zci(
+        "176400 seconds",
+        structured_answer => make_answer({
+			seconds => 176400,
+			minutes => 2940,
+			hours => 49,
+			days => 2.04166666666667,
         })
     ),
 	

--- a/t/Timediff.t
+++ b/t/Timediff.t
@@ -12,15 +12,19 @@ sub make_answer(%){
     
     return {
         data => {
-            days    => $input->{'days'},
-            hours   => $input->{'hours'},
-            minutes => $input->{'minutes'},
-            seconds => $input->{'seconds'},
+            record_data => {
+                days    => $input->{'days'},
+                hours   => $input->{'hours'},
+                minutes => $input->{'minutes'},
+                seconds => $input->{'seconds'},
+            },
+            record_keys => ['days', 'hours', 'minutes', 'seconds']
         },
         templates => {
-            group => 'text',
+            group => 'list',
             options => {
-                content => 'DDH.timediff.content'
+                content => 'record',
+                moreAt => 0
             }
         }
     };
@@ -32,19 +36,19 @@ ddg_goodie_test(
     'timediff 2016-04-11T09:00:00 2016-04-08T18:17:00' => test_zci(
         "225780 seconds",
         structured_answer => make_answer({
-			seconds => 225780,
-			minutes => 3763,
-			hours => 62.7166666666667,
-			days => 2.61319444444444,
+			seconds => "225,780",
+			minutes => "3,763",
+			hours => "62.7166666666667",
+			days => "2.61319444444444",
         })
     ),
     'timediff 2016-04-08T20:00:00 2016-04-10T21:00:00' => test_zci(
         "176400 seconds",
         structured_answer => make_answer({
-			seconds => 176400,
-			minutes => 2940,
-			hours => 49,
-			days => 2.04166666666667,
+			seconds => "176,400",
+			minutes => "2,940",
+			hours => "49",
+			days => "2.04166666666667",
         })
     ),
 	

--- a/t/Timediff.t
+++ b/t/Timediff.t
@@ -1,0 +1,45 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Goodie;
+use utf8;
+zci answer_type => 'timediff';
+zci is_cached   => 0;
+
+sub make_answer(%){
+    my ($input) = @_;
+    
+    return {
+        data => {
+            days    => $input->{'days'},
+            hours   => $input->{'hours'},
+            minutes => $input->{'minutes'},
+            seconds => $input->{'seconds'},
+        },
+        templates => {
+            group => 'text',
+            options => {
+                content => 'DDH.conversions.timediff'
+            }
+        }
+    };
+}
+
+ddg_goodie_test(
+    ['DDG::Goodie::Timediff'],
+
+    'timediff 2016-04-11T09:00:00 2016-04-08T18:17:00' => test_zci(
+        "225780 seconds",
+        structured_answer => make_answer({
+			seconds => 225780,
+			minutes => 3763,
+			hours => 62.7166666666667,
+			days => 26.8785714285714,
+        })
+    ),
+	
+	'timediff examples' = > undef,
+	'timediff function' = > undef,
+);
+done_testing;


### PR DESCRIPTION
I found myself looking through a variety of logs today and there's no IA for finding how long it is between two points in time, we have one for days etc but not timestamps accurate to the second. Hence this IA

![timediff](https://cloud.githubusercontent.com/assets/978048/14405017/70275b5a-fe7c-11e5-939e-a54501d4c6b4.png)

-----------

https://duck.co/ia/view/timediff