### PR TITLE
Tip IA: Trigger calculations off of 'tax' and some cleanup

### DIFF
--- a/lib/DDG/Goodie/Tips.pm
+++ b/lib/DDG/Goodie/Tips.pm
@@ -1,12 +1,12 @@
 package DDG::Goodie::Tips;
-# ABSTRACT: calculate a tip on a bill
+# ABSTRACT: calculate a tip/tax on a bill or a general percentage
 
 use strict;
 use DDG::Goodie;
 with 'DDG::GoodieRole::NumberStyler';
 
-# Yes, 'of' is very generic, the gaurd should kick back false positives very quickly.
-triggers any => 'tip', 'tips', 'of';
+# Yes, 'of' is very generic, the guard should kick back false positives very quickly.
+triggers any => 'tip', 'tips', 'of', 'tax';
 
 zci answer_type => 'tip';
 zci is_cached   => 1;
@@ -14,17 +14,47 @@ zci is_cached   => 1;
 my $number_re = number_style_regex();
 
 handle query_lc => sub {
-    return unless (/^(?<p>$number_re)(?: ?%| percent) (?:(?<do_tip>tip (?:on|for|of))|of)(?: an?)? (?<sign>[\$\-]?)(?<num>$number_re)(?: bill)?$/);
+    return unless (/^(?<p>$number_re)(?: ?%| percent) (?:(?<do_tip>(?<tax_or_tip>tip|tax) (?:on|for|of))|of)(?: an?)? (?<sign>[\$\-]?)(?<num>$number_re)(?: bill)?$/);
+    
     my ($p, $num, $sign) = ($+{'p'}, $+{'num'}, $+{'sign'});
     my $style = number_style_for($p, $num);
     $p   = $style->for_computation($p) / 100;
     $num = $style->for_computation($num);
     my $t = $p * $num;
-
-    return 'Tip: $' . $style->for_display(sprintf "%.2f", $t) . '; Total: $' . $style->for_display(sprintf "%.2f", $num + $t) if ($+{'do_tip'});
+    
+    if ($+{'do_tip'}) {
+        my $subtotal = $style->for_display(sprintf "%.2f", $num);
+        my $tax_or_tip = ucfirst($+{'tax_or_tip'});
+        my $tax_or_tip_value = $style->for_display(sprintf "%.2f", $t);
+        my $total = $style->for_display(sprintf "%.2f", $num + $t);
+        
+        my $tax_or_tip_answer = "Subtotal: \$$subtotal; $tax_or_tip: \$$tax_or_tip_value; Total: \$$total";
+        return $tax_or_tip_answer,
+            structured_answer => {
+                data => {
+                    title => "$tax_or_tip_answer",
+                },
+                templates => {
+                    group => 'text'
+                }
+            };
+    }
 
     $t = sprintf "%.2f", $t if ($sign eq '$');    # Maybe this makes cents.
-    return $sign . $style->for_display($t) . ' is ' . $style->for_display($p * 100) . ' percent of ' . $sign . $style->for_display($num);
+    my $calculated_answer = $style->for_display($t);
+    my $percentage = $style->for_display($p * 100);
+    my $number = $style->for_display($num);
+    my $percent_answer = "$sign$calculated_answer is $percentage% of $sign$number";
+    
+    return $percent_answer,
+        structured_answer => {
+            data => {
+                title => "$percent_answer"
+            },
+            templates => {
+                group => 'text'
+            }
+        };
 };
 
 1;

--- a/t/Tips.t
+++ b/t/Tips.t
@@ -11,9 +11,7 @@ zci is_cached   => 1;
 
 sub make_structured_answer {
     my ($type, $subtotal, $additive, $total) = @_;
-    
-    print $type;
-    
+        
     my $title;
     if ($type eq 'percentage') {
         $title = "$total is $additive% of $subtotal";

--- a/t/Tips.t
+++ b/t/Tips.t
@@ -9,19 +9,52 @@ use DDG::Test::Goodie;
 zci answer_type => 'tip';
 zci is_cached   => 1;
 
+sub with_tax_response {
+    my ($subtotal, $tax, $total) = @_;
+    
+    return "Subtotal: \$$subtotal; Tax: \$$tax; Total: \$$total";
+}
+
+sub with_tip_response {
+    my ($subtotal, $tip, $total) = @_;
+    
+    return "Subtotal: \$$subtotal; Tip: \$$tip; Total: \$$total";
+}
+
+sub with_percentage_answer {
+    my ($input, $percentage, $calculated_answer) = @_;
+    
+    return "$calculated_answer is $percentage% of $input";
+}
+
+sub make_structured_answer {
+    my ($answer) = @_;
+    
+    return $answer,
+        structured_answer => {
+            data => {
+                title => "$answer",
+            },
+            templates => {
+                group => 'text'
+            }
+        };
+}
+
 ddg_goodie_test(
     [qw( DDG::Goodie::Tips)],
-    '20% tip on $20'                  => test_zci('Tip: $4.00; Total: $24.00'),
-    '20% tip on $20 bill'             => test_zci('Tip: $4.00; Total: $24.00'),
-    '20% tip for a $20 bill'          => test_zci('Tip: $4.00; Total: $24.00'),
-    '20 percent tip on $20'           => test_zci('Tip: $4.00; Total: $24.00'),
-    '20% tip on $21.63'               => test_zci('Tip: $4.33; Total: $25.96'),
-    '20 percent tip for a $20 bill'   => test_zci('Tip: $4.00; Total: $24.00'),
-    '20 percent tip for a $2000 bill' => test_zci('Tip: $400.00; Total: $2,400.00'),
-    '25 percent of 20000'             => test_zci('5,000 is 25 percent of 20,000'),
-    '2% of 25,000'                    => test_zci('500 is 2 percent of 25,000'),
-    '2% of $25,000'                   => test_zci('$500.00 is 2 percent of $25,000'),
-    '2,000% of -2'                    => test_zci('-40 is 2,000 percent of -2'),
+    '20% tip on $20'                  => test_zci(make_structured_answer(with_tip_response('20.00', '4.00', '24.00'))),
+    '20% tip on $20 bill'             => test_zci(make_structured_answer(with_tip_response('20.00', '4.00', '24.00'))),
+    '20% tip for a $20 bill'          => test_zci(make_structured_answer(with_tip_response('20.00', '4.00', '24.00'))),
+    '20 percent tip on $20'           => test_zci(make_structured_answer(with_tip_response('20.00', '4.00', '24.00'))),
+    '20% tip on $21.63'               => test_zci(make_structured_answer(with_tip_response('21.63', '4.33', '25.96'))),
+    '20 percent tip for a $20 bill'   => test_zci(make_structured_answer(with_tip_response('20.00', '4.00', '24.00'))),
+    '20 percent tip for a $2000 bill' => test_zci(make_structured_answer(with_tip_response('2,000.00', '400.00', '2,400.00'))),
+    '20% tax on $20'                  => test_zci(make_structured_answer(with_tax_response('20.00', '4.00', '24.00'))),
+    '25 percent of 20000'             => test_zci(make_structured_answer(with_percentage_answer('20,000', '25', '5,000'))),
+    '2% of 25,000'                    => test_zci(make_structured_answer(with_percentage_answer('25,000', '2', '500'))),
+    '2% of $25,000'                   => test_zci(make_structured_answer(with_percentage_answer('$25,000', '2', '$500.00'))),
+    '2,000% of -2'                    => test_zci(make_structured_answer(with_percentage_answer('-2', '2,000', '-40'))),
     'best of 5'                       => undef,
     '4 of 5 dentists'                 => undef,
 );

--- a/t/Tips.t
+++ b/t/Tips.t
@@ -9,31 +9,24 @@ use DDG::Test::Goodie;
 zci answer_type => 'tip';
 zci is_cached   => 1;
 
-sub with_tax_response {
-    my ($subtotal, $tax, $total) = @_;
-    
-    return "Subtotal: \$$subtotal; Tax: \$$tax; Total: \$$total";
-}
-
-sub with_tip_response {
-    my ($subtotal, $tip, $total) = @_;
-    
-    return "Subtotal: \$$subtotal; Tip: \$$tip; Total: \$$total";
-}
-
-sub with_percentage_answer {
-    my ($input, $percentage, $calculated_answer) = @_;
-    
-    return "$calculated_answer is $percentage% of $input";
-}
-
 sub make_structured_answer {
-    my ($answer) = @_;
+    my ($type, $subtotal, $additive, $total) = @_;
     
-    return $answer,
+    print $type;
+    
+    my $title;
+    if ($type eq 'percentage') {
+        $title = "$total is $additive% of $subtotal";
+    }
+    else {
+        $type = ucfirst($type);
+        $title = "Subtotal: \$$subtotal; $type: \$$additive; Total: \$$total";
+    }
+    
+    return $title,
         structured_answer => {
             data => {
-                title => "$answer",
+                title => "$title",
             },
             templates => {
                 group => 'text'
@@ -41,20 +34,22 @@ sub make_structured_answer {
         };
 }
 
+sub build_test {test_zci(make_structured_answer(@_))}
+
 ddg_goodie_test(
     [qw( DDG::Goodie::Tips)],
-    '20% tip on $20'                  => test_zci(make_structured_answer(with_tip_response('20.00', '4.00', '24.00'))),
-    '20% tip on $20 bill'             => test_zci(make_structured_answer(with_tip_response('20.00', '4.00', '24.00'))),
-    '20% tip for a $20 bill'          => test_zci(make_structured_answer(with_tip_response('20.00', '4.00', '24.00'))),
-    '20 percent tip on $20'           => test_zci(make_structured_answer(with_tip_response('20.00', '4.00', '24.00'))),
-    '20% tip on $21.63'               => test_zci(make_structured_answer(with_tip_response('21.63', '4.33', '25.96'))),
-    '20 percent tip for a $20 bill'   => test_zci(make_structured_answer(with_tip_response('20.00', '4.00', '24.00'))),
-    '20 percent tip for a $2000 bill' => test_zci(make_structured_answer(with_tip_response('2,000.00', '400.00', '2,400.00'))),
-    '20% tax on $20'                  => test_zci(make_structured_answer(with_tax_response('20.00', '4.00', '24.00'))),
-    '25 percent of 20000'             => test_zci(make_structured_answer(with_percentage_answer('20,000', '25', '5,000'))),
-    '2% of 25,000'                    => test_zci(make_structured_answer(with_percentage_answer('25,000', '2', '500'))),
-    '2% of $25,000'                   => test_zci(make_structured_answer(with_percentage_answer('$25,000', '2', '$500.00'))),
-    '2,000% of -2'                    => test_zci(make_structured_answer(with_percentage_answer('-2', '2,000', '-40'))),
+    '20% tip on $20'                  => build_test('tip', '20.00', '4.00', '24.00'),
+    '20% tip on $20 bill'             => build_test('tip', '20.00', '4.00', '24.00'),
+    '20% tip for a $20 bill'          => build_test('tip', '20.00', '4.00', '24.00'),
+    '20 percent tip on $20'           => build_test('tip', '20.00', '4.00', '24.00'),
+    '20% tip on $21.63'               => build_test('tip', '21.63', '4.33', '25.96'),
+    '20 percent tip for a $20 bill'   => build_test('tip', '20.00', '4.00', '24.00'),
+    '20 percent tip for a $2000 bill' => build_test('tip', '2,000.00', '400.00', '2,400.00'),
+    '20% tax on $20'                  => build_test('tax', '20.00', '4.00', '24.00'),
+    '25 percent of 20000'             => build_test('percentage', '20,000', '25', '5,000'),
+    '2% of 25,000'                    => build_test('percentage', '25,000', '2', '500'),
+    '2% of $25,000'                   => build_test('percentage', '$25,000', '2', '$500.00'),
+    '2,000% of -2'                    => build_test('percentage', '-2', '2,000', '-40'),
     'best of 5'                       => undef,
     '4 of 5 dentists'                 => undef,
 );


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [x] Improvement
    - [x] Bug fix: **`Tips: Fix #1044`**

###### Description of changes

- This IA can now trigger off of "tax"
- Conversion to a structured answer response
- Include subtotal to the response for a more immersive answer
- Instead of `percent of` in the percentage response, changed to `% of`

###### Which issues (if any) does this fix?

Fixes #1044 - Allow queries to have "tax" in them to trigger this

###### People to notify (@mention interested parties)

@mattlehning @moollaza @mattr555 @mintsoft 

---

Instant Answer Page: https://duck.co/ia/view/tips

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @mattlehning 

