### PR TITLE
vim_cheatsheet: Add `folding commands` section

### DIFF
--- a/share/goodie/cheat_sheets/json/vim.json
+++ b/share/goodie/cheat_sheets/json/vim.json
@@ -29,7 +29,8 @@
         "Tabs",
         "Registers",
         "Additional Ex Commands",
-        "Basic Configuration"
+        "Basic Configuration",
+        "Folding Commands"
     ],
     "sections": {
         "Tabs": [{
@@ -513,6 +514,55 @@
         }, {
             "val": "show line and column number of the cursor",
             "key": ":set ru"
-        }]
+        }],
+        "Folding Commands": [{
+	    "val": "creates a fold from the cursor down # lines",
+	    "key": "zf#j"
+	}, {
+	    "val": "string creates a fold from the cursor to string",
+	    "key": "zf/"
+	}, {
+	    "val": "moves the cursor to the next fold",
+	    "key": "zj"
+	}, {
+	    "val": "moves the cursor to the previous fold",
+	    "key": "zk"
+	}, {
+	    "val": "toggle a fold under cursor",
+	    "key": "za"
+	}, {
+	    "val": "opens a fold at the cursor",
+	    "key": "zo"
+	}, {
+	    "val": "opens all folds at the cursor",
+	    "key": "zO"
+	}, {
+	    "val": "closes a fold under cursor",
+	    "key": "zc"
+	}, {
+	    "val": "increases the foldlevel by one",
+	    "key": "zm"
+	}, {
+	    "val": "closes all open folds",
+	    "key": "zM"
+	}, {
+	    "val": "decreases the foldlevel by one",
+	    "key": "zr"
+	}, {
+	    "val": "decreases the foldlevel to zero -- all folds will be open",
+	    "key": "zR"
+	}, {
+	    "val": "deletes the fold at the cursor",
+	    "key": "zd"
+	}, {
+	    "val": "deletes all folds",
+	    "key": "zE"
+	}, {
+	    "val": "move to start of open fold",
+	    "key": "[z"
+	}, {
+	    "val": "move to end of open fold",
+	    "key": "]z"
+	}]
     }
 }


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [x] Enhancement: **`vim_cheatsheet: Add "folding commands" section`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

To improve debugging, we should be able to see across forest and
not just across trees. The folding of functions would help to achieve
the desired behaviour. The vim_cheatsheet should add a section of commands
associated with folding on vim.

Provide an overview of the changes this pull request introduces.

* added section for folding commands

###### Which issues (if any) does this fix?

Fixes #NNNN - how specifically does it fix the issue?

###### People to notify (@GuiltyDolphin , @zekiel , @moollaza )


---

Instant Answer Page: https://duck.co/ia/view/vim_cheat_sheet




