### PR TITLE
Bug fix: scala_cheat_sheet: Fix #2944

### DIFF
--- a/share/goodie/cheat_sheets/json/scala.json
+++ b/share/goodie/cheat_sheets/json/scala.json
@@ -16,7 +16,7 @@
     "sections": {
         "Program Compilation and Execution" : [
             {
-                "key" : "scalac Hello.j­ava",
+                "key" : "scalac Hello.scala",
                 "val" : "Compile Scala File"
             },
             {


### PR DESCRIPTION
Fixes #2944
---
Fixed typo where the file type was mentioned as java instead of scala.

Instant Answer Page: https://duck.co/ia/view/scala_cheat_sheet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @amitdev

