### PR TITLE
AsciiCodeCheatSheet: Adding Numbers so the tests pass

### DIFF
--- a/share/goodie/cheat_sheets/json/asciicode.json
+++ b/share/goodie/cheat_sheets/json/asciicode.json
@@ -18,6 +18,7 @@
     "section_order": [
         "Special Characters",
         "Special Characters (continued)",
+        "Numbers",
         "Upper Case",
         "Lower Case"
     ],


### PR DESCRIPTION
@moollaza this cheatsheet fails the tests, and for some reason they didn't run on the PR!
It's missing the numbers section; so I've added it where I think it should go

---------------
IA Page: https://duck.co/ia/view/ascii_code_cheat_sheet