### PR TITLE
Constants: Fix issue #3142

### DIFF
--- a/share/goodie/constants/constants.yml
+++ b/share/goodie/constants/constants.yml
@@ -131,8 +131,8 @@ charge of electron:
     symbol:
     wiki:
     value:
-        plain: '-1.60217646 × 10^-19 coulombs'
-        html: '-1.60217646 × 10<sup>-19</sup> coulombs'
+        plain: '-1.60217646 × 10^-19 coulombs. The magnitude of the charge of electron is 1.60217646 × 10^-19 coulombs'
+        html: '-1.60217646 × 10<sup>-19</sup> coulombs<br>The magnitude of the charge of electron is 1.60217646 × 10^-19 coulombs'
 
 electron mass:
     name: Electron Mass

--- a/share/goodie/constants/constants.yml
+++ b/share/goodie/constants/constants.yml
@@ -116,6 +116,7 @@ charge of proton:
         - charge of a proton
         - charge proton
         - proton charge
+        - magnitude of charge of electron
     symbol:
     wiki:
     value:

--- a/share/goodie/constants/constants.yml
+++ b/share/goodie/constants/constants.yml
@@ -131,8 +131,8 @@ charge of electron:
     symbol:
     wiki:
     value:
-        plain: '1.60217646 × 10^-19 coulombs'
-        html: '1.60217646 × 10<sup>-19</sup> coulomb'
+        plain: '-1.60217646 × 10^-19 coulombs'
+        html: '-1.60217646 × 10<sup>-19</sup> coulombs'
 
 electron mass:
     name: Electron Mass
@@ -149,8 +149,8 @@ electron volt:
     symbol:
     wiki:
     value:
-        plain: '1.60217646 × 10^-19 joules'
-        html: '1.60217646 × 10<sup>-19</sup> joules'
+        plain: '-1.60217646 × 10^-19 joules'
+        html: '-1.60217646 × 10<sup>-19</sup> joules'
 
 epsilon 0:
     name: Electric Constant

--- a/share/goodie/constants/constants.yml
+++ b/share/goodie/constants/constants.yml
@@ -133,7 +133,7 @@ charge of electron:
     wiki:
     value:
         plain: '-1.60217646 × 10^-19 coulombs. The magnitude of the charge of electron is 1.60217646 × 10^-19 coulombs'
-        html: '-1.60217646 × 10<sup>-19</sup> coulombs<br>The magnitude of the charge of electron is 1.60217646 × 10^-19 coulombs'
+        html: '-1.60217646 × 10<sup>-19</sup> coulombs<br><sub>The magnitude of the charge of electron is 1.60217646 × 10^-19 coulombs</sub>'
 
 electron mass:
     name: Electron Mass

--- a/share/goodie/constants/constants.yml
+++ b/share/goodie/constants/constants.yml
@@ -149,8 +149,8 @@ electron volt:
     symbol:
     wiki:
     value:
-        plain: '-1.60217646 × 10^-19 joules'
-        html: '-1.60217646 × 10<sup>-19</sup> joules'
+        plain: '1.60217646 × 10^-19 joules'
+        html: '1.60217646 × 10<sup>-19</sup> joules'
 
 epsilon 0:
     name: Electric Constant


### PR DESCRIPTION
###### Description of changes

Fixed the issue regarding positive value of electron charge using the suggestions mentioned in the thread of Issue #3142 .
When someone searches for **magnitude** of charge of electron, displays positive value, otherwise displays negative value with a small note mentioning that the magnitude is positive.

###### Which issues (if any) does this fix?

Fixes #3142 - Electron charge is now -1.6E-19C, which is technically correct along with a note about it's magnitude. Searching for **magnitude** in specific now displays the positive value.

###### People to notify (@mention interested parties)
@edgesince84 , @mintsoft , @GuiltyDolphin may note the changes.

---

Instant Answer Page: http://duck.co/ia/view/constants

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @hemanth 