### PR TITLE
GreatestCommonFactor: Use Math::BigInt & change to text template

### DIFF
--- a/lib/DDG/Goodie/GreatestCommonFactor.pm
+++ b/lib/DDG/Goodie/GreatestCommonFactor.pm
@@ -3,6 +3,7 @@ package DDG::Goodie::GreatestCommonFactor;
 
 use strict;
 use DDG::Goodie;
+use Math::BigInt try => 'GMP';
 
 zci answer_type => "greatest_common_factor";
 zci is_cached   => 1;
@@ -24,7 +25,7 @@ handle remainder => sub {
 
     my $result = shift @numbers;
     foreach (@numbers) {
-        $result = gcf($result, $_)
+        $result = Math::BigInt::bgcd($result, $_)
     }
 
     return "Greatest common factor of $formatted_numbers is $result.",
@@ -34,11 +35,5 @@ handle remainder => sub {
         result    => $result
       };
 };
-
-sub gcf {
-    my ($x, $y) = @_;
-    ($x, $y) = ($y, $x % $y) while $y;
-    return $x;
-}
 
 1;

--- a/lib/DDG/Goodie/GreatestCommonFactor.pm
+++ b/lib/DDG/Goodie/GreatestCommonFactor.pm
@@ -23,10 +23,7 @@ handle remainder => sub {
     my $formatted_numbers = join(', ', @numbers);
     $formatted_numbers =~ s/, ([^,]*)$/ and $1/;
 
-    my $result = shift @numbers;
-    foreach (@numbers) {
-        $result = Math::BigInt::bgcd($result, $_)
-    }
+    my $result = Math::BigInt::bgcd(@numbers);
 
     return "Greatest common factor of $formatted_numbers is $result.",
       structured_answer => {

--- a/lib/DDG/Goodie/GreatestCommonFactor.pm
+++ b/lib/DDG/Goodie/GreatestCommonFactor.pm
@@ -30,9 +30,13 @@ handle remainder => sub {
 
     return "Greatest common factor of $formatted_numbers is $result.",
       structured_answer => {
-        input     => [$formatted_numbers],
-        operation => 'Greatest common factor',
-        result    => $result
+	data => {
+	  title => "$result",
+	  subtitle => "Greatest common factor: $formatted_numbers"
+	},
+	templates => {
+	  group => "text",
+	}
       };
 };
 

--- a/t/GreatestCommonFactor.t
+++ b/t/GreatestCommonFactor.t
@@ -13,121 +13,181 @@ ddg_goodie_test(
     'gcf 9 81' => test_zci(
         'Greatest common factor of 9 and 81 is 9.',
         structured_answer => {
-            input     => ['9 and 81'],
-            operation => 'Greatest common factor',
-            result    => 9
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 9 and 81',
+            title    => 9
+          }
         }
     ),
     '1000 100 greatest common factor' => test_zci(
         'Greatest common factor of 100 and 1000 is 100.',
         structured_answer => {
-            input     => ['100 and 1000'],
-            operation => 'Greatest common factor',
-            result    => 100
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 100 and 1000',
+            title    => 100
+          }
         }
     ),
     'GCF 12 76' => test_zci(
         'Greatest common factor of 12 and 76 is 4.',
         structured_answer => {
-            input     => ['12 and 76'],
-            operation => 'Greatest common factor',
-            result    => 4
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 12 and 76',
+            title    => 4
+          }
         }
     ),
     'GCF 121 11' => test_zci(
         'Greatest common factor of 11 and 121 is 11.',
         structured_answer => {
-            input     => ['11 and 121'],
-            operation => 'Greatest common factor',
-            result    => 11
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 11 and 121',
+            title    => 11
+          }
         }
     ),
     '99 9 greatest common factor' => test_zci(
         'Greatest common factor of 9 and 99 is 9.',
         structured_answer => {
-            input     => ['9 and 99'],
-            operation => 'Greatest common factor',
-            result    => 9
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 9 and 99',
+            title    => 9
+          }
         }
     ),
     'greatest common divisor 4 6' => test_zci(
         'Greatest common factor of 4 and 6 is 2.',
         structured_answer => {
-            input     => ['4 and 6'],
-            operation => 'Greatest common factor',
-            result    => 2
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 4 and 6',
+            title    => 2
+          }
         }
     ),
     'gcd 4 6' => test_zci(
         'Greatest common factor of 4 and 6 is 2.',
         structured_answer => {
-            input     => ['4 and 6'],
-            operation => 'Greatest common factor',
-            result    => 2
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 4 and 6',
+            title    => 2
+          }
         }
     ),
     'gcd 2' => test_zci(
         'Greatest common factor of 2 is 2.',
         structured_answer => {
-            input     => ['2'],
-            operation => 'Greatest common factor',
-            result    => 2
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 2',
+            title    => 2
+          }
         }
     ),
     'gcd 12 18 24' => test_zci(
         'Greatest common factor of 12, 18 and 24 is 6.',
         structured_answer => {
-            input     => ['12, 18 and 24'],
-            operation => 'Greatest common factor',
-            result    => 6
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 12, 18 and 24',
+            title    => 6
+          }
         }
     ),
     'gcd 25 20 15 10 5' => test_zci(
         'Greatest common factor of 5, 10, 15, 20 and 25 is 5.',
         structured_answer => {
-            input     => ['5, 10, 15, 20 and 25'],
-            operation => 'Greatest common factor',
-            result    => 5
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 5, 10, 15, 20 and 25',
+            title    => 5
+          }
         }
     ),
     'gcd 6, 9, ,,,,     12       15' => test_zci(
         'Greatest common factor of 6, 9, 12 and 15 is 3.',
         structured_answer => {
-            input     => ['6, 9, 12 and 15'],
-            operation => 'Greatest common factor',
-            result    => 3
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 6, 9, 12 and 15',
+            title    => 3
+          }
         }
     ),
     'gcd 2 3' => test_zci(
         'Greatest common factor of 2 and 3 is 1.',
         structured_answer => {
-            input     => ['2 and 3'],
-            operation => 'Greatest common factor',
-            result    => 1
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 2 and 3',
+            title    => 1
+          }
         }
     ),
     'gcd 2 3 5' => test_zci(
         'Greatest common factor of 2, 3 and 5 is 1.',
         structured_answer => {
-            input     => ['2, 3 and 5'],
-            operation => 'Greatest common factor',
-            result    => 1
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 2, 3 and 5',
+            title    => 1
+          }
         }
     ),
     'gcd 0 2' => test_zci(
         'Greatest common factor of 0 and 2 is 2.',
         structured_answer => {
-            input     => ['0 and 2'],
-            operation => 'Greatest common factor',
-            result    => 2
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 0 and 2',
+            title    => 2
+          }
         }
     ),
     'gcd 0 0' => test_zci(
         'Greatest common factor of 0 and 0 is 0.',
         structured_answer => {
-            input     => ['0 and 0'],
-            operation => 'Greatest common factor',
-            result    => 0
+	  templates => {
+	    group => 'text'
+	  },
+	  data => {
+            subtitle => 'Greatest common factor: 0 and 0',
+            title    => 0
+          }
         }
     ),
 );

--- a/t/GreatestCommonFactor.t
+++ b/t/GreatestCommonFactor.t
@@ -8,188 +8,40 @@ use DDG::Test::Goodie;
 zci answer_type => "greatest_common_factor";
 zci is_cached   => 1;
 
+# Build a structured answer that should match the response from the
+# Perl file.
+sub build_answer {
+    my ($numbers, $result) = @_;
+
+    return "Greatest common factor of $numbers is $result.",
+        structured_answer => {
+            data => {
+                title    => $result,
+                subtitle => "Greatest common factor: $numbers"
+            },
+            templates => {
+                group => "text"
+            }
+        };
+}
+
 ddg_goodie_test(
     [qw( DDG::Goodie::GreatestCommonFactor )],
-    'gcf 9 81' => test_zci(
-        'Greatest common factor of 9 and 81 is 9.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 9 and 81',
-            title    => 9
-          }
-        }
-    ),
-    '1000 100 greatest common factor' => test_zci(
-        'Greatest common factor of 100 and 1000 is 100.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 100 and 1000',
-            title    => 100
-          }
-        }
-    ),
-    'GCF 12 76' => test_zci(
-        'Greatest common factor of 12 and 76 is 4.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 12 and 76',
-            title    => 4
-          }
-        }
-    ),
-    'GCF 121 11' => test_zci(
-        'Greatest common factor of 11 and 121 is 11.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 11 and 121',
-            title    => 11
-          }
-        }
-    ),
-    '99 9 greatest common factor' => test_zci(
-        'Greatest common factor of 9 and 99 is 9.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 9 and 99',
-            title    => 9
-          }
-        }
-    ),
-    'greatest common divisor 4 6' => test_zci(
-        'Greatest common factor of 4 and 6 is 2.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 4 and 6',
-            title    => 2
-          }
-        }
-    ),
-    'gcd 4 6' => test_zci(
-        'Greatest common factor of 4 and 6 is 2.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 4 and 6',
-            title    => 2
-          }
-        }
-    ),
-    'gcd 2' => test_zci(
-        'Greatest common factor of 2 is 2.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 2',
-            title    => 2
-          }
-        }
-    ),
-    'gcd 12 18 24' => test_zci(
-        'Greatest common factor of 12, 18 and 24 is 6.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 12, 18 and 24',
-            title    => 6
-          }
-        }
-    ),
-    'gcd 25 20 15 10 5' => test_zci(
-        'Greatest common factor of 5, 10, 15, 20 and 25 is 5.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 5, 10, 15, 20 and 25',
-            title    => 5
-          }
-        }
-    ),
-    'gcd 6, 9, ,,,,     12       15' => test_zci(
-        'Greatest common factor of 6, 9, 12 and 15 is 3.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 6, 9, 12 and 15',
-            title    => 3
-          }
-        }
-    ),
-    'gcd 2 3' => test_zci(
-        'Greatest common factor of 2 and 3 is 1.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 2 and 3',
-            title    => 1
-          }
-        }
-    ),
-    'gcd 2 3 5' => test_zci(
-        'Greatest common factor of 2, 3 and 5 is 1.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 2, 3 and 5',
-            title    => 1
-          }
-        }
-    ),
-    'gcd 0 2' => test_zci(
-        'Greatest common factor of 0 and 2 is 2.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 0 and 2',
-            title    => 2
-          }
-        }
-    ),
-    'gcd 0 0' => test_zci(
-        'Greatest common factor of 0 and 0 is 0.',
-        structured_answer => {
-	  templates => {
-	    group => 'text'
-	  },
-	  data => {
-            subtitle => 'Greatest common factor: 0 and 0',
-            title    => 0
-          }
-        }
-    ),
+    'gcf 9 81' 				=> test_zci(build_answer('9 and 81', 9)),
+    '1000 100 greatest common factor' 	=> test_zci(build_answer('100 and 1000', 100)),
+    'GCF 12 76' 			=> test_zci(build_answer('12 and 76', 4)),
+    'GCF 121 11' 			=> test_zci(build_answer('11 and 121', 11)),
+    '99 9 greatest common factor' 	=> test_zci(build_answer('9 and 99', 9)),
+    'greatest common divisor 4 6' 	=> test_zci(build_answer('4 and 6', 2)),
+    'gcd 4 6' 				=> test_zci(build_answer('4 and 6', 2)),
+    'gcd 2' 				=> test_zci(build_answer('2', 2)),
+    'gcd 12 18 24' 			=> test_zci(build_answer('12, 18 and 24', 6)),
+    'gcd 25 20 15 10 5' 		=> test_zci(build_answer('5, 10, 15, 20 and 25', 5)),
+    'gcd 6, 9, ,,,,     12       15' 	=> test_zci(build_answer('6, 9, 12 and 15', 3)),
+    'gcd 2 3' 				=> test_zci(build_answer('2 and 3', 1)),
+    'gcd 2 3 5' 			=> test_zci(build_answer('2, 3 and 5', 1)),
+    'gcd 0 2' 				=> test_zci(build_answer('0 and 2', 2)),
+    'gcd 0 0' 				=> test_zci(build_answer('0 and 0', 0))
 );
 
 done_testing;


### PR DESCRIPTION
Removed custom GCD function and replaced it with `Math::BigInt::bgcd`, and changed to `text` template for view

Fixes #2985

Instant Answer Page: https://duck.co/ia/view/greatest_common_factor

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @austinheimark
