### PR TITLE
ReverseResistorColours: Add x0.1 and x0.01 multipliers

### DIFF
--- a/lib/DDG/Goodie/ReverseResistorColours.pm
+++ b/lib/DDG/Goodie/ReverseResistorColours.pm
@@ -21,8 +21,8 @@ my %coloursToDigits = (
     'violet' => { value => 7,   tolerance => .1  },
     'grey'   => { value => 8,   tolerance => .05 },
     'white'  => { value => 9,   tolerance => ''  },
-    'gold'   => { value => '',  tolerance => 5   },
-    'silver' => { value => '',  tolerance => 10  },
+    'gold'   => { value => '-1',  tolerance => 5   },
+    'silver' => { value => '-2',  tolerance => 10  },
 );
 
 handle query_raw => sub {
@@ -40,10 +40,7 @@ handle query_raw => sub {
     }
     $resistance += ($coloursToDigits{$colours[0]}{value} * 10);
     $resistance += $coloursToDigits{$colours[1]}{value};
-    for (my $i = 0; $i < $coloursToDigits{$colours[2]}{value}; $i++) {
-        $resistance = $resistance * 10;
-    }
-    my $mult = $coloursToDigits{$colours[2]}{value};
+    $resistance = $resistance * (10 ** $coloursToDigits{$colours[2]}{value});
     if (exists $colours[3]) {
         $marginE = $coloursToDigits{$colours[3]}{tolerance};
     } else {

--- a/t/ReverseResistorColours.t
+++ b/t/ReverseResistorColours.t
@@ -114,6 +114,44 @@ ddg_goodie_test(
             }
         }
     ),
+    'brown black gold silver resistor' => test_zci(
+        'A brown black gold silver resistor has a resistance of 1 Ω ± 10%.',
+        structured_answer => {
+            data => {
+                title => '1 Ω ± 10%',
+                subtitle => 'Resistance of brown black gold silver resistor'
+            },
+            meta => {
+                sourceName => "Wikipedia",
+                sourceUrl => "https://en.wikipedia.org/wiki/Electronic_color_code",
+            },
+            templates => {
+                group => 'text',
+                options => {          
+                    moreAt => 1,
+                }
+            }
+        }
+    ),
+    'brown black silver gold resistor' => test_zci(
+        'A brown black silver gold resistor has a resistance of 0.1 Ω ± 5%.',
+        structured_answer => {
+            data => {
+                title => '0.1 Ω ± 5%',
+                subtitle => 'Resistance of brown black silver gold resistor'
+            },
+            meta => {
+                sourceName => "Wikipedia",
+                sourceUrl => "https://en.wikipedia.org/wiki/Electronic_color_code",
+            },
+            templates => {
+                group => 'text',
+                options => {          
+                    moreAt => 1,
+                }
+            }
+        }
+    )
 );
 
 done_testing;

--- a/t/ReverseResistorColours.t
+++ b/t/ReverseResistorColours.t
@@ -22,8 +22,10 @@ sub build_structured_answer {
             sourceUrl => "https://en.wikipedia.org/wiki/Electronic_color_code"
         },
         templates => {
-            group  => 'text',
-            moreAt => 1
+            group => 'text',
+            options => {          
+                moreAt => 1,
+            }
         }
     };
 }

--- a/t/ReverseResistorColours.t
+++ b/t/ReverseResistorColours.t
@@ -11,7 +11,7 @@ zci is_cached => 1;
 zci answer_type => 'ohms';
 
 sub build_structured_answer {
-    my ($exp_result, $exp_input) = @_;
+    my ($exp_input, $exp_result) = @_;
     return "A $exp_input resistor has a resistance of $exp_result.", structured_answer => {
         data => {
             title    => "$exp_result",

--- a/t/ReverseResistorColours.t
+++ b/t/ReverseResistorColours.t
@@ -10,148 +10,40 @@ use utf8;
 zci is_cached => 1;
 zci answer_type => 'ohms';
 
+sub build_structured_answer {
+    my ($exp_result, $exp_input) = @_;
+    return "A $exp_input resistor has a resistance of $exp_result.", structured_answer => {
+        data => {
+            title    => "$exp_result",
+            subtitle => "Resistance of $exp_input resistor"
+        },
+        meta => {
+            sourceName => "Wikipedia",
+            sourceUrl => "https://en.wikipedia.org/wiki/Electronic_color_code"
+        },
+        templates => {
+            group  => 'text',
+            moreAt => 1
+        }
+    };
+}
+
+sub build_test { test_zci(build_structured_answer(@_)) }
+
 ddg_goodie_test(
     [qw(
         DDG::Goodie::ReverseResistorColours
     )],
-
-    'black green red resistor' => test_zci(
-        'A black green red resistor has a resistance of 500 Ω ± 20%.',
-        structured_answer => {
-            data => {
-                title => '500 Ω ± 20%',
-                subtitle => 'Resistance of black green red resistor'
-            },
-            meta => {
-                sourceName => "Wikipedia",
-                sourceUrl => "https://en.wikipedia.org/wiki/Electronic_color_code",
-            },
-            templates => {
-                group => 'text',
-                options => {          
-                    moreAt => 1,
-                }
-            }
-        }
-    ),
-    'red orange yellow gold resistor' => test_zci(
-        'A red orange yellow gold resistor has a resistance of 230 kΩ ± 5%.',
-        structured_answer => {
-            data => {
-                title => '230 kΩ ± 5%',
-                subtitle => 'Resistance of red orange yellow gold resistor'
-            },
-            meta => {
-                sourceName => "Wikipedia",
-                sourceUrl => "https://en.wikipedia.org/wiki/Electronic_color_code",
-            },
-            templates => {
-                group => 'text',
-                options => {          
-                    moreAt => 1,
-                }
-            }
-        }
-    ),
-    'resistor yellow blue purple'=> test_zci(
-        'A yellow blue violet resistor has a resistance of 460 MΩ ± 20%.',
-         structured_answer => {
-            data => {
-                title => '460 MΩ ± 20%',
-                subtitle => 'Resistance of yellow blue violet resistor'
-            },
-            meta => {
-                sourceName => "Wikipedia",
-                sourceUrl => "https://en.wikipedia.org/wiki/Electronic_color_code",
-            },
-            templates => {
-                group => 'text',
-                options => {          
-                    moreAt => 1,
-                }
-            }
-        }
-    ),
-
-    'resistor yellow green' => undef,
-    'resistor red orange blue red green' => undef,
-    'resistor red banana orangutan' => undef,
-    'red yellow white gold resistor' => test_zci(
-        'A red yellow white gold resistor has a resistance of 24 GΩ ± 5%.',
-        structured_answer => {
-            data => {
-                title => '24 GΩ ± 5%',
-                subtitle => 'Resistance of red yellow white gold resistor'
-            },
-            meta => {
-                sourceName => "Wikipedia",
-                sourceUrl => "https://en.wikipedia.org/wiki/Electronic_color_code",
-            },
-            templates => {
-                group => 'text',
-                options => {          
-                    moreAt => 1,
-                }
-            }
-        }
-    ),
-    'resistor red yellow white' => test_zci(
-        'A red yellow white resistor has a resistance of 24 GΩ ± 20%.',
-        structured_answer => {
-            data => {
-                title => '24 GΩ ± 20%',
-                subtitle => 'Resistance of red yellow white resistor'
-            },
-            meta => {
-                sourceName => "Wikipedia",
-                sourceUrl => "https://en.wikipedia.org/wiki/Electronic_color_code",
-            },
-            templates => {
-                group => 'text',
-                options => {          
-                    moreAt => 1,
-                }
-            }
-        }
-    ),
-    'brown black gold silver resistor' => test_zci(
-        'A brown black gold silver resistor has a resistance of 1 Ω ± 10%.',
-        structured_answer => {
-            data => {
-                title => '1 Ω ± 10%',
-                subtitle => 'Resistance of brown black gold silver resistor'
-            },
-            meta => {
-                sourceName => "Wikipedia",
-                sourceUrl => "https://en.wikipedia.org/wiki/Electronic_color_code",
-            },
-            templates => {
-                group => 'text',
-                options => {          
-                    moreAt => 1,
-                }
-            }
-        }
-    ),
-    'brown black silver gold resistor' => test_zci(
-        'A brown black silver gold resistor has a resistance of 0.1 Ω ± 5%.',
-        structured_answer => {
-            data => {
-                title => '0.1 Ω ± 5%',
-                subtitle => 'Resistance of brown black silver gold resistor'
-            },
-            meta => {
-                sourceName => "Wikipedia",
-                sourceUrl => "https://en.wikipedia.org/wiki/Electronic_color_code",
-            },
-            templates => {
-                group => 'text',
-                options => {          
-                    moreAt => 1,
-                }
-            }
-        }
-    )
+    'black green red resistor'              => build_test('black green red', '500 Ω ± 20%'),
+    'red orange yellow gold resistor'       => build_test('red orange yellow gold', '230 kΩ ± 5%'),
+    'yellow blue purple resistor'           => build_test('yellow blue violet', '460 MΩ ± 20%'),
+    'resistor yellow green'                 => undef,
+    'resistor red orange blue red green'    => undef,
+    'resistor red banana orangutan'         => undef,
+    'red yellow white gold resistor'        => build_test('red yellow white gold', '24 GΩ ± 5%'),
+    'resistor red yellow white'             => build_test('red yellow white', '24 GΩ ± 20%'),
+    'brown black gold silver resistor'      => build_test('brown black gold silver', '1 Ω ± 10%'),
+    'brown black silver gold resistor'      => build_test('brown black silver gold', '0.1 Ω ± 5%')
 );
 
 done_testing;


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [x] Improvement
    - [x] Enhancement: **`{IA Name}: {Description of Improvements}`**

###### Description of changes

Currently, the goodie returns 10ohm for "brown black gold silver resistor", which is wrong, as this is the code for 1ohm.
* add gold and silver multipliers (x0.1 and x0.01)
* simplify the multiplier formula
* remove unused "mult" variable

###### People to notify (@mention interested parties)
@Mailkov

---

Instant Answer Page: https://duck.co/ia/view/reverse_resistor_colours

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @Mailkov 

Currently, the goodie returns 10ohm for "brown black gold silver resistor", which is wrong, as this is the code for 1ohm.
* add gold and silver multipliers (x0.1 and x0.01)
* simplify the multiplier formula
* remove unused "mult" variable