### PR TITLE
Italian cheatsheet fix

### DIFF
--- a/share/goodie/cheat_sheets/json/language/italian.json
+++ b/share/goodie/cheat_sheets/json/language/italian.json
@@ -182,7 +182,7 @@
       "Dinner on the Town" : [
          {
             "val" : "Avete piatti vegetariani?",
-            "key" : "Do you have vegetaryan dishes?"
+            "key" : "Do you have vegetarian dishes?"
          },
          {
             "val" : "Portata principale",

--- a/share/goodie/cheat_sheets/json/perl.json
+++ b/share/goodie/cheat_sheets/json/perl.json
@@ -132,7 +132,7 @@
         }],
         "Basic Syntax": [{
             "val": "Read command line params",
-            "key": "($a, $b) = (@ARGV);"
+            "key": "($a, $b) = shift(@ARGV);"
         }, {
             "val": "Define subroutine",
             "key": "sub p\\{my $var = shift; ...\\}"

--- a/share/goodie/cheat_sheets/json/perl.json
+++ b/share/goodie/cheat_sheets/json/perl.json
@@ -132,7 +132,7 @@
         }],
         "Basic Syntax": [{
             "val": "Read command line params",
-            "key": "($a, $b) = shift(@ARGV);"
+            "key": "($a, $b) = (@ARGV);"
         }, {
             "val": "Define subroutine",
             "key": "sub p\\{my $var = shift; ...\\}"


### PR DESCRIPTION
###### Improvement: **`Italian Cheat sheet: Minor typo fix`**

---
Fix wrong spelling of vegetarian.

Instant Answer Page: https://duck.co/ia/view/italian_cheat_sheet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @marcostudios 
