### PR TITLE
Improve triggering of PrimeFactors goodie

### DIFF
--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -21,9 +21,10 @@ triggers startend => (
     'prime factorization',
     'prime factorization of',
     'factorize',
-    'prime factorize',
-    'prime'
+    'prime factorize'
 );
+
+triggers any => "prime";
 
 sub convert_to_superscripts (_) {
     my $string = $_[0];
@@ -91,9 +92,8 @@ sub format_answer {
 handle remainder => sub {
 
     # Exit if `prime` trigger do not contain `is` keyword
-    if ($req->matched_trigger eq "prime"){
-        return unless grep ($_, 'is');
-        $_ =~ s/\bis\b//gi;
+    if ($req->matched_trigger eq "prime") {
+        return unless /^is \d+ prime\??$/ # capture queries like "is 3 prime" and "is 7 prime?"
     }
     
     # Exit if it's not a digit.

--- a/lib/DDG/Goodie/PrimeFactors.pm
+++ b/lib/DDG/Goodie/PrimeFactors.pm
@@ -22,6 +22,7 @@ triggers startend => (
     'prime factorization of',
     'factorize',
     'prime factorize',
+    'prime'
 );
 
 sub convert_to_superscripts (_) {
@@ -88,10 +89,17 @@ sub format_answer {
 }
 
 handle remainder => sub {
+
+    # Exit if `prime` trigger do not contain `is` keyword
+    if ($req->matched_trigger eq "prime"){
+        return unless grep ($_, 'is');
+        $_ =~ s/\bis\b//gi;
+    }
+    
     # Exit if it's not a digit.
     # TODO: We should accept different number formats.
     return unless /^\d+$/;
-
+    
     my $start_time = time();
     my @factors = ();
 


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.
- [ ] New Instant Answer
  - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
  - [ ] Other: **`New {IA Name} Instant Answer`**
- [x] Improvement
  - [x] Bug fix: **`prime_factors: Fix {2799} improve triggering`**
  - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
  - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**
###### Description of changes

The PrimeFactors goodie was not triggered for certain
queries like `is 7 prime`. This could be fixed by adding
trigger keyword and using a regexp guard on handler.

Provide an overview of the changes this pull request introduces.
- checks if `is` keyword is contained in query for trigger `prime`
###### Which issues (if any) does this fix?

See also: #2799

Fixes #NNNN - how specifically does it fix the issue?
###### People to notify (@stevenmg, @GuiltyDolphin)

---

Instant Answer Page: https://duck.co/ia/view/prime_factors

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @austinheimark
