### PR TITLE
Constants: Adding use strict to force Perl 5 detection

### DIFF
--- a/lib/DDG/Goodie/Constants.pm
+++ b/lib/DDG/Goodie/Constants.pm
@@ -1,5 +1,8 @@
 package DDG::Goodie::Constants;
 # ABSTRACT: Various Math and Physics constants.
+
+use strict;
+use warnings;
 use DDG::Goodie;
 use YAML::XS qw( LoadFile );
 


### PR DESCRIPTION
Yet another example when linguist has screwed up the language detection ¬_¬

Ref: https://github.com/github/linguist/issues/2149

------------------
IA Page: https://duck.co/ia/view/constants