### PR TITLE
Vim Cheat Sheet: put exit commands at the top

### DIFF
--- a/lib/DDG/Goodie/HexToASCII.pm
+++ b/lib/DDG/Goodie/HexToASCII.pm
@@ -7,7 +7,8 @@ use DDG::Goodie;
 # Used to restrict long generated outputs
 use constant MAX_INPUT_CHARS => 128;
 
-triggers start => 'ascii';
+triggers startend => 'ascii', 'hex to ascii';
+triggers end => 'to ascii', 'as ascii';
 
 zci is_cached   => 1;
 zci answer_type => 'ascii';

--- a/share/goodie/cheat_sheets/json/swift.json
+++ b/share/goodie/cheat_sheets/json/swift.json
@@ -125,7 +125,7 @@
     ],
     "Dictionaries": [
       {
-        "key": "var days = \\[\"mon\": \"monday\", \"tue\": \"tuseday\"\\]",
+        "key": "var days = \\[\"mon\": \"monday\", \"tue\": \"tuesday\"\\]",
         "val": "Declare a new dictionary"
       },
       {

--- a/share/goodie/cheat_sheets/json/vim.json
+++ b/share/goodie/cheat_sheets/json/vim.json
@@ -9,12 +9,12 @@
     "template_type": "keyboard",
     "section_order": [
         "Cursor movement",
+        "Exiting",
         "Insert mode - inserting/appending text",
         "Editing",
         "Marking text (visual mode)",
         "Visual commands",
         "Cut and paste",
-        "Exiting",
         "Search and replace",
         "Working with multiple files",
         "Tabs",


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [x] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

Moved Vim's exit commands closer to the top to make their easier to find

###### Which issues (if any) does this fix?

Fixes #2885 - Alters the order information is presented in

###### People to notify (@mention interested parties)


---

Instant Answer Page: https://duck.co/ia/view/vim_cheat_sheet
[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @kablamo
