### PR TITLE
sort: stop triggering for single input query on sort_goodie

### DIFF
--- a/lib/DDG/Goodie/Sort.pm
+++ b/lib/DDG/Goodie/Sort.pm
@@ -39,7 +39,6 @@ handle remainder => sub {
 
     my $count = 0;
     @numbers = map { 0 + $_ } grep { ++$count <= MAX_LIST_SIZE } @numbers;    # Normalize and limit list size.
-    
     my $unsorted_list = join($delim, @numbers);
     my $sorted_list = join($delim, sort { $ascending ? $a <=> $b : $b <=> $a } @numbers);
     my $dir = $ascending ? 'ascendingly' : 'descendingly';

--- a/lib/DDG/Goodie/Sort.pm
+++ b/lib/DDG/Goodie/Sort.pm
@@ -38,7 +38,8 @@ handle remainder => sub {
     return unless all { looks_like_number($_) } @numbers;
 
     my $count = 0;
-    @numbers = map { 0 + $_ } grep { ++$count <= MAX_LIST_SIZE } @numbers;    # Normalize and limit list size.
+    @numbers = map { 0 + $_ } grep { ++$count <= MAX_LIST_SIZE } @numbers; # Normalize and limit list size.
+
     my $unsorted_list = join($delim, @numbers);
     my $sorted_list = join($delim, sort { $ascending ? $a <=> $b : $b <=> $a } @numbers);
     my $dir = $ascending ? 'ascendingly' : 'descendingly';

--- a/lib/DDG/Goodie/Sort.pm
+++ b/lib/DDG/Goodie/Sort.pm
@@ -38,7 +38,8 @@ handle remainder => sub {
 
     my $count = 0;
     @numbers = map { 0 + $_ } grep { ++$count <= MAX_LIST_SIZE } @numbers;    # Normalize and limit list size.
-
+    return unless $count > 1;
+    
     my $unsorted_list = join($delim, @numbers);
     my $sorted_list = join($delim, sort { $ascending ? $a <=> $b : $b <=> $a } @numbers);
     my $dir = $ascending ? 'ascendingly' : 'descendingly';

--- a/lib/DDG/Goodie/Sort.pm
+++ b/lib/DDG/Goodie/Sort.pm
@@ -34,11 +34,11 @@ handle remainder => sub {
 
     my @numbers = split /[\s,;]+/, $input;
 
+    return unless @numbers > 1;
     return unless all { looks_like_number($_) } @numbers;
 
     my $count = 0;
     @numbers = map { 0 + $_ } grep { ++$count <= MAX_LIST_SIZE } @numbers;    # Normalize and limit list size.
-    return unless $count > 1;
     
     my $unsorted_list = join($delim, @numbers);
     my $sorted_list = join($delim, sort { $ascending ? $a <=> $b : $b <=> $a } @numbers);

--- a/t/Sort.t
+++ b/t/Sort.t
@@ -32,6 +32,8 @@ ddg_goodie_test(
     'sort -3 -10 56 10' => build_test('-3, -10, 56, 10','ascendingly', '-10, -3, 10, 56'),
     'sort descending 10, -1, +5.3, -95, 1' => build_test('10, -1, 5.3, -95, 1', 'descendingly', '10, 5.3, 1, -1, -95'),
     'sort descending 10, -1, +5.3, -95, 1, 1e2' => build_test('10, -1, 5.3, -95, 1, 100', 'descendingly', '100, 10, 5.3, 1, -1, -95'),
+    'sort 1' => undef,
+    'sort 455' => undef,
     'sort algorithm'      => undef,
     'sort 1 fish, 2 fish' => undef,
     'sort' => undef,


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [x] Enhancement: **`trigger for query input > 1`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

The sort_goodie should not be triggered for single numbers (input)
query. This could be fixed by using a return statement check on handler.

Provide an overview of the changes this pull request introduces.

* goodie not triggered for single number (input)

###### Which issues (if any) does this fix?

See also: #3144

Fixes #NNNN - how specifically does it fix the issue?

###### People to notify (@GuiltyDolphin)


---

Instant Answer Page: https://duck.co/ia/view/sort

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @koosha--





