### PR TITLE
Fix casing in Section Order

### DIFF
--- a/share/goodie/cheat_sheets/json/arduino.json
+++ b/share/goodie/cheat_sheets/json/arduino.json
@@ -161,7 +161,7 @@
                 "val": "Not"
             }
         ],
-        "Bitwise operators": [
+        "Bitwise Operators": [
             {
                 "key": "&",
                 "val": "And"


### PR DESCRIPTION
Fixed casing typo in section_order

https://duck.co/ia/view/arduino_cheat_sheet