### PR TITLE
Elixir Cheat Sheet: Remove duplicate "String.reverse/1"

### DIFF
--- a/share/goodie/cheat_sheets/json/elixir.json
+++ b/share/goodie/cheat_sheets/json/elixir.json
@@ -115,7 +115,7 @@
         }, {
             "val": "Character List",
             "key": "'abc'"
-        },  {
+        }, {
             "val": "Keyword List",
             "key": "\\[a: :foo, b: :bar\\]"
         }, {
@@ -180,16 +180,16 @@
         }, {
             "val": "returns a random entry from a collection",
             "key": "Enum.random/1"
-        },{
+        }, {
             "val": "reverses a string",
             "key": "String.reverse/1"
-        },{
+        }, {
             "val": "returns date / time tuple",
             "key": ":erlang.localtime/0"
         }, {
             "val": "returns a list's last element",
             "key": "List.last/1"
-        },{
+        }, {
             "val": "calls the Erlang timer module (milliseconds)",
             "key": ":timer.sleep/1"
         }]

--- a/share/goodie/cheat_sheets/json/elixir.json
+++ b/share/goodie/cheat_sheets/json/elixir.json
@@ -187,9 +187,6 @@
             "val": "returns date / time tuple",
             "key": ":erlang.localtime/0"
         }, {
-            "val": "reverses a string",
-            "key": "String.reverse/1"
-        },{
             "val": "returns a list's last element",
             "key": "List.last/1"
         },{


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [x] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

Provide an overview of the changes this pull request introduces.
This PR remove the duplicate of `String.reverse/1` in the Elixir Cheat Sheet. Also I fixed some inconsistent usage of spaces.

---

Instant Answer Page: https://duck.co/ia/view/elixir_cheat_sheet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @pjhampton