### PR TITLE
Red Hat cheatsheet: Added aliases and naming consistency

### DIFF
--- a/share/goodie/cheat_sheets/json/redhat.json
+++ b/share/goodie/cheat_sheets/json/redhat.json
@@ -11,15 +11,15 @@
     ],
     "template_type": "terminal",
     "section_order": [
-        "Yum queries",
+        "Yum Queries",
         "Troubleshoot",
-        "Package maintenance",
+        "Package Maintenance",
         "Repositories",
-        "Options for the yum command",
+        "Options for the Yum Command",
         "Miscellaneous"
     ],
     "sections": {
-        "Yum queries": [{
+        "Yum Queries": [{
             "key":"help",
             "val":"Displays yum commands and options"
         },{
@@ -57,7 +57,7 @@
             "key":"fs",
             "val":"Act on file system"
         }],
-        "Package maintenance": [{
+        "Package Maintenance": [{
             "key":"install",
             "val":"Install a package from a repository to your system"
         },{
@@ -101,7 +101,7 @@
             "key":"makecache",
             "val":"Download yum repository data to cache"
         }],
-        "Options for the yum command":[{
+        "Options for the Yum Command":[{
             "key":"-y",
             "val":"Assume yes if prompted"
         },{

--- a/share/goodie/cheat_sheets/json/redhat.json
+++ b/share/goodie/cheat_sheets/json/redhat.json
@@ -1,18 +1,21 @@
 {
     "id": "redhat_cheat_sheet",
-    "name": "Redhat Commands",
-    "description": "Yum Commands for Redhat Enterprise ",
+    "name": "Red Hat Yum Commands",
+    "description": "Yum Commands for Red Hat Enterprise ",
     "metadata": {
-        "sourceName": "Redhat",
+        "sourceName": "Red Hat",
         "sourceUrl": "https://access.redhat.com/articles/yum-cheat-sheet"
     },
+    "aliases": [
+        "red hat", "redhat yum", "redhat enterprise yum", "red hat yum", "red hat enterprise yum"
+    ],
     "template_type": "terminal",
     "section_order": [
-        "Yum Queries",
+        "Yum queries",
         "Troubleshoot",
         "Package maintenance",
         "Repositories",
-        "Options for YUM command",
+        "Options for the yum command",
         "Miscellaneous"
     ],
     "sections": {
@@ -98,7 +101,7 @@
             "key":"makecache",
             "val":"Download yum repository data to cache"
         }],
-        "Options for YUM command":[{
+        "Options for the yum command":[{
             "key":"-y",
             "val":"Assume yes if prompted"
         },{

--- a/share/goodie/cheat_sheets/json/redhat.json
+++ b/share/goodie/cheat_sheets/json/redhat.json
@@ -19,7 +19,7 @@
         "Miscellaneous"
     ],
     "sections": {
-        "Yum Queries": [{
+        "Yum queries": [{
             "key":"help",
             "val":"Displays yum commands and options"
         },{


### PR DESCRIPTION
Look at the official site, they seem to be called "Red Hat" (with a space).
Also added the aliases as this cheat sheet is specifically about yum.

---
https://duck.co/ia/view/redhat_cheat_sheet
Maintainer: @ankushg07 