### PR TITLE
DjangoModelCheatSheet: Change template_type to reference, add more triggering aliases

### DIFF
--- a/share/goodie/cheat_sheets/json/django-model.json
+++ b/share/goodie/cheat_sheets/json/django-model.json
@@ -9,10 +9,16 @@
     },
 
     "aliases": [
-        "django orm"
+        "django orm",
+        "django model",
+        "django models",
+        "django model field",
+        "django models field",
+        "django model fields",
+        "django models fields"
     ],
 
-    "template_type": "terminal",
+    "template_type": "reference",
 
     "section_order": [
         "Field Types",

--- a/share/goodie/cheat_sheets/json/django-model.json
+++ b/share/goodie/cheat_sheets/json/django-model.json
@@ -10,7 +10,6 @@
 
     "aliases": [
         "django orm",
-        "django model",
         "django models",
         "django model field",
         "django models field",


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [x] Bug fix: **`DjangoModelCheatSheet: Fix #2940`**
    - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

Provide an overview of the changes this pull request introduces.

IA now has more triggers as mentioned in the issue and has template_type = `reference` which makes more sense in this case since more users will be looking for `Django model reference` rather than `Django model commands`. This is my opinion. I am seeking suggestions about this.

###### Which issues (if any) does this fix?

Fixes #2940 

###### People to notify (@mention interested parties)

---

Instant Answer Page: https://duck.co/ia/view/django_model_cheat_sheet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): 
@pjhampton 
