### PR TITLE
Frequency: Update IA to use List template

### DIFF
--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -10,6 +10,7 @@ handle remainder => sub {
     if ($_ =~ /^of ([a-z]|(?:all ?|)(?:letters|characters|chars|)) in (.+)/i) {
 
         my $collect = lc $1;
+        my $query_str = $2;
         my $target_str = lc $2;
 
         my $count = 0;
@@ -39,7 +40,7 @@ handle remainder => sub {
         };
 
         if ($collect =~ /($regex_all)/) {
-            $title = "Frequency of each character in $target_str";
+            $title = "Frequency of each character in $query_str";
         }
         else {
             $title = "Frequency $_";

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -18,6 +18,8 @@ handle remainder => sub {
         my %freq;
         my @chars = split //, $target_str;
 
+        my ($title, $subtitle, @record_data, @record_keys);
+
         foreach (@chars) {
             if ($_ =~ /[a-z]/) {
                 if ($collect =~ /all|letters|characters|chars/) {
@@ -26,41 +28,38 @@ handle remainder => sub {
                 else {
                     ++$freq{$_} if $_ eq $collect;
                 }
-
                 ++$count;
             };
         };
 
-        my $list_data = [];
-        foreach my $key (sort keys %freq) {
-            my $temp_hash = {
-                alphabet => "$key",
-                frequency => "$freq{$key}"
-            };
-            push( @$list_data, $temp_hash );
-        }
 
+        my @temp_keys;
         my @out;
-        foreach my $key (keys %freq) {
+        foreach my $key (sort keys %freq) {
+            push( @temp_keys, $key );
             push @out, join ":", $key, $freq{$key} . "/" . $count;
         };
 
-        my $plaintext = join ' ', @out if @out;
-    	
+        @record_data = \%freq;
+        @record_keys = \@temp_keys;
+
+        my $plaintext = join ' ', @out;
+
         return $plaintext,
         structured_answer => {
             data => {
                 title => "Frequency",
-                list => $list_data
+                record_data => @record_data,
+                record_keys => @record_keys
             },
             meta => {},
             templates => {
                 group => 'list',
                 options => {
-                    list_content => "DDH.frequency.list_content"
+                    content => "record"
                 },
             },
-        };
+        } if @out;
     };
 
     return;

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -17,7 +17,7 @@ handle remainder => sub {
         my %freq;
         my @chars = split //, $target_str;
 
-        my ($title, @record_data, @record_keys);
+        my ($title, $subtitle, @record_data, @record_keys);
         my $regex_all = "all|letters|characters|chars";
         
         foreach (@chars) {
@@ -39,11 +39,13 @@ handle remainder => sub {
             push @out, join ":", $key, $freq{$key} . "/" . $count;
         };
 
+        $title = $query_str;
+
         if ($collect =~ /($regex_all)/) {
-            $title = "Frequency of each character in $query_str";
+            $subtitle = "Frequency of all characters";
         }
         else {
-            $title = "Frequency $_";
+            $subtitle = "Frequency of '$collect'";
         }
 
         @record_data = \%freq;
@@ -55,6 +57,7 @@ handle remainder => sub {
         structured_answer => {
             data => {
                 title => $title,
+                subtitle => $subtitle,
                 record_data => @record_data,
                 record_keys => @record_keys
             },

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -7,36 +7,60 @@ use DDG::Goodie;
 triggers start => 'frequency', 'freq';
 
 handle remainder => sub {
-    if ($_ =~ /^of ([a-z]|(?:all ?|)(?:letters|characters|chars|)) in (.+)/i)
-    {
+    if ($_ =~ /^of ([a-z]|(?:all ?|)(?:letters|characters|chars|)) in (.+)/i) {
 
-	my $collect = lc $1;
-	my $target_str = lc $2;
+        my $collect = lc $1;
+        my $target_str = lc $2;
 
-#	warn qq($collect\t$target_str\n);
+#     	warn qq($collect\t$target_str\n);
 
-	my $count = 0;
-	my %freq;
-	my @chars = split //, $target_str;
+        my $count = 0;
+        my %freq;
+        my @chars = split //, $target_str;
 
-	foreach (@chars)
-	{
-	    if ($_ =~ /[a-z]/)
-	    {
-		if ($collect =~ /all|letters|characters|chars/) { ++$freq{$_}; }
-		else { ++$freq{$_} if $_ eq $collect; }
+        foreach (@chars) {
+            if ($_ =~ /[a-z]/) {
+                if ($collect =~ /all|letters|characters|chars/) {
+                    ++$freq{$_};
+                }
+                else {
+                    ++$freq{$_} if $_ eq $collect;
+                }
 
-		++$count;
-	    };
-	};
+                ++$count;
+            };
+        };
 
-	my @out;
-	foreach my $key (keys %freq)
-	{
-	    push @out, join ":", $key, $freq{$key} . "/" . $count;
-	};
+        my $list_data = [];
+        foreach my $key (sort keys %freq) {
+            my $temp_hash = {
+                alphabet => "$key",
+                frequency => "$freq{$key}"
+            };
+            push( @$list_data, $temp_hash );
+        }
 
-	return "Frequency: " . join ' ',sort(@out) if @out;
+        my @out;
+        foreach my $key (keys %freq) {
+        push @out, join " ", $key, $freq{$key} . "/" . $count;
+        };
+
+        my $plaintext = join ' ', @out if @out;
+    	
+        return $plaintext,
+        structured_answer => {
+            data => {
+                title => "Frequency",
+                list => $list_data
+            },
+            meta => {},
+            templates => {
+                group => 'list',
+                options => {
+                    list_content => "DDH.frequency.list_content"
+                },
+            },
+        };;
     };
 
     return;

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -52,7 +52,6 @@ handle remainder => sub {
                 record_data => @record_data,
                 record_keys => @record_keys
             },
-            meta => {},
             templates => {
                 group => 'list',
                 options => {

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -16,7 +16,7 @@ handle remainder => sub {
         my %freq;
         my @chars = split //, $target_str;
 
-        my ($title, $subtitle, @record_data, @record_keys);
+        my (@record_data, @record_keys);
 
         foreach (@chars) {
             if ($_ =~ /[a-z]/) {
@@ -29,7 +29,6 @@ handle remainder => sub {
                 ++$count;
             };
         };
-
 
         my @temp_keys;
         my @out;
@@ -46,7 +45,7 @@ handle remainder => sub {
         return $plaintext,
         structured_answer => {
             data => {
-                title => "Frequency",
+                title => "Frequency " . $_,
                 record_data => @record_data,
                 record_keys => @record_keys
             },

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -16,11 +16,12 @@ handle remainder => sub {
         my %freq;
         my @chars = split //, $target_str;
 
-        my (@record_data, @record_keys);
-
+        my ($title, @record_data, @record_keys);
+        my $regex_all = "all|letters|characters|chars";
+        
         foreach (@chars) {
             if ($_ =~ /[a-z]/) {
-                if ($collect =~ /all|letters|characters|chars/) {
+                if ($collect =~ /($regex_all)/) {
                     ++$freq{$_};
                 }
                 else {
@@ -37,6 +38,13 @@ handle remainder => sub {
             push @out, join ":", $key, $freq{$key} . "/" . $count;
         };
 
+        if ($collect =~ /($regex_all)/) {
+            $title = "Frequency of each character in $target_str";
+        }
+        else {
+            $title = "Frequency $_";
+        }
+
         @record_data = \%freq;
         @record_keys = \@temp_keys;
 
@@ -45,7 +53,7 @@ handle remainder => sub {
         return $plaintext,
         structured_answer => {
             data => {
-                title => "Frequency " . $_,
+                title => $title,
                 record_data => @record_data,
                 record_keys => @record_keys
             },

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -7,7 +7,7 @@ use DDG::Goodie;
 triggers start => 'frequency', 'freq';
 
 handle remainder => sub {
-    if ($_ =~ /^of ([a-z]|(?:all ?|)(?:letters|characters|chars|alphabets|)) in ([\w\s]+)/i) {
+    if ($_ =~ /^of ([a-z]|(?:all ?|)(?:letters|characters|chars|alphabets|)) in (.+)/i) {
 
         my $collect_exact = $1;
         my $collect = lc $1;

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -42,7 +42,7 @@ handle remainder => sub {
 
         my @out;
         foreach my $key (keys %freq) {
-        push @out, join " ", $key, $freq{$key} . "/" . $count;
+            push @out, join ":", $key, $freq{$key} . "/" . $count;
         };
 
         my $plaintext = join ' ', @out if @out;
@@ -60,7 +60,7 @@ handle remainder => sub {
                     list_content => "DDH.frequency.list_content"
                 },
             },
-        };;
+        };
     };
 
     return;

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -9,6 +9,7 @@ triggers start => 'frequency', 'freq';
 handle remainder => sub {
     if ($_ =~ /^of ([a-z]|(?:all ?|)(?:letters|characters|chars|)) in (.+)/i) {
 
+        my $collect_exact = $1;
         my $collect = lc $1;
         my $query_str = $2;
         my $target_str = lc $2;
@@ -45,7 +46,7 @@ handle remainder => sub {
             $subtitle = "Frequency of all characters";
         }
         else {
-            $subtitle = "Frequency of '$collect'";
+            $subtitle = "Frequency of '$collect_exact'";
         }
 
         @record_data = \%freq;

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -7,7 +7,7 @@ use DDG::Goodie;
 triggers start => 'frequency', 'freq';
 
 handle remainder => sub {
-    if ($_ =~ /^of ([a-z]|(?:all ?|)(?:letters|characters|chars|alphabets|)) in (.+)/i) {
+    if ($_ =~ /^of ([a-z]|(?:all ?|)(?:letters|characters|chars|alphabets|)) in ([\w\s]+)/i) {
 
         my $collect_exact = $1;
         my $collect = lc $1;

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -7,7 +7,7 @@ use DDG::Goodie;
 triggers start => 'frequency', 'freq';
 
 handle remainder => sub {
-    if ($_ =~ /^of ([a-z]|(?:all ?|)(?:letters|characters|chars|)) in (.+)/i) {
+    if ($_ =~ /^of ([a-z]|(?:all ?|)(?:letters|characters|chars|alphabets|)) in (.+)/i) {
 
         my $collect_exact = $1;
         my $collect = lc $1;

--- a/lib/DDG/Goodie/Frequency.pm
+++ b/lib/DDG/Goodie/Frequency.pm
@@ -12,8 +12,6 @@ handle remainder => sub {
         my $collect = lc $1;
         my $target_str = lc $2;
 
-#     	warn qq($collect\t$target_str\n);
-
         my $count = 0;
         my %freq;
         my @chars = split //, $target_str;

--- a/share/goodie/frequency/list_content.handlebars
+++ b/share/goodie/frequency/list_content.handlebars
@@ -1,2 +1,0 @@
-<span class="twenty twenty--screen-xs twenty--screen-s">{{alphabet}}:</span>
-<span class="g twenty twenty--screen-xs twenty--screen-s tx-clr--dk">{{frequency}}</span>

--- a/share/goodie/frequency/list_content.handlebars
+++ b/share/goodie/frequency/list_content.handlebars
@@ -1,0 +1,2 @@
+<span class="twenty twenty--screen-xs twenty--screen-s">{{alphabet}}:</span>
+<span class="g twenty twenty--screen-xs twenty--screen-s tx-clr--dk">{{frequency}}</span

--- a/share/goodie/frequency/list_content.handlebars
+++ b/share/goodie/frequency/list_content.handlebars
@@ -1,2 +1,2 @@
 <span class="twenty twenty--screen-xs twenty--screen-s">{{alphabet}}:</span>
-<span class="g twenty twenty--screen-xs twenty--screen-s tx-clr--dk">{{frequency}}</span
+<span class="g twenty twenty--screen-xs twenty--screen-s tx-clr--dk">{{frequency}}</span>

--- a/t/Frequency.t
+++ b/t/Frequency.t
@@ -76,7 +76,7 @@ ddg_goodie_test(
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', "testing 1234 ABC!", "$all_chars_subtitle", {
+    'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', "testing 1234 ABC", "$all_chars_subtitle", {
         'a' => 1,
         'b' => 1,
         'c' => 1,

--- a/t/Frequency.t
+++ b/t/Frequency.t
@@ -9,172 +9,87 @@ use DDG::Test::Goodie;
 zci is_cached => 1;
 zci answer_type => 'frequency';
 
-my @structured_answer = {
-    data => ignore(),
-    templates => {
-        group => "list",
-        options => {
-            content => "record"
-        }
-    }
-};
+sub build_structured_test {
+    my ($plaintext, $record_data, $record_keys) = @_;
 
-my $title = "Frequency";
-my @templates = {
-    group => "list",
-    options => {
-        content => "record"
-    }
-};
+    return $plaintext,
+    structured_answer => {
+        data => {
+        title => "Frequency",
+        record_data => $record_data,
+        record_keys => $record_keys
+        },
+        templates => {
+            group => "list",
+            options => {
+                content => "record"
+            }
+        }
+    };
+}
+
+sub build_test {
+    test_zci(build_structured_test(@_));
+}
 
 ddg_goodie_test(
         [qw(
                 DDG::Goodie::Frequency
         )],
 
-    "frequency of all in test" => test_zci(
-        "e:1/4 s:1/4 t:2/4",
-        structured_answer => {
-            data => {
-                title => $title,
-                record_data => {
-                    'e' => 1,
-                    's' => 1,
-                    't' => 2
-                },
-                record_keys => ['e', 's', 't']
-            },
-            templates => @templates
-        }
-    ),
+    "frequency of all in test" => build_test('e:1/4 s:1/4 t:2/4', {
+        'e' => 1,
+        's' => 1,
+        't' => 2
+    }, ['e', 's', 't']),
 
-    'frequency of all letters in test' => test_zci(
-        'e:1/4 s:1/4 t:2/4',
-        structured_answer => {
-            data => {
-                title => $title,
-                record_data => {
-                    'e' => 1,
-                    's' => 1,
-                    't' => 2
-                },
-                record_keys => ['e', 's', 't']
-            },
-            templates => @templates
-        }
-    ),
+    'frequency of all letters in test' => build_test('e:1/4 s:1/4 t:2/4', {
+        'e' => 1,
+        's' => 1,
+        't' => 2
+    }, ['e', 's', 't']),
 
-    'frequency of letters in test' => test_zci(
-        'e:1/4 s:1/4 t:2/4',
-        structured_answer => {
-            data => {
-                title => $title,
-                record_data => {
-                    'e' => 1,
-                    's' => 1,
-                    't' => 2
-                },
-                record_keys => ['e', 's', 't']
-            },
-            templates => @templates
-        }
-    ),
+    'frequency of letters in test' => build_test('e:1/4 s:1/4 t:2/4', {
+        'e' => 1,
+        's' => 1,
+        't' => 2
+    }, ['e', 's', 't']),
 
-    'frequency of all characters in test' => test_zci(
-        'e:1/4 s:1/4 t:2/4',
-        structured_answer => {
-            data => {
-                title => $title,
-                record_data => {
-                    'e' => 1,
-                    's' => 1,
-                    't' => 2
-                },
-                record_keys => ['e', 's', 't']
-            },
-            templates => @templates
-        }
-    ),
+    'frequency of all characters in test' => build_test('e:1/4 s:1/4 t:2/4', {
+        'e' => 1,
+        's' => 1,
+        't' => 2
+    }, ['e', 's', 't']),
 
-    'frequency of all chars in test' => test_zci(
-        'e:1/4 s:1/4 t:2/4',
-        structured_answer => {
-            data => {
-                title => $title,
-                record_data => {
-                    'e' => 1,
-                    's' => 1,
-                    't' => 2
-                },
-                record_keys => ['e', 's', 't']
-            },
-            templates => @templates
-        }
-    ),
+    'frequency of all chars in test' => build_test('e:1/4 s:1/4 t:2/4', {
+        'e' => 1,
+        's' => 1,
+        't' => 2
+    }, ['e', 's', 't']),
 
-    'frequency of all in testing 1234 ABC!' => test_zci(
-        'a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10',
-        structured_answer => {
-            data => {
-                title => $title,
-                record_data => {
-                    'a' => 1,
-                    'b' => 1,
-                    'c' => 1,
-                    'e' => 1,
-                    'g' => 1,
-                    'i' => 1,
-                    'n' => 1,
-                    's' => 1,
-                    't' => 2
-                },
-                record_keys => ['a', 'b', 'c', 'e', 'g', 'i', 'n', 's', 't']
-            },
-            templates => @templates
-        }
-    ),
+    'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', {
+        'a' => 1,
+        'b' => 1,
+        'c' => 1,
+        'e' => 1,
+        'g' => 1,
+        'i' => 1,
+        'n' => 1,
+        's' => 1,
+        't' => 2
+    }, ['a', 'b', 'c', 'e', 'g', 'i', 'n', 's', 't']),
 
-    'frequency of a in Atlantic Ocean' => test_zci(
-        'a:3/13',
-        structured_answer => {
-            data => {
-                title => $title,
-                record_data => {
-                    "a" => 3
-                },
-                record_keys => ["a"]
-            },
-            templates => @templates
-        }
-    ),
+    'frequency of a in Atlantic Ocean' => build_test('a:3/13', {
+        "a" => 3
+    }, ["a"]),
 
-    'freq of B in battle' => test_zci(
-        'b:1/6',
-        structured_answer => {
-            data => {
-                title => $title,
-                record_data => {
-                    'b' => 1
-                },
-                record_keys => ['b']
-            },
-            templates => @templates
-        }
-    ),
+    'freq of B in battle' => build_test('b:1/6', {
+        'b' => 1
+    }, ['b']),
 
-    'freq of s in Spoons' => test_zci(
-        's:2/6',
-        structured_answer => {
-            data => {
-                title => $title,
-                record_data => {
-                    's' => 2
-                },
-                record_keys => ['s']
-            },
-            templates => @templates
-        }
-    ),
+    'freq of s in Spoons' => build_test('s:2/6', {
+        's' => 2
+    }, ['s']),
 
     'frequency s in spoons' => undef,
     'freq s in spoons' => undef,

--- a/t/Frequency.t
+++ b/t/Frequency.t
@@ -76,7 +76,7 @@ ddg_goodie_test(
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', "testing 1234 ABC", "$all_chars_subtitle", {
+    'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', "testing 1234 ABC!", "$all_chars_subtitle", {
         'a' => 1,
         'b' => 1,
         'c' => 1,

--- a/t/Frequency.t
+++ b/t/Frequency.t
@@ -11,6 +11,12 @@ zci answer_type => 'frequency';
 
 my $all_chars_subtitle = "Frequency of all characters";
 
+my @test_response = ('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
+    'e' => 1,
+    's' => 1,
+    't' => 2
+}, ['e', 's', 't']);
+
 sub build_structured_test {
     my ($plaintext, $title, $subtitle, $record_data, $record_keys) = @_;
 
@@ -40,41 +46,17 @@ ddg_goodie_test(
                 DDG::Goodie::Frequency
         )],
 
-    "frequency of all in test" => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
-        'e' => 1,
-        's' => 1,
-        't' => 2
-    }, ['e', 's', 't']),
+    "frequency of all in test" => build_test(@test_response),
 
-    'frequency of all letters in test' => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
-        'e' => 1,
-        's' => 1,
-        't' => 2
-    }, ['e', 's', 't']),
+    'frequency of all letters in test' => build_test(@test_response),
 
-    'frequency of letters in test' => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
-        'e' => 1,
-        's' => 1,
-        't' => 2
-    }, ['e', 's', 't']),
+    'frequency of letters in test' => build_test(@test_response),
 
-    'frequency of all characters in test' => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
-        'e' => 1,
-        's' => 1,
-        't' => 2
-    }, ['e', 's', 't']),
+    'frequency of all characters in test' => build_test(@test_response),
 
-    'frequency of all alphabets in test' => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
-        'e' => 1,
-        's' => 1,
-        't' => 2
-    }, ['e', 's', 't']),
+    'frequency of all alphabets in test' => build_test(@test_response),
 
-    'frequency of all chars in test' => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
-        'e' => 1,
-        's' => 1,
-        't' => 2
-    }, ['e', 's', 't']),
+    'frequency of all chars in test' => build_test(@test_response),
 
     'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', "testing 1234 ABC!", "$all_chars_subtitle", {
         'a' => 1,

--- a/t/Frequency.t
+++ b/t/Frequency.t
@@ -9,15 +9,16 @@ use DDG::Test::Goodie;
 zci is_cached => 1;
 zci answer_type => 'frequency';
 
-my $general_title_prefix = "Frequency of each character in";
+my $all_chars_subtitle = "Frequency of all characters";
 
 sub build_structured_test {
-    my ($plaintext, $title, $record_data, $record_keys) = @_;
+    my ($plaintext, $title, $subtitle, $record_data, $record_keys) = @_;
 
     return $plaintext,
     structured_answer => {
         data => {
         title => $title,
+        subtitle => $subtitle,
         record_data => $record_data,
         record_keys => $record_keys
         },
@@ -39,37 +40,37 @@ ddg_goodie_test(
                 DDG::Goodie::Frequency
         )],
 
-    "frequency of all in test" => build_test('e:1/4 s:1/4 t:2/4', "$general_title_prefix test", {
+    "frequency of all in test" => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all letters in test' => build_test('e:1/4 s:1/4 t:2/4', "$general_title_prefix test", {
+    'frequency of all letters in test' => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of letters in test' => build_test('e:1/4 s:1/4 t:2/4', "$general_title_prefix test", {
+    'frequency of letters in test' => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all characters in test' => build_test('e:1/4 s:1/4 t:2/4', "$general_title_prefix test", {
+    'frequency of all characters in test' => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all chars in test' => build_test('e:1/4 s:1/4 t:2/4', "$general_title_prefix test", {
+    'frequency of all chars in test' => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', "$general_title_prefix testing 1234 ABC!", {
+    'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', "testing 1234 ABC!", "$all_chars_subtitle", {
         'a' => 1,
         'b' => 1,
         'c' => 1,
@@ -81,15 +82,15 @@ ddg_goodie_test(
         't' => 2
     }, ['a', 'b', 'c', 'e', 'g', 'i', 'n', 's', 't']),
 
-    'frequency of a in Atlantic Ocean' => build_test('a:3/13', "Frequency of a in Atlantic Ocean", {
+    'frequency of a in Atlantic Ocean' => build_test('a:3/13', "Atlantic Ocean", "Frequency of 'a'", {
         "a" => 3
     }, ["a"]),
 
-    'freq of B in battle' => build_test('b:1/6', "Frequency of B in battle", {
+    'freq of B in battle' => build_test('b:1/6', "battle", "Frequency of 'B'", {
         'b' => 1
     }, ['b']),
 
-    'freq of s in Spoons' => build_test('s:2/6', "Frequency of s in Spoons", {
+    'freq of s in Spoons' => build_test('s:2/6', "Spoons", "Frequency of 's'", {
         's' => 2
     }, ['s']),
 

--- a/t/Frequency.t
+++ b/t/Frequency.t
@@ -9,22 +9,82 @@ use DDG::Test::Goodie;
 zci is_cached => 1;
 zci answer_type => 'frequency';
 
+my @structured_answer = {
+    data => ignore(),
+    templates => {
+        group => "list",
+        options => {
+            content => "record"
+        }
+    }
+};
+
+# We don't want to test too specifically on the included data, so just confirm
+# we got the correct answer.
 ddg_goodie_test(
         [qw(
                 DDG::Goodie::Frequency
         )],
-    'frequency of all in test' => test_zci('Frequency: e:1/4 s:1/4 t:2/4'),
-    'frequency of all letters in test' => test_zci('Frequency: e:1/4 s:1/4 t:2/4'),
-    'frequency of letters in test' => test_zci('Frequency: e:1/4 s:1/4 t:2/4'),
-    'frequency of all characters in test' => test_zci('Frequency: e:1/4 s:1/4 t:2/4'),
-    'frequency of all chars in test' => test_zci('Frequency: e:1/4 s:1/4 t:2/4'),
-    'frequency of all in testing 1234 ABC!' => test_zci('Frequency: a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10'),
-    'frequency of all in Assassins!' => test_zci('Frequency: a:2/9 i:1/9 n:1/9 s:5/9'),
-    'frequency of a in Atlantic Ocean' => test_zci('Frequency: a:3/13'),
-    'freq of B in battle' => test_zci('Frequency: b:1/6'),
-    'freq of s in Spoons' => test_zci('Frequency: s:2/6'),
-    'frequency of all characters in testing' => test_zci('Frequency: e:1/7 g:1/7 i:1/7 n:1/7 s:1/7 t:2/7'),
-    'frequency of B in battle' => test_zci('Frequency: b:1/6'),
+
+    "frequency of all in test" => test_zci(
+        "e:1/4 s:1/4 t:2/4",
+        structured_answer => @structured_answer
+    ),
+
+    'frequency of all letters in test' => test_zci(
+        'e:1/4 s:1/4 t:2/4',
+        structured_answer => @structured_answer
+    ),
+
+    'frequency of letters in test' => test_zci(
+        'e:1/4 s:1/4 t:2/4',
+        structured_answer => @structured_answer
+    ),
+
+    'frequency of all characters in test' => test_zci(
+        'e:1/4 s:1/4 t:2/4',
+        structured_answer => @structured_answer
+    ),
+
+    'frequency of all chars in test' => test_zci(
+        'e:1/4 s:1/4 t:2/4',
+        structured_answer => @structured_answer
+    ),
+
+    'frequency of all in testing 1234 ABC!' => test_zci(
+        'a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10',
+        structured_answer => @structured_answer
+    ),
+
+    'frequency of all in Assassins!' => test_zci(
+        'a:2/9 i:1/9 n:1/9 s:5/9',
+        structured_answer => @structured_answer
+    ),
+
+    'frequency of a in Atlantic Ocean' => test_zci(
+        'a:3/13'.
+        structured_answer => @structured_answer
+    ),
+
+    'freq of B in battle' => test_zci(
+        'b:1/6',
+        structured_answer => @structured_answer
+    ),
+
+    'freq of s in Spoons' => test_zci(
+        's:2/6',
+        structured_answer => @structured_answer
+    ),
+
+    'frequency of all characters in testing' => test_zci(
+        'e:1/7 g:1/7 i:1/7 n:1/7 s:1/7 t:2/7',
+        structured_answer => @structured_answer
+    ),
+
+    'frequency of B in battle' => test_zci(
+        'b:1/6',
+        structured_answer => @structured_answer
+    )
 );
 
 done_testing;

--- a/t/Frequency.t
+++ b/t/Frequency.t
@@ -19,8 +19,14 @@ my @structured_answer = {
     }
 };
 
-# We don't want to test too specifically on the included data, so just confirm
-# we got the correct answer.
+my $title = "Frequency";
+my @templates = {
+    group => "list",
+    options => {
+        content => "record"
+    }
+};
+
 ddg_goodie_test(
         [qw(
                 DDG::Goodie::Frequency
@@ -28,63 +34,155 @@ ddg_goodie_test(
 
     "frequency of all in test" => test_zci(
         "e:1/4 s:1/4 t:2/4",
-        structured_answer => @structured_answer
+        structured_answer => {
+            data => {
+                title => $title,
+                record_data => {
+                    'e' => 1,
+                    's' => 1,
+                    't' => 2
+                },
+                record_keys => ['e', 's', 't']
+            },
+            templates => @templates
+        }
     ),
 
     'frequency of all letters in test' => test_zci(
         'e:1/4 s:1/4 t:2/4',
-        structured_answer => @structured_answer
+        structured_answer => {
+            data => {
+                title => $title,
+                record_data => {
+                    'e' => 1,
+                    's' => 1,
+                    't' => 2
+                },
+                record_keys => ['e', 's', 't']
+            },
+            templates => @templates
+        }
     ),
 
     'frequency of letters in test' => test_zci(
         'e:1/4 s:1/4 t:2/4',
-        structured_answer => @structured_answer
+        structured_answer => {
+            data => {
+                title => $title,
+                record_data => {
+                    'e' => 1,
+                    's' => 1,
+                    't' => 2
+                },
+                record_keys => ['e', 's', 't']
+            },
+            templates => @templates
+        }
     ),
 
     'frequency of all characters in test' => test_zci(
         'e:1/4 s:1/4 t:2/4',
-        structured_answer => @structured_answer
+        structured_answer => {
+            data => {
+                title => $title,
+                record_data => {
+                    'e' => 1,
+                    's' => 1,
+                    't' => 2
+                },
+                record_keys => ['e', 's', 't']
+            },
+            templates => @templates
+        }
     ),
 
     'frequency of all chars in test' => test_zci(
         'e:1/4 s:1/4 t:2/4',
-        structured_answer => @structured_answer
+        structured_answer => {
+            data => {
+                title => $title,
+                record_data => {
+                    'e' => 1,
+                    's' => 1,
+                    't' => 2
+                },
+                record_keys => ['e', 's', 't']
+            },
+            templates => @templates
+        }
     ),
 
     'frequency of all in testing 1234 ABC!' => test_zci(
         'a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10',
-        structured_answer => @structured_answer
-    ),
-
-    'frequency of all in Assassins!' => test_zci(
-        'a:2/9 i:1/9 n:1/9 s:5/9',
-        structured_answer => @structured_answer
+        structured_answer => {
+            data => {
+                title => $title,
+                record_data => {
+                    'a' => 1,
+                    'b' => 1,
+                    'c' => 1,
+                    'e' => 1,
+                    'g' => 1,
+                    'i' => 1,
+                    'n' => 1,
+                    's' => 1,
+                    't' => 2
+                },
+                record_keys => ['a', 'b', 'c', 'e', 'g', 'i', 'n', 's', 't']
+            },
+            templates => @templates
+        }
     ),
 
     'frequency of a in Atlantic Ocean' => test_zci(
-        'a:3/13'.
-        structured_answer => @structured_answer
+        'a:3/13',
+        structured_answer => {
+            data => {
+                title => $title,
+                record_data => {
+                    "a" => 3
+                },
+                record_keys => ["a"]
+            },
+            templates => @templates
+        }
     ),
 
     'freq of B in battle' => test_zci(
         'b:1/6',
-        structured_answer => @structured_answer
+        structured_answer => {
+            data => {
+                title => $title,
+                record_data => {
+                    'b' => 1
+                },
+                record_keys => ['b']
+            },
+            templates => @templates
+        }
     ),
 
     'freq of s in Spoons' => test_zci(
         's:2/6',
-        structured_answer => @structured_answer
+        structured_answer => {
+            data => {
+                title => $title,
+                record_data => {
+                    's' => 2
+                },
+                record_keys => ['s']
+            },
+            templates => @templates
+        }
     ),
 
-    'frequency of all characters in testing' => test_zci(
-        'e:1/7 g:1/7 i:1/7 n:1/7 s:1/7 t:2/7',
-        structured_answer => @structured_answer
-    ),
+    'frequency s in spoons' => undef,
+    'freq s in spoons' => undef,
+    'frequency s spoons' => undef,
+    'freq s spoons' => undef,
+    'frequency of s spoons' => undef,
+    'freq of s spoons' => undef
 
-    'frequency of B in battle' => test_zci(
-        'b:1/6',
-        structured_answer => @structured_answer
-    )
 );
 
 done_testing;

--- a/t/Frequency.t
+++ b/t/Frequency.t
@@ -9,6 +9,8 @@ use DDG::Test::Goodie;
 zci is_cached => 1;
 zci answer_type => 'frequency';
 
+my $general_title_prefix = "Frequency of each character in";
+
 sub build_structured_test {
     my ($plaintext, $title, $record_data, $record_keys) = @_;
 
@@ -37,37 +39,37 @@ ddg_goodie_test(
                 DDG::Goodie::Frequency
         )],
 
-    "frequency of all in test" => build_test('e:1/4 s:1/4 t:2/4', "Frequency of all in test", {
+    "frequency of all in test" => build_test('e:1/4 s:1/4 t:2/4', "$general_title_prefix test", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all letters in test' => build_test('e:1/4 s:1/4 t:2/4', "Frequency of all letters in test", {
+    'frequency of all letters in test' => build_test('e:1/4 s:1/4 t:2/4', "$general_title_prefix test", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of letters in test' => build_test('e:1/4 s:1/4 t:2/4', "Frequency of letters in test", {
+    'frequency of letters in test' => build_test('e:1/4 s:1/4 t:2/4', "$general_title_prefix test", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all characters in test' => build_test('e:1/4 s:1/4 t:2/4', "Frequency of all characters in test", {
+    'frequency of all characters in test' => build_test('e:1/4 s:1/4 t:2/4', "$general_title_prefix test", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all chars in test' => build_test('e:1/4 s:1/4 t:2/4', "Frequency of all chars in test", {
+    'frequency of all chars in test' => build_test('e:1/4 s:1/4 t:2/4', "$general_title_prefix test", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', "Frequency of all in testing 1234 ABC!", {
+    'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', "$general_title_prefix testing 1234 ABC!", {
         'a' => 1,
         'b' => 1,
         'c' => 1,

--- a/t/Frequency.t
+++ b/t/Frequency.t
@@ -64,6 +64,12 @@ ddg_goodie_test(
         't' => 2
     }, ['e', 's', 't']),
 
+    'frequency of all alphabets in test' => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
+        'e' => 1,
+        's' => 1,
+        't' => 2
+    }, ['e', 's', 't']),
+
     'frequency of all chars in test' => build_test('e:1/4 s:1/4 t:2/4', "test", "$all_chars_subtitle", {
         'e' => 1,
         's' => 1,

--- a/t/Frequency.t
+++ b/t/Frequency.t
@@ -10,12 +10,12 @@ zci is_cached => 1;
 zci answer_type => 'frequency';
 
 sub build_structured_test {
-    my ($plaintext, $record_data, $record_keys) = @_;
+    my ($plaintext, $title, $record_data, $record_keys) = @_;
 
     return $plaintext,
     structured_answer => {
         data => {
-        title => "Frequency",
+        title => $title,
         record_data => $record_data,
         record_keys => $record_keys
         },
@@ -37,37 +37,37 @@ ddg_goodie_test(
                 DDG::Goodie::Frequency
         )],
 
-    "frequency of all in test" => build_test('e:1/4 s:1/4 t:2/4', {
+    "frequency of all in test" => build_test('e:1/4 s:1/4 t:2/4', "Frequency of all in test", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all letters in test' => build_test('e:1/4 s:1/4 t:2/4', {
+    'frequency of all letters in test' => build_test('e:1/4 s:1/4 t:2/4', "Frequency of all letters in test", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of letters in test' => build_test('e:1/4 s:1/4 t:2/4', {
+    'frequency of letters in test' => build_test('e:1/4 s:1/4 t:2/4', "Frequency of letters in test", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all characters in test' => build_test('e:1/4 s:1/4 t:2/4', {
+    'frequency of all characters in test' => build_test('e:1/4 s:1/4 t:2/4', "Frequency of all characters in test", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all chars in test' => build_test('e:1/4 s:1/4 t:2/4', {
+    'frequency of all chars in test' => build_test('e:1/4 s:1/4 t:2/4', "Frequency of all chars in test", {
         'e' => 1,
         's' => 1,
         't' => 2
     }, ['e', 's', 't']),
 
-    'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', {
+    'frequency of all in testing 1234 ABC!' => build_test('a:1/10 b:1/10 c:1/10 e:1/10 g:1/10 i:1/10 n:1/10 s:1/10 t:2/10', "Frequency of all in testing 1234 ABC!", {
         'a' => 1,
         'b' => 1,
         'c' => 1,
@@ -79,15 +79,15 @@ ddg_goodie_test(
         't' => 2
     }, ['a', 'b', 'c', 'e', 'g', 'i', 'n', 's', 't']),
 
-    'frequency of a in Atlantic Ocean' => build_test('a:3/13', {
+    'frequency of a in Atlantic Ocean' => build_test('a:3/13', "Frequency of a in Atlantic Ocean", {
         "a" => 3
     }, ["a"]),
 
-    'freq of B in battle' => build_test('b:1/6', {
+    'freq of B in battle' => build_test('b:1/6', "Frequency of B in battle", {
         'b' => 1
     }, ['b']),
 
-    'freq of s in Spoons' => build_test('s:2/6', {
+    'freq of s in Spoons' => build_test('s:2/6', "Frequency of s in Spoons", {
         's' => 2
     }, ['s']),
 


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

- [x] Improvement
    - [x] Bug fix: **`Frequency: Fix #2715`**

###### Description of changes
This IA used to return a plain text response. Now that it's updated it returns a `structured_answer`. The `List` group with the record template works well here. Each letter and its frequency is a row in the table.

###### Which issues (if any) does this fix?
Fixes #2715 

###### People to notify (@mention interested parties)
@moollaza @tagawa 

---

Instant Answer Page: https://duck.co/ia/view/frequency

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @unlisted 