### PR TITLE
Cheatsheet Fixes

### DIFF
--- a/share/goodie/cheat_sheets/json/aws-lambda.json
+++ b/share/goodie/cheat_sheets/json/aws-lambda.json
@@ -8,7 +8,6 @@
 		"sourceUrl": "https://github.com/jalateras/aws-lambda-cheatsheet/blob/master/README.md"
 	},
 	"aliases": [
-		"aws basics",
 		"lambda services"
 	],
 	"section_order": [

--- a/share/goodie/cheat_sheets/json/wunderlist-mac.json
+++ b/share/goodie/cheat_sheets/json/wunderlist-mac.json
@@ -1,5 +1,5 @@
 {
-    "id": "wunderlist_mac",
+    "id": "wunderlist_mac_cheat_sheet",
     "name": "Wunderlist",
     "description": "Keyboard shortcuts for the Wunderlist to-do list manager for mac",
     "metadata": {


### PR DESCRIPTION
I merged a couple PRs that didn't appear to be in a failing state, turns out they were :frowning: 

This fixes them!

- Corrected Wunderlist Mac ID
- Removed overlapping alias from AWS Lamba

https://duck.co/ia/view/wunderlist_mac_cheat_sheet
https://duck.co/ia/view/aws_lambda_cheat_sheet