### PR TITLE
Constants: Increased display priority

### DIFF
--- a/lib/DDG/Goodie/Constants.pm
+++ b/lib/DDG/Goodie/Constants.pm
@@ -36,7 +36,10 @@ handle query_lc => sub {
     return $result, structured_answer => {
         input     => [],
         operation => $constant->{'name'},
-        result    => $result
+        result    => $result,
+        meta      => {
+            signal => 'high'
+        }
     };
 };
 

--- a/t/Constants.t
+++ b/t/Constants.t
@@ -17,6 +17,7 @@ ddg_goodie_test(
             input     => [],
             operation => 'Hardy Ramanujan Number 1729',
             result    => "1<sup>3</sup> + 12<sup>3</sup> = 9<sup>3</sup> + 10<sup>3</sup>",
+            meta      => {signal => 'high'}
         }
     ),
     #without apostrophe
@@ -26,6 +27,7 @@ ddg_goodie_test(
             input => [],
             operation => 'Avogadro\'s Number',
             result => '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
+            meta      => {signal => 'high'}
         }
     ),
     #with apostrophe
@@ -35,6 +37,7 @@ ddg_goodie_test(
             input => [],
             operation => 'Avogadro\'s Number',
             result => '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
+            meta      => {signal => 'high'}
         }
     ),
     #constant without html (only plain)
@@ -44,6 +47,7 @@ ddg_goodie_test(
             input => [],
             operation => 'Euler\'s Constant',
             result => '0.577215665',
+            meta      => {signal => 'high'}
         }
     ),
     "How old is my grandma?" => undef,


### PR DESCRIPTION
Setting the signal to `high` so that its display takes priority over the Wikipedia info box.

(Requested in the [Django subreddit](https://www.reddit.com/r/django/comments/4gpkh1/help_improve_duckduckgos_djangorelated_searches/d2juky0))

---
https://duck.co/ia/view/constants