### PR TITLE
URLEncode: enable triggering on 'uri' as well

### DIFF
--- a/lib/DDG/Goodie/URLEncode.pm
+++ b/lib/DDG/Goodie/URLEncode.pm
@@ -6,7 +6,8 @@ use URI::Escape::XS qw(uri_escape);
 use warnings;
 use strict;
 
-triggers startend   =>      'url encode', 'encode url', 'urlencode', 'encodeurl', 'url escape', 'escape url', 'urlescape', 'escapeurl';
+triggers startend   =>      'url encode', 'encode url', 'urlencode', 'encodeurl', 'url escape', 'escape url', 'urlescape', 'escapeurl',
+                            'uri encode', 'encode uri', 'uriencode', 'encodeuri', 'uri escape', 'escape uri', 'uriescape', 'escapeuri';
 
 zci answer_type =>          'encoded_url';
 zci is_cached   =>          1;

--- a/t/URLEncode.t
+++ b/t/URLEncode.t
@@ -33,7 +33,11 @@ ddg_goodie_test(
     # Primary example queries
     'url encode https://duckduckgo.com/' => test_zci(build_answer('https%3A%2F%2Fduckduckgo.com%2F', 'https://duckduckgo.com/')),
 
+    'uri encode https://duckduckgo.com/' => test_zci(build_answer('https%3A%2F%2Fduckduckgo.com%2F', 'https://duckduckgo.com/')),
+
     'encode url xkcd.com/blag' => test_zci(build_answer('xkcd.com%2Fblag', 'xkcd.com/blag')),
+
+    'encode uri xkcd.com/blag' => test_zci(build_answer('xkcd.com%2Fblag', 'xkcd.com/blag')),
 
     # Secondary example queries
     'http://arstechnica.com/ url escape' => test_zci(build_answer('http%3A%2F%2Farstechnica.com%2F', 'http://arstechnica.com/')),


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [ ] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [x] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

`uri` is now matched in the same way as `url` was. A few tests have been added. Let me know if you'd like the full test suite replicating.

###### Which issues (if any) does this fix?

Fixes #3201 by duplicating all existing triggers to match `uri`.

###### People to notify (@mention interested parties)

@nishanths, @tagawa 

---

Instant Answer Page: https://duck.co/ia/view/urlencode

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @nishanths

