### PR TITLE
GreatestCommonFactor: Don't trigger on single numbers, Fix #3407

### DIFF
--- a/lib/DDG/Goodie/GreatestCommonFactor.pm
+++ b/lib/DDG/Goodie/GreatestCommonFactor.pm
@@ -18,23 +18,39 @@ handle remainder => sub {
     # holds at least one number.
 
     my @numbers = grep(/^\d/, split /(?:\s|,)+/);
-    @numbers = sort { $a <=> $b } @numbers;
-
-    my $formatted_numbers = join(', ', @numbers);
-    $formatted_numbers =~ s/, ([^,]*)$/ and $1/;
-
-    my $result = Math::BigInt::bgcd(@numbers);
-
-    return "Greatest common factor of $formatted_numbers is $result.",
-      structured_answer => {
-	data => {
-	  title => "$result",
-	  subtitle => "Greatest common factor: $formatted_numbers"
-	},
-	templates => {
-	  group => "text",
-	}
+    my $size = scalar @numbers;
+    print "Numbers: @numbers ";
+    print "Size: $size ";
+    if ($size == 1) {
+        return "Cannot return Greatest Common Factor.",
+         structured_answer => {
+	    data => {
+	     title => "Greatest common factor cannot be computed",
+	      subtitle => "Need at least 2 numbers, example: GCD 2,6"
+	    },
+	    templates => {
+	      group => "text",
+	    }
       };
+    }
+    else {
+        @numbers = sort { $a <=> $b } @numbers;
+        my $formatted_numbers = join(', ', @numbers);
+        $formatted_numbers =~ s/, ([^,]*)$/ and $1/;
+
+        my $result = Math::BigInt::bgcd(@numbers);
+
+        return "Greatest common factor of $formatted_numbers is $result.",
+         structured_answer => {
+	    data => {
+	     title => "$result",
+	      subtitle => "Greatest common factor: $formatted_numbers"
+	    },
+        templates => {
+          group => "text",
+	    }
+        };
+    }
 };
 
 1;

--- a/lib/DDG/Goodie/GreatestCommonFactor.pm
+++ b/lib/DDG/Goodie/GreatestCommonFactor.pm
@@ -19,16 +19,7 @@ handle remainder => sub {
 
     my @numbers = grep(/^\d/, split /(?:\s|,)+/);
     if (@numbers == 1) {
-      return "Cannot return Greatest Common Factor.",
-       structured_answer => {
-	    data => {
-	     title => "Greatest common factor cannot be computed",
-	     subtitle => "Need at least 2 numbers, example: GCD 2,6"
-	    },
-	    templates => {
-	      group => "text",
-	    }
-      };
+      return;
     }
     else {
         @numbers = sort { $a <=> $b } @numbers;

--- a/lib/DDG/Goodie/GreatestCommonFactor.pm
+++ b/lib/DDG/Goodie/GreatestCommonFactor.pm
@@ -18,15 +18,12 @@ handle remainder => sub {
     # holds at least one number.
 
     my @numbers = grep(/^\d/, split /(?:\s|,)+/);
-    my $size = scalar @numbers;
-    print "Numbers: @numbers ";
-    print "Size: $size ";
-    if ($size == 1) {
-        return "Cannot return Greatest Common Factor.",
-         structured_answer => {
+    if (@numbers == 1) {
+      return "Cannot return Greatest Common Factor.",
+       structured_answer => {
 	    data => {
 	     title => "Greatest common factor cannot be computed",
-	      subtitle => "Need at least 2 numbers, example: GCD 2,6"
+	     subtitle => "Need at least 2 numbers, example: GCD 2,6"
 	    },
 	    templates => {
 	      group => "text",
@@ -35,6 +32,7 @@ handle remainder => sub {
     }
     else {
         @numbers = sort { $a <=> $b } @numbers;
+        
         my $formatted_numbers = join(', ', @numbers);
         $formatted_numbers =~ s/, ([^,]*)$/ and $1/;
 
@@ -42,14 +40,14 @@ handle remainder => sub {
 
         return "Greatest common factor of $formatted_numbers is $result.",
          structured_answer => {
-	    data => {
-	     title => "$result",
-	      subtitle => "Greatest common factor: $formatted_numbers"
-	    },
-        templates => {
-          group => "text",
+	      data => {
+	       title => "$result",
+	       subtitle => "Greatest common factor: $formatted_numbers"
+	     },
+         templates => {
+           group => "text",
 	    }
-        };
+      };
     }
 };
 

--- a/lib/DDG/Goodie/GreatestCommonFactor.pm
+++ b/lib/DDG/Goodie/GreatestCommonFactor.pm
@@ -18,28 +18,25 @@ handle remainder => sub {
     # holds at least one number.
 
     my @numbers = grep(/^\d/, split /(?:\s|,)+/);
-    if (@numbers == 1) {
-      return;
-    }
-    else {
-        @numbers = sort { $a <=> $b } @numbers;
+    return unless @numbers > 1;
+  
+    @numbers = sort { $a <=> $b } @numbers;
         
-        my $formatted_numbers = join(', ', @numbers);
-        $formatted_numbers =~ s/, ([^,]*)$/ and $1/;
+    my $formatted_numbers = join(', ', @numbers);
+    $formatted_numbers =~ s/, ([^,]*)$/ and $1/;
 
-        my $result = Math::BigInt::bgcd(@numbers);
+    my $result = Math::BigInt::bgcd(@numbers);
 
-        return "Greatest common factor of $formatted_numbers is $result.",
-         structured_answer => {
-	      data => {
-	       title => "$result",
-	       subtitle => "Greatest common factor: $formatted_numbers"
-	     },
-         templates => {
-           group => "text",
-	    }
-      };
+    return "Greatest common factor of $formatted_numbers is $result.",
+     structured_answer => {
+	  data => {
+	   title => "$result",
+	   subtitle => "Greatest common factor: $formatted_numbers"
+	 },
+     templates => {
+       group => "text",
     }
+  };
 };
 
 1;

--- a/t/GreatestCommonFactor.t
+++ b/t/GreatestCommonFactor.t
@@ -45,7 +45,10 @@ ddg_goodie_test(
     'gcd 2 3 5'                       => build_test('2, 3 and 5', 1),
     'gcd 0 2'                         => build_test('0 and 2', 2),
     'gcd 0 0'                         => build_test('0 and 0', 0),
-    'gcf 2'                           => build_test('', 1),
+    
+    #Tests that should fail
+    'gcd 2'                           => undef,
+    'gcf 2'                           => undef,
 );
 
 done_testing;

--- a/t/GreatestCommonFactor.t
+++ b/t/GreatestCommonFactor.t
@@ -37,7 +37,7 @@ ddg_goodie_test(
     '99 9 greatest common factor'     => build_test('9 and 99', 9),
     'greatest common divisor 4 6'     => build_test('4 and 6', 2),
     'gcd 4 6'                         => build_test('4 and 6', 2),
-    'gcd 2'                           => build_test('2', 2),
+    'gcd 2'                           => build_test('', 1),
     'gcd 12 18 24'                    => build_test('12, 18 and 24', 6),
     'gcd 25 20 15 10 5'               => build_test('5, 10, 15, 20 and 25', 5),
     'gcd 6, 9, ,,,,     12       15'  => build_test('6, 9, 12 and 15', 3),
@@ -45,6 +45,7 @@ ddg_goodie_test(
     'gcd 2 3 5'                       => build_test('2, 3 and 5', 1),
     'gcd 0 2'                         => build_test('0 and 2', 2),
     'gcd 0 0'                         => build_test('0 and 0', 0),
+    'gcf 2'                           => build_test('', 1),
 );
 
 done_testing;

--- a/t/GreatestCommonFactor.t
+++ b/t/GreatestCommonFactor.t
@@ -37,7 +37,6 @@ ddg_goodie_test(
     '99 9 greatest common factor'     => build_test('9 and 99', 9),
     'greatest common divisor 4 6'     => build_test('4 and 6', 2),
     'gcd 4 6'                         => build_test('4 and 6', 2),
-    'gcd 2'                           => build_test('', 1),
     'gcd 12 18 24'                    => build_test('12, 18 and 24', 6),
     'gcd 25 20 15 10 5'               => build_test('5, 10, 15, 20 and 25', 5),
     'gcd 6, 9, ,,,,     12       15'  => build_test('6, 9, 12 and 15', 3),


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [X] Improvement
    - [X] Bug fix: **`GreatestCommonFactor: Fix #3407, Don't trigger on single numbers`**
    - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

Don't trigger on single numbers

###### Which issues (if any) does this fix?

Fixes #3407 - I made it so that it outputs "Cannot compute Greatest common factor" if user only inputs one number. On the discussion, it said that it is not usually done that way, so I can change it if need be.

###### People to notify @zekiel @GuiltyDolphin @austinheimark @procommand


---

Instant Answer Page: https://duck.co/ia/view/greatest_common_factor

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html):  @austinheimark

