### PR TITLE
Timezone Converter IA: Templates type should be group

### DIFF
--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -178,7 +178,7 @@ handle query => sub {
             subtitle => "Convert Timezone: ".html_enc($input_string)
         },
         templates => {
-            type => 'text'
+            group => 'text'
         }
     };
 };

--- a/t/TimezoneConverter.t
+++ b/t/TimezoneConverter.t
@@ -18,7 +18,7 @@ sub build_test {
            subtitle => "Convert Timezone: $input"
        },
        templates => {
-           type => 'text'
+           group => 'text'
        }
     });
 }


### PR DESCRIPTION
###### Description of changes

The Timezone Converter IA is not showing up on PROD. Had to change `text` to `group` in order for the `templates` block to be valid.

###### People to notify (@mention interested parties)

@GlitchMr @moollaza 
---

Instant Answer Page: https://duck.co/ia/view/timezone_converter

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @GlitchMr

