### PR TITLE
Random Number: Fixed #3168 and #3169, limit triggers to only when you have two different numbers

### DIFF
--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -17,6 +17,8 @@ handle query_lc => sub {
 
     my $start = $1 || 0;
     my $end   = $2 || 0;
+    
+    return unless ($start != $end) && ($end != undef);
 
     $start = 1000000000 if $start > 1000000000;
     $start = 0          if $start < 0;
@@ -37,6 +39,7 @@ handle query_lc => sub {
         $rand *= ($valDiff + 1);
         $rand = int($rand) + $start;
     }
+    
 
     return "$rand (random number)",
       structured_answer => {

--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -24,7 +24,7 @@ handle query_lc => sub {
     
     #makes sure user inputs two numbers
     return if ($start != $end) && ($end == 0);
-    #  and both numbers are not zero
+    #or both numbers are zero
     return if ($start == $end) && ($end == 0);
 
     $start = 1000000000 if $start > 1000000000;

--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -47,7 +47,7 @@ handle query_lc => sub {
         $rand *= ($valDiff + 1);
         $rand = int($rand) + $start;
     }
-    
+
     return "$rand (random number)",
       structured_answer => {
         data => {

--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -22,10 +22,9 @@ handle query_lc => sub {
     my $start = $1 || 0;
     my $end   = $2 || 0;
     
-    #makes sure user inputs two numbers
+    #makes sure user inputs two numbers, and both numbers are not zero
     return if ($start != $end) && ($end == 0);
-    #or both numbers are zero
-    return if ($start == $end) && ($end == 0);
+    return if ($start == $end) && ($end == 0) && !(($_ =~ /^\!?(?:rand(?:om|)(?: num(?:ber|)|))$/i));
 
     $start = 1000000000 if $start > 1000000000;
     $start = 0          if $start < 0;

--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -17,7 +17,6 @@ handle query_lc => sub {
 
     my $start = $1 || 0;
     my $end   = $2 || 0;
-    
     return unless ($start != $end) && ($end != undef);
 
     $start = 1000000000 if $start > 1000000000;
@@ -40,7 +39,6 @@ handle query_lc => sub {
         $rand = int($rand) + $start;
     }
     
-
     return "$rand (random number)",
       structured_answer => {
         data => {

--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -24,6 +24,8 @@ handle query_lc => sub {
     
     #makes sure user inputs two numbers
     return if ($start != $end) && ($end == 0);
+    #  and both numbers are not zero
+    return if ($start == $end) && ($end == 0);
 
     $start = 1000000000 if $start > 1000000000;
     $start = 0          if $start < 0;

--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -13,11 +13,17 @@ handle query_lc => sub {
     srand();
     # Random number.
     # q_check (as opposed to q_internal) Allows for decimals.
+    
+    # checks if only 'rand' or 'random' is entered
+    return if ($_ =~ /^\!?(?:rand(?:om|))$/i);
+    
     return unless ($_ =~ /^\!?(?:rand(?:om|)(?: num(?:ber|)|)(?: between|))( [\d\.]+|)(?: and|)( [\d\.]+|)$/i);
 
     my $start = $1 || 0;
     my $end   = $2 || 0;
-    return unless ($start != $end) && ($end != undef);
+    
+    #makes sure user inputs two numbers
+    return if ($start != $end) && ($end == 0);
 
     $start = 1000000000 if $start > 1000000000;
     $start = 0          if $start < 0;
@@ -31,6 +37,9 @@ handle query_lc => sub {
     ($end, $start) = ($start, $end) if ($start > $end);
 
     my $valDiff = $end - $start;
+    
+    #returns if both end and start are equal, and end has been changed by the user
+    return if ($valDiff == 0) && ($end != 0);
 
     my $rand = rand;
 

--- a/t/RandomNumber.t
+++ b/t/RandomNumber.t
@@ -41,7 +41,7 @@ ddg_goodie_test(
     'random number between 1 and '    => undef,
     'random 10'                       => undef,
     'random 7 7'                      => undef,
-    'random'                          => undef,
+    'random'                          => undef.
     
     #not related to random numbers
     'random day'                      => undef,

--- a/t/RandomNumber.t
+++ b/t/RandomNumber.t
@@ -44,9 +44,7 @@ ddg_goodie_test(
     
     #not related to random numbers
     'random day'                      => undef,
-    'random access'                   => undef
-    
-    
+    'random access'                   => undef  
 );
 
 done_testing;

--- a/t/RandomNumber.t
+++ b/t/RandomNumber.t
@@ -41,8 +41,8 @@ ddg_goodie_test(
     'random number between 1 and '    => undef,
     'random 10'                       => undef,
     'random 7 7'                      => undef,
-    'random 0 0'                      => undef,
     'random'                          => undef,
+    'random 0 0'                      => undef,
     #not related to random numbers
     'random day'                      => undef,
     'random access'                   => undef

--- a/t/RandomNumber.t
+++ b/t/RandomNumber.t
@@ -36,13 +36,12 @@ ddg_goodie_test(
     'random number between 0 and 1'   => build_test(0, 1, qr/$RE{num}{real}/),
     'random number between 0 and 10'  => build_test(0, 10, qr/\d{1,2}/),
     'random number between 0 and 100' => build_test(0, 100, qr/\d{1,3}/),
-    
+
     #cases that don't have any numbers, only one number, or both numbers the same should fail
     'random number between 1 and '    => undef,
     'random 10'                       => undef,
     'random 7 7'                      => undef,
-    'random'                          => undef.
-    
+    'random'                          => undef,
     #not related to random numbers
     'random day'                      => undef,
     'random access'                   => undef

--- a/t/RandomNumber.t
+++ b/t/RandomNumber.t
@@ -32,19 +32,20 @@ ddg_goodie_test(
     [qw( DDG::Goodie::RandomNumber )],
 
     'random number between 12 and 45' => build_test(12, 45, qr/\d{2}/),
+    'random number'                   => build_test(0, 1, qr/$RE{num}{real}/),
     'random number between 0 and 1'   => build_test(0, 1, qr/$RE{num}{real}/),
     'random number between 0 and 10'  => build_test(0, 10, qr/\d{1,2}/),
     'random number between 0 and 100' => build_test(0, 100, qr/\d{1,3}/),
     
     #cases that don't have any numbers, only one number, or both numbers the same should fail
-    'random number'                   => undef,
-    'random number betwoon 1 and '    => undef,
-    'random 1'                        => undef,
+    'random number between 1 and '    => undef,
+    'random 10'                       => undef,
     'random 7 7'                      => undef,
+    'random'                          => undef.
     
     #not related to random numbers
     'random day'                      => undef,
-    'random access'                   => undef  
+    'random access'                   => undef
 );
 
 done_testing;

--- a/t/RandomNumber.t
+++ b/t/RandomNumber.t
@@ -32,12 +32,21 @@ ddg_goodie_test(
     [qw( DDG::Goodie::RandomNumber )],
 
     'random number between 12 and 45' => build_test(12, 45, qr/\d{2}/),
-    'random number'                   => build_test(0, 1, qr/$RE{num}{real}/),
     'random number between 0 and 1'   => build_test(0, 1, qr/$RE{num}{real}/),
     'random number between 0 and 10'  => build_test(0, 10, qr/\d{1,2}/),
     'random number between 0 and 100' => build_test(0, 100, qr/\d{1,3}/),
+    
+    #cases that don't have any numbers, only one number, or both numbers the same should fail
+    'random number'                   => undef,
+    'random number betwoon 1 and '    => undef,
+    'random 1'                        => undef,
+    'random 7 7'                      => undef,
+    
+    #not related to random numbers
     'random day'                      => undef,
     'random access'                   => undef
+    
+    
 );
 
 done_testing;

--- a/t/RandomNumber.t
+++ b/t/RandomNumber.t
@@ -41,6 +41,7 @@ ddg_goodie_test(
     'random number between 1 and '    => undef,
     'random 10'                       => undef,
     'random 7 7'                      => undef,
+    'random 0 0'                      => undef,
     'random'                          => undef,
     #not related to random numbers
     'random day'                      => undef,

--- a/t/RandomNumber.t
+++ b/t/RandomNumber.t
@@ -41,7 +41,7 @@ ddg_goodie_test(
     'random number between 1 and '    => undef,
     'random 10'                       => undef,
     'random 7 7'                      => undef,
-    'random'                          => undef.
+    'random'                          => undef,
     
     #not related to random numbers
     'random day'                      => undef,


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.
- [ ] New Instant Answer
  - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
  - [ ] Other: **`New {IA Name} Instant Answer`**
- [X] Improvement
  - [X] Bug fix: **`Random Number: Fix #3168 and #3169`**
  - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
  - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**
###### Description of changes

Limit triggers to only when you have two different numbers. Don't trigger if lower and upper bounds are the same, there is only one number, or no numbers present.
###### Which issues (if any) does this fix?

Fixes #3168 and #3169 - Limit triggers to only when you have two different numbers
###### People to notify (@mention interested parties)

@GuiltyDolphin 

---

Instant Answer Page: https://duck.co/ia/view/random_number

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @jonk1993 
