### PR TITLE
Conversions: Add degree symbol alias for celcius and fahrenheit (fixes #2950)

### DIFF
--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -979,6 +979,7 @@ unit: poundal
 ---
 aliases:
   - f
+  - °f
 can_be_negative: 1
 factor: 1
 type: temperature
@@ -986,6 +987,7 @@ unit: fahrenheit
 ---
 aliases:
   - c
+  - °c
 can_be_negative: 1
 factor: 1
 type: temperature


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [X] Improvement
    - [X] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

Adds `°` degree symbol for Celsius and Fahrenheit.

###### Which issues (if any) does this fix?

Fixes #2950

###### People to notify (@mention interested parties)

@mintsoft 
@edgesince84 
@GuiltyDolphin 

---

Instant Answer Page: https://duck.co/ia/view/conversions

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @mintsoft