### PR TITLE
remove improper use of shift when unpacking from @ARGV

### DIFF
--- a/share/goodie/cheat_sheets/json/perl.json
+++ b/share/goodie/cheat_sheets/json/perl.json
@@ -132,7 +132,7 @@
         }],
         "Basic Syntax": [{
             "val": "Read command line params",
-            "key": "($a, $b) = (@ARGV);"
+            "key": "($a, $b) = @ARGV;"
         }, {
             "val": "Define subroutine",
             "key": "sub p\\{my $var = shift; ...\\}"

--- a/share/goodie/cheat_sheets/json/perl.json
+++ b/share/goodie/cheat_sheets/json/perl.json
@@ -132,7 +132,7 @@
         }],
         "Basic Syntax": [{
             "val": "Read command line params",
-            "key": "($a, $b) = shift(@ARGV);"
+            "key": "($a, $b) = (@ARGV);"
         }, {
             "val": "Define subroutine",
             "key": "sub p\\{my $var = shift; ...\\}"


### PR DESCRIPTION
**`perl cheatsheet: Fix shift() syntax #2945 `**
---

Instant Answer Page: https://duck.co/ia/view/perl_cheat_sheet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @pratik-nagelia 

