### PR TITLE
Constants: Switching to template

### DIFF
--- a/lib/DDG/Goodie/Constants.pm
+++ b/lib/DDG/Goodie/Constants.pm
@@ -35,11 +35,14 @@ handle query_lc => sub {
 
     return $val->{'plain'}, structured_answer => {
         data => {
-            title => $result,
-            subtitle => $constant->{'name'}
+            constant => $result,
+            description => $constant->{'name'}
         },
         templates => {
             group => 'text',
+            options => {
+                content => 'DDH.constants.content'
+            }
         },
         meta => {
             signal => 'high'

--- a/lib/DDG/Goodie/Constants.pm
+++ b/lib/DDG/Goodie/Constants.pm
@@ -34,10 +34,14 @@ handle query_lc => sub {
     my $result = $val->{'html'} ? $val->{'html'} : $val->{'plain'};
 
     return $result, structured_answer => {
-        input     => [],
-        operation => $constant->{'name'},
-        result    => $result,
-        meta      => {
+		data => {
+			title => $result,
+			subtitle => $constant->{'name'}
+		},
+		templates => {
+			group => 'text',
+		},
+        meta => {
             signal => 'high'
         }
     };

--- a/lib/DDG/Goodie/Constants.pm
+++ b/lib/DDG/Goodie/Constants.pm
@@ -34,13 +34,13 @@ handle query_lc => sub {
     my $result = $val->{'html'} ? $val->{'html'} : $val->{'plain'};
 
     return $result, structured_answer => {
-		data => {
-			title => $result,
-			subtitle => $constant->{'name'}
-		},
-		templates => {
-			group => 'text',
-		},
+        data => {
+            title => $result,
+            subtitle => $constant->{'name'}
+        },
+        templates => {
+            group => 'text',
+        },
         meta => {
             signal => 'high'
         }

--- a/lib/DDG/Goodie/Constants.pm
+++ b/lib/DDG/Goodie/Constants.pm
@@ -36,12 +36,12 @@ handle query_lc => sub {
     return $val->{'plain'}, structured_answer => {
         data => {
             constant => $result,
-            description => $constant->{'name'}
+            subtitle => $constant->{'name'}
         },
         templates => {
             group => 'text',
             options => {
-                content => 'DDH.constants.content'
+                title_content => 'DDH.constants.title_content'
             }
         },
         meta => {

--- a/lib/DDG/Goodie/Constants.pm
+++ b/lib/DDG/Goodie/Constants.pm
@@ -33,7 +33,7 @@ handle query_lc => sub {
     #fallback to plain answer if html is not present
     my $result = $val->{'html'} ? $val->{'html'} : $val->{'plain'};
 
-    return $result, structured_answer => {
+    return $val->{'plain'}, structured_answer => {
         data => {
             title => $result,
             subtitle => $constant->{'name'}

--- a/share/goodie/constants/content.handlebars
+++ b/share/goodie/constants/content.handlebars
@@ -1,6 +1,4 @@
-<div class='zci__constants'>
-    <h3 class='zci__caption zci__result'>{{{constant}}}</h3>
-    <h4 class='zci__subheader'>
-        <span class='zci__input'>{{description}}</span>
-    </h4>
-</div>
+<h3 class='zci__caption zci__result'>{{{constant}}}</h3>
+<h4 class='zci__subheader'>
+    <span class='zci__input'>{{description}}</span>
+</h4>

--- a/share/goodie/constants/content.handlebars
+++ b/share/goodie/constants/content.handlebars
@@ -1,4 +1,0 @@
-<h3 class='zci__caption zci__result'>{{{constant}}}</h3>
-<h4 class='zci__subheader'>
-    <span class='zci__input'>{{description}}</span>
-</h4>

--- a/share/goodie/constants/content.handlebars
+++ b/share/goodie/constants/content.handlebars
@@ -1,0 +1,6 @@
+<div class='zci__constants'>
+    <h3 class='zci__caption zci__result'>{{{constant}}}</h3>
+    <h4 class='zci__subheader'>
+        <span class='zci__input'>{{description}}</span>
+    </h4>
+</div>

--- a/share/goodie/constants/title_content.handlebars
+++ b/share/goodie/constants/title_content.handlebars
@@ -1,0 +1,1 @@
+<h3 class='c-base__title'>{{{constant}}}</h3>

--- a/t/Constants.t
+++ b/t/Constants.t
@@ -9,46 +9,47 @@ use DDG::Test::Goodie;
 zci answer_type => "constants";
 zci is_cached   => 1;
 
+sub build_test
+{
+    my ($text, $subtitle, $title) = @_;
+    return test_zci($text, structured_answer => {
+        data => {
+            title => $title,
+            subtitle => $subtitle,
+        },
+        templates => {
+            group => 'text',
+        },
+        meta => {
+            signal => 'high'
+        }
+    });
+}
+
 ddg_goodie_test(
     [qw( DDG::Goodie::Constants )],
-    "Hardy Ramanujan number" => test_zci(
-       '1<sup>3</sup> + 12<sup>3</sup> = 9<sup>3</sup> + 10<sup>3</sup>',
-        structured_answer => {
-            input     => [],
-            operation => 'Hardy Ramanujan Number 1729',
-            result    => "1<sup>3</sup> + 12<sup>3</sup> = 9<sup>3</sup> + 10<sup>3</sup>",
-            meta      => {signal => 'high'}
-        }
+    "Hardy Ramanujan number" => build_test(
+        '1<sup>3</sup> + 12<sup>3</sup> = 9<sup>3</sup> + 10<sup>3</sup>',
+        'Hardy Ramanujan Number 1729',
+         "1<sup>3</sup> + 12<sup>3</sup> = 9<sup>3</sup> + 10<sup>3</sup>",
     ),
     #without apostrophe
-    "Avogadros number" => test_zci(
+    "Avogadros number" => build_test(
         '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
-        structured_answer => {
-            input => [],
-            operation => 'Avogadro\'s Number',
-            result => '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
-            meta      => {signal => 'high'}
-        }
+        'Avogadro\'s Number',
+        '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
     ),
     #with apostrophe
-    "Avogadro's number" => test_zci(
+    "Avogadro's number" => build_test(
         '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
-        structured_answer => {
-            input => [],
-            operation => 'Avogadro\'s Number',
-            result => '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
-            meta      => {signal => 'high'}
-        }
+        'Avogadro\'s Number',
+        '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
     ),
     #constant without html (only plain)
-    "Eulers constant" => test_zci(
+    "Eulers constant" => build_test(
         '0.577215665',
-        structured_answer => {
-            input => [],
-            operation => 'Euler\'s Constant',
-            result => '0.577215665',
-            meta      => {signal => 'high'}
-        }
+        "Euler's Constant",
+        '0.577215665',
     ),
     "How old is my grandma?" => undef,
     "why?" => undef, 

--- a/t/Constants.t
+++ b/t/Constants.t
@@ -29,19 +29,19 @@ sub build_test
 ddg_goodie_test(
     [qw( DDG::Goodie::Constants )],
     "Hardy Ramanujan number" => build_test(
-        '1<sup>3</sup> + 12<sup>3</sup> = 9<sup>3</sup> + 10<sup>3</sup>',
+        '1^3 + 12^3 = 9^3 + 10^3',
         'Hardy Ramanujan Number 1729',
          "1<sup>3</sup> + 12<sup>3</sup> = 9<sup>3</sup> + 10<sup>3</sup>",
     ),
     #without apostrophe
     "Avogadros number" => build_test(
-        '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
+        '6.0221415 × 10^23 mol^-1',
         'Avogadro\'s Number',
         '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
     ),
     #with apostrophe
     "Avogadro's number" => build_test(
-        '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
+        '6.0221415 × 10^23 mol^-1',
         'Avogadro\'s Number',
         '6.0221415 × 10<sup>23</sup> mol<sup>-1</sup>',
     ),

--- a/t/Constants.t
+++ b/t/Constants.t
@@ -14,11 +14,14 @@ sub build_test
     my ($text, $subtitle, $title) = @_;
     return test_zci($text, structured_answer => {
         data => {
-            title => $title,
-            subtitle => $subtitle,
+            constant => $title,
+            description => $subtitle,
         },
         templates => {
             group => 'text',
+            options => {
+                content => 'DDH.constants.content'
+            }
         },
         meta => {
             signal => 'high'

--- a/t/Constants.t
+++ b/t/Constants.t
@@ -15,12 +15,12 @@ sub build_test
     return test_zci($text, structured_answer => {
         data => {
             constant => $title,
-            description => $subtitle,
+            subtitle => $subtitle,
         },
         templates => {
             group => 'text',
             options => {
-                content => 'DDH.constants.content'
+                title_content => 'DDH.constants.title_content'
             }
         },
         meta => {
@@ -34,7 +34,7 @@ ddg_goodie_test(
     "Hardy Ramanujan number" => build_test(
         '1^3 + 12^3 = 9^3 + 10^3',
         'Hardy Ramanujan Number 1729',
-         "1<sup>3</sup> + 12<sup>3</sup> = 9<sup>3</sup> + 10<sup>3</sup>",
+        "1<sup>3</sup> + 12<sup>3</sup> = 9<sup>3</sup> + 10<sup>3</sup>",
     ),
     #without apostrophe
     "Avogadros number" => build_test(
@@ -55,7 +55,7 @@ ddg_goodie_test(
         '0.577215665',
     ),
     "How old is my grandma?" => undef,
-    "why?" => undef, 
+    "why?" => undef,
 );
 
 done_testing;


### PR DESCRIPTION
###### Description of changes

In Ref to: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/2767 converting to a full template

This also fixes:
* That the text answer output was HTML;
* The HTML was being encoded so the answers looked terrible

---

Instant Answer Page: https://duck.co/ia/view/constants

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @hemanth

