### PR TITLE
CsharpCheatSheet: Removed trailing whitespaces

### DIFF
--- a/share/goodie/cheat_sheets/json/csharp.json
+++ b/share/goodie/cheat_sheets/json/csharp.json
@@ -28,7 +28,7 @@
          },
          {  
             "key":"as",
-            "val":" Use the as operator to perform certain type of conversions between compatible reference types or nullable types. "
+            "val":" Use the as operator to perform certain type of conversions between compatible reference types or nullable types."
          },
          {  
             "key":"base",
@@ -36,7 +36,7 @@
          },
          {  
             "key":"break",
-            "val":"The break statement terminates the closest enclosing loop or switch statement in which it appears. "
+            "val":"The break statement terminates the closest enclosing loop or switch statement in which it appears."
          },
          {  
             "key":"try-catch",
@@ -44,11 +44,11 @@
          },
          {  
             "key":"char",
-            "val":"The char keyword is used to represent a Unicode character"
+            "val":"The char keyword is used to represent a Unicode character."
          },
          {  
             "key":"const",
-            "val":"The const keyword to declare a constant field or a constant local. Constant fields and locals aren't variables and may not be modified. "
+            "val":"The const keyword to declare a constant field or a constant local. Constant fields and locals aren't variables and may not be modified."
          },
          {  
             "key":"delegate",
@@ -76,7 +76,7 @@
          },
          {  
             "key":"implicit",
-            "val":"The implicit keyword is used to declare an implicit user-defined type conversion operator. "
+            "val":"The implicit keyword is used to declare an implicit user-defined type conversion operator."
          },
          {  
             "key":"in",
@@ -96,7 +96,7 @@
          },
          {  
             "key":"new",
-            "val":"The new keyword can be used as an operator, a modifier, or a constraint"
+            "val":"The new keyword can be used as an operator, a modifier, or a constraint."
          },
          {  
             "key":"operator",
@@ -126,7 +126,7 @@
       "Primary Operators":[  
          {  
             "key":".",
-            "val":"member access."
+            "val":"member access"
          },
          {  
             "key":"?.",
@@ -134,63 +134,63 @@
          },
          {  
             "key":"f()",
-            "val":" function invocation."
+            "val":" function invocation"
          },
          {  
             "key":"?[]",
-            "val":"null conditional indexing.Returns null if the left hand operand is null."
+            "val":"null conditional indexing. Returns null if the left hand operand is null."
          },
          {  
             "key":"++",
-            "val":"increment operator."
+            "val":"increment operator"
          },
          {  
             "key":"--",
-            "val":"decrement operator."
+            "val":"decrement operator"
          },
          {  
             "key":"Sizeof",
-            "val":"returns the size in bytes of the type operand."
+            "val":"returns the size in bytes of the type operand"
          },
          {  
             "key":"->",
-            "val":"pointer dereferencing combined with member access."
+            "val":"pointer dereferencing combined with member access"
          }
       ],
       "Unary Operators":[  
          {  
             "key":"+x",
-            "val":"returns the value of x."
+            "val":"returns the value of x"
          },
          {  
             "key":"-",
-            "val":"numeric negation."
+            "val":"numeric negation"
          },
          {  
             "key":"!",
-            "val":"logical negation."
+            "val":"logical negation"
          },
          {  
             "key":"~",
-            "val":"bitwise complement."
+            "val":"bitwise complement"
          },
          {  
             "key":"&",
-            "val":"address of."
+            "val":"address of"
          }
       ],
       "Multiplicative Operators":[  
          {  
             "key":"*",
-            "val":" multiplication."
+            "val":" multiplication"
          },
          {  
             "key":"/",
-            "val":"division."
+            "val":"division"
          },
          {  
             "key":"%",
-            "val":"modulus."
+            "val":"modulus"
          }
       ],
       "Relational Operators":[  
@@ -204,17 +204,17 @@
          },
          {  
             "key":"<=",
-            "val":"less than or equal to."
+            "val":"less than or equal to"
          },
          {  
             "key":">=",
-            "val":"greater than or equal to."
+            "val":"greater than or equal to"
          }
       ],
       "Assignment and Lambda Operators":[  
          {  
             "key":"=",
-            "val":"assignment."
+            "val":"assignment"
          },
          {  
             "key":"+=",
@@ -234,7 +234,7 @@
          },
          {  
             "key":"=>",
-            "val":"lambda declaration."
+            "val":"lambda declaration"
          }
       ],
       "Preprocessor Directives":[  
@@ -256,7 +256,7 @@
          },
          {  
             "key":"#undef",
-            "val":"#undef is used to undefine a symbol"
+            "val":"#undef is used to undefine a symbol."
          },
          {  
             "key":"#warning",
@@ -272,29 +272,29 @@
          },
          {  
             "key":"#pragma",
-            "val":"#pragma gives the compiler special instructions for the compilation of the file in which it appears. "
+            "val":"#pragma gives the compiler special instructions for the compilation of the file in which it appears."
          }
       ],
       "Compiler Options":[  
          {  
             "key":"@",
-            "val":"Reads a response file for more options."
+            "val":"Reads a response file for more options"
          },
          {  
             "key":"/?",
-            "val":"Displays a usage message to stdout."
+            "val":"Displays a usage message to stdout"
          },
          {  
             "key":"/addmodule",
-            "val":"Links the specified modules into this assembly."
+            "val":"Links the specified modules into this assembly"
          },
          {  
             "key":"/appconfig",
-            "val":"Specifies the location of app.config at assembly binding time."
+            "val":"Specifies the location of app.config at assembly binding time"
          },
          {  
             "key":"/checked",
-            "val":"Causes the compiler to generate overflow checks."
+            "val":"Causes the compiler to generate overflow checks"
          },
          {  
             "key":"/codepage",
@@ -302,11 +302,11 @@
          },
          {  
             "key":"/debug",
-            "val":"Emits debugging information."
+            "val":"Emits debugging information"
          },
          {  
             "key":"/define",
-            "val":"returns the value of x."
+            "val":"returns the value of x"
          },
          {  
             "key":"/errorreport",
@@ -314,23 +314,23 @@
          },
          {  
             "key":"/keycontainer",
-            "val":"Specifies a strong name key container."
+            "val":"Specifies a strong name key container"
          },
          {  
             "key":"/lib",
-            "val":"Specifies additional directories in which to search for references."
+            "val":"Specifies additional directories in which to search for references"
          },
          {  
             "key":"/link",
-            "val":"Makes COM type information in specified assemblies available to the project."
+            "val":"Makes COM type information in specified assemblies available to the project"
          },
          {  
             "key":"/main",
-            "val":"Specifies the type that contains the entry point."
+            "val":"Specifies the type that contains the entry point"
          },
          {  
             "key":"/win32res",
-            "val":"Specifies the win32 resource file (.res)."
+            "val":"Specifies the win32 resource file (.res)"
          }
       ]
    }


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [x] Enhancement: **`CsharpCheatSheet: Removed trailing whitespaces`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes
I noticed that having whitespaces at the end of `val` in a cheat sheet generates warnings. So, removed whitespaces from this new cheat sheet.

---

Instant Answer Page: https://duck.co/ia/view/csharp_cheat_sheet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @gitcodes 

