### PR TITLE
Bash Cheat Sheet: Added example bash redirection on devfs files for TCP/UDP sockets

### DIFF
--- a/share/goodie/cheat_sheets/json/bash.json
+++ b/share/goodie/cheat_sheets/json/bash.json
@@ -574,6 +574,14 @@
             {
                 "key": "cmd &",
                 "val": "Execute cmd in the background (fork)"
+            },
+            {
+                "key": "cat < /dev/tcp/<hostname>/<port>",
+                "val": "Open a TCP socket to <hostname> at <port> and write the contents of stdin"
+            },
+            {
+                "key": "cat < /dev/udp/<hostname>/<port>",
+                "val": "Open a UDP socket to <hostname> at <port> and write the contents of stdin"
             }
         ]
     }


### PR DESCRIPTION
Added example bash redirection on devfs files for TCP/UDP sockets

Bash treats certain filenames specially.  In the case of `/dev/tcp/<host>/<port>` and `/dev/udp/<host>/<port>`, it will open a corresponding socket to the <host> on <port>, which can then be interacted with via redirection.

---

Instant Answer Page: https://duck.co/ia/view/bash_cheat_sheet
