### PR TITLE
Erlang cheat sheet: Add f/1 to shell commands

### DIFF
--- a/share/goodie/cheat_sheets/json/erlang.json
+++ b/share/goodie/cheat_sheets/json/erlang.json
@@ -121,6 +121,9 @@
             "val": "repeat the expression in query <N>",
             "key": "e(N)."
         }, {
+            "val": "forget variable binding <N>",
+            "key": "f(N)."
+        }, {
             "val": "forget all variable bindings",
             "key": "f()."
         }, {


### PR DESCRIPTION
Add f/1 to shell commands, right next to f/0, in Erlang Cheat Sheet

Fixes #2942 

IA Page: https://duck.co/ia/view/erlang_cheat_sheet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @pjhampton
