### PR TITLE
Elixir Cheat Sheet: Fix typo

### DIFF
--- a/share/goodie/cheat_sheets/json/elixir.json
+++ b/share/goodie/cheat_sheets/json/elixir.json
@@ -11,7 +11,7 @@
         "Equality",
         "Other Operators",
         "Example Functions",
-        "Arithemetic",
+        "Arithmetic",
         "Sigils",
         "Types"
     ],
@@ -62,7 +62,7 @@
             "val": "less than or equal to",
             "key": "<="
         }],
-        "Arithemetic": [{
+        "Arithmetic": [{
             "val": "plus",
             "key": "+"
         }, {


### PR DESCRIPTION
This PR fix a small typo in the Elixir Cheat Sheet.

-----
IA Page:  https://duck.co/ia/view/elixir_cheat_sheet 
[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @pjhampton