### PR TITLE
Swift Cheat Sheet: Fix #2803 Deprecated syntax in Swift cheatsheet

### DIFF
--- a/share/goodie/cheat_sheets/json/swift.json
+++ b/share/goodie/cheat_sheets/json/swift.json
@@ -176,7 +176,7 @@
     ],
     "Loops": [
       {
-        "key": "for var index = 1; index < n; ++index \\{\n\t//statements\n\\}",
+        "key": "for item in list \\{\n\t//statements\n\\}",
         "val": "For loop"
       },
       {


### PR DESCRIPTION
Fix for loop syntax for Swift 2.2. The syntax used currently is deprecated and will be removed in Swift 3.

---

Instant Answer Page: https://duck.co/ia/view/swift_cheat_sheet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @gautamkrishnar 

