### PR TITLE
ConvertLatLon: Replace minus sign with hyphen (#2920)

### DIFF
--- a/lib/DDG/Goodie/ConvertLatLon.pm
+++ b/lib/DDG/Goodie/ConvertLatLon.pm
@@ -235,7 +235,7 @@ sub format_dms {
 
     #Otherwise, add a minus sign if negative
     } elsif ($dmsSign == -1) {
-        $formatted = '−' . $formatted;
+        $formatted = '-' . $formatted;
     }
 
     return $formatted;
@@ -253,7 +253,7 @@ sub format_decimal {
     if ($cardinal) {
         $formatted .= ' ' . uc($cardinal);
     } elsif ($decDegrees / abs($decDegrees) == -1) {
-        $formatted = '−' . $formatted;
+        $formatted = '-' . $formatted;
     }
 
     return $formatted;

--- a/t/ConvertLatLon.t
+++ b/t/ConvertLatLon.t
@@ -31,11 +31,12 @@ ddg_goodie_test(
             result    => "71.1675&deg; E",
         }
     ),
-    '- 16º 30\' 0" - 68º 9\' 0" as decimal' => test_zci('−16.5° −68.15°',
+    '-16º 30\' 0" -68º 9\' 0" as decimal' => test_zci('-16.5° -68.15°'
+      ,
         structured_answer => {
-            input     => ["−16° 30′", "−68° 9′"],
+            input     => ["-16° 30′", "-68° 9′"],
             operation => "Convert to decimal",
-            result    => "&minus;16.5&deg;, &minus;68.15&deg;",
+            result    => "-16.5&deg;, -68.15&deg;",
         }
     ),
     #Latitudes and longitudes of cities, various trigger combinations


### PR DESCRIPTION
Fixes #2920: replace Unicode minus sign with a hyphen when displaying negative latitudes or longitudes, to allow easier copy pasting to mapping services.

[https://duck.co/ia/view/convert_lat_lon](https://duck.co/ia/view/convert_lat_lon)