### PR TITLE
CheatSheets: Have tests only check ID rather than all data

### DIFF
--- a/t/CheatSheets/CheatSheets.t
+++ b/t/CheatSheets/CheatSheets.t
@@ -6,6 +6,7 @@ use Test::More;
 use DDG::Test::Goodie;
 use JSON::XS;
 use File::Find::Rule;
+use Test::Deep;
 
 zci answer_type => "cheat_sheet";
 zci is_cached   => 1;
@@ -26,10 +27,11 @@ sub getTests {
         my $name = File::Basename::fileparse($file);
         my $defaultName = $name =~ s/-/ /gr;
         $defaultName =~ s/.json//;
+        my $id = $data->{id};
 
         $aliases{$defaultName} = $file;
 
-        $tests{$defaultName." cheat sheet"} = test_zci(build_answer($data));
+        $tests{$defaultName." cheat sheet"} = test_zci(build_answer($id));
 
         if ($data->{'aliases'}) {
             foreach my $alias (@{$data->{'aliases'}}) {
@@ -40,7 +42,7 @@ sub getTests {
                     die "$name and $other_file both using alias '$lc_alias'";
                 }
                 $aliases{$lc_alias} = $file;
-                $tests{$alias." cheat sheet"} = test_zci(build_answer($data));
+                $tests{$alias." cheat sheet"} = test_zci(build_answer($id));
             }
         }
     }
@@ -48,12 +50,12 @@ sub getTests {
 }
 
 sub build_answer {
-    my ($data) = @_;
+    my $id = shift;
 
     return 'Cheat Sheet', structured_answer => {
         id => 'cheat_sheets',
-        dynamic_id => $data->{id},
-        data => $data,
+        dynamic_id => $id,
+        data => isa('HASH'),
         templates => {
             group => 'base',
             item => 0,


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [X] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [X] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

Updated the cheat sheet tests (not the JSON ones) to only check ID rather than *all* data. For me the tests have gone from 15 seconds before the change to 2 seconds after.

###### Which issues (if any) does this fix?

None

###### People to notify (@mention interested parties)

@zachthompson 

---

Instant Answer Page: https://duck.co/ia/view/cheat_sheets

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @zachthompson 