### PR TITLE
Convert simple structured to full template goodie

### DIFF
--- a/lib/DDG/Goodie/FlipText.pm
+++ b/lib/DDG/Goodie/FlipText.pm
@@ -21,7 +21,7 @@ handle remainder => sub {
     return $result,
       structured_answer => {
         data => {
-            title => $result,
+            title    => $result,
             subtitle => "Flip text $input"
         },
         templates => {

--- a/lib/DDG/Goodie/FlipText.pm
+++ b/lib/DDG/Goodie/FlipText.pm
@@ -6,7 +6,7 @@ use DDG::Goodie;
 
 use Text::UpsideDown;
 
-triggers startend => "flip text", "mirror text", "spin text", "rotate text", "upside down";
+triggers startend => "flip text", "mirror text", "spin text", "rotate text";
 
 zci answer_type => "flip_text";
 zci is_cached   => 1;

--- a/lib/DDG/Goodie/FlipText.pm
+++ b/lib/DDG/Goodie/FlipText.pm
@@ -6,7 +6,7 @@ use DDG::Goodie;
 
 use Text::UpsideDown;
 
-triggers startend => "flip text", "mirror text", "spin text", "rotate text";
+triggers startend => "flip text", "mirror text", "spin text", "rotate text", "upside down";
 
 zci answer_type => "flip_text";
 zci is_cached   => 1;
@@ -20,9 +20,13 @@ handle remainder => sub {
 
     return $result,
       structured_answer => {
-        input     => [html_enc($input)],
-        operation => 'Flip text',
-        result    => html_enc($result),
+        data => {
+            title => $result,
+            subtitle => "Flip text $input"
+        },
+        templates => {
+            group => 'text',
+        }
       };
 };
 

--- a/t/FlipText.t
+++ b/t/FlipText.t
@@ -31,7 +31,7 @@ ddg_goodie_test(
     'mirror text test' => build_test('test','ʇsǝʇ'),
     'flip text my sentence' => build_test('my sentence','ǝɔuǝʇuǝs ʎɯ'),
     'mirror text text' => build_test('text','ʇxǝʇ'),
-    'upside down <hello-world>' => build_test('<hello-world>','<pʃɹoʍ-oʃʃǝɥ>'),
+    'flip text <hello-world>' => build_test('<hello-world>','<pʃɹoʍ-oʃʃǝɥ>'),
     'rotate text "hello world"' => build_test('"hello world"','„pʃɹoʍ oʃʃǝɥ„'),
     'spin text ;hello world;' => build_test(';hello world;','؛pʃɹoʍ oʃʃǝɥ؛'),
     'spin text <<"hello\' % & * () = + . #@!^(/world">>' => build_test('<<"hello\' % & * () = + . #@!^(/world">>','<<„pʃɹoʍ/)∨¡@# ˙ + = () ⁎ ⅋ % ,oʃʃǝɥ„>>'),

--- a/t/FlipText.t
+++ b/t/FlipText.t
@@ -9,40 +9,33 @@ use DDG::Test::Goodie;
 zci answer_type => 'flip_text';
 zci is_cached   => 1;
 
+sub build_structured_answer{
+    my ($input,$result) = @_;
+    return $result,
+    structured_answer => {
+        data => {
+            title => $result,
+            subtitle => "Flip text $input"
+        },
+        templates => {
+            group => 'text',
+        }
+    }
+}
+
+sub build_test{ test_zci(build_structured_answer(@_)) }
+
 ddg_goodie_test(
     [qw( DDG::Goodie::FlipText)],
-    'flip text test' => test_zci(
-        "\x{0287}\x{0073}\x{01DD}\x{0287}",
-        structured_answer => {
-            input     => ['test'],
-            operation => 'Flip text',
-            result    => '&#x287;s&#x1DD;&#x287;'
-        }
-    ),
-    'mirror text test' => test_zci(
-        "\x{0287}\x{0073}\x{01DD}\x{0287}",
-        structured_answer => {
-            input     => ['test'],
-            operation => 'Flip text',
-            result    => '&#x287;s&#x1DD;&#x287;'
-        }
-    ),
-    'flip text my sentence' => test_zci(
-        'ǝɔuǝʇuǝs ʎɯ',
-        structured_answer => {
-            input     => ['my sentence'],
-            operation => 'Flip text',
-            result    => '&#x1DD;&#x254;u&#x1DD;&#x287;u&#x1DD;s &#x28E;&#x26F;'
-        }
-    ),
-    'mirror text text' => test_zci(
-        'ʇxǝʇ',
-        structured_answer => {
-            input     => ['text'],
-            operation => 'Flip text',
-            result    => '&#x287;x&#x1DD;&#x287;'
-        }
-    ),
+    'flip text test' => build_test('test','ʇsǝʇ'),
+    'mirror text test' => build_test('test','ʇsǝʇ'),
+    'flip text my sentence' => build_test('my sentence','ǝɔuǝʇuǝs ʎɯ'),
+    'mirror text text' => build_test('text','ʇxǝʇ'),
+    'upside down <hello-world>' => build_test('<hello-world>','<pʃɹoʍ-oʃʃǝɥ>'),
+    'rotate text "hello world"' => build_test('"hello world"','„pʃɹoʍ oʃʃǝɥ„'),
+    'spin text ;hello world;' => build_test(';hello world;','؛pʃɹoʍ oʃʃǝɥ؛'),
+    'spin text <<"hello\' % & * () = + . #@!^(/world">>' => build_test('<<"hello\' % & * () = + . #@!^(/world">>','<<„pʃɹoʍ/)∨¡@# ˙ + = () ⁎ ⅋ % ,oʃʃǝɥ„>>'),
+    'spin text [\'hello\']' => build_test('[\'hello\']','[,oʃʃǝɥ,]'),
 );
 
 done_testing;

--- a/t/FlipText.t
+++ b/t/FlipText.t
@@ -14,7 +14,7 @@ sub build_structured_answer{
     return $result,
     structured_answer => {
         data => {
-            title => $result,
+            title    => $result,
             subtitle => "Flip text $input"
         },
         templates => {
@@ -27,15 +27,15 @@ sub build_test{ test_zci(build_structured_answer(@_)) }
 
 ddg_goodie_test(
     [qw( DDG::Goodie::FlipText)],
-    'flip text test' => build_test('test','ʇsǝʇ'),
-    'mirror text test' => build_test('test','ʇsǝʇ'),
-    'flip text my sentence' => build_test('my sentence','ǝɔuǝʇuǝs ʎɯ'),
-    'mirror text text' => build_test('text','ʇxǝʇ'),
-    'flip text <hello-world>' => build_test('<hello-world>','<pʃɹoʍ-oʃʃǝɥ>'),
+    'flip text test'            => build_test('test','ʇsǝʇ'),
+    'mirror text test'          => build_test('test','ʇsǝʇ'),
+    'flip text my sentence'     => build_test('my sentence','ǝɔuǝʇuǝs ʎɯ'),
+    'mirror text text'          => build_test('text','ʇxǝʇ'),
+    'flip text <hello-world>'   => build_test('<hello-world>','<pʃɹoʍ-oʃʃǝɥ>'),
     'rotate text "hello world"' => build_test('"hello world"','„pʃɹoʍ oʃʃǝɥ„'),
-    'spin text ;hello world;' => build_test(';hello world;','؛pʃɹoʍ oʃʃǝɥ؛'),
+    'spin text ;hello world;'   => build_test(';hello world;','؛pʃɹoʍ oʃʃǝɥ؛'),
+    'spin text [\'hello\']'     => build_test('[\'hello\']','[,oʃʃǝɥ,]'),
     'spin text <<"hello\' % & * () = + . #@!^(/world">>' => build_test('<<"hello\' % & * () = + . #@!^(/world">>','<<„pʃɹoʍ/)∨¡@# ˙ + = () ⁎ ⅋ % ,oʃʃǝɥ„>>'),
-    'spin text [\'hello\']' => build_test('[\'hello\']','[,oʃʃǝɥ,]'),
 );
 
 done_testing;


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [x] Enhancement: **`FlipText: change to 'text' template, refactor test suite`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

Goodies have full support for templates, and it'd be great to make sure all
Goodies use full templates. The "simple structured_answer" was provided
as a way to get goodies using basic templates before they had full template
support.

Provide an overview of the changes this pull request introduces.

* change to 'text' template for structured_answer object

* refactored test suite

* added alias and removed encode

###### Which issues (if any) does this fix?
See also: Updates FlipText Goodie Re: #2767

Fixes #NNNN - how specifically does it fix the issue?

###### People to notify (@moollaza, @GuiltyDolphin )


---

Instant Answer Page: https://duck.co/ia/view/flip_text

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @rpicard
