### PR TITLE
Refer MAC address and Generate MAC to each other

### DIFF
--- a/lib/DDG/Goodie/GenerateMAC.pm
+++ b/lib/DDG/Goodie/GenerateMAC.pm
@@ -41,7 +41,7 @@ handle remainder => sub {
             infoboxData => $infobox
         },
         templates => {
-            group => 'info'
+            group => 'text'
         }    
     };
 };

--- a/lib/DDG/Goodie/GenerateMAC.pm
+++ b/lib/DDG/Goodie/GenerateMAC.pm
@@ -14,6 +14,20 @@ triggers startend => "generate mac addr",
 zci answer_type => "MAC Address";
 zci is_cached => 0;
 
+sub build_infobox_element {
+    my $query = shift;
+    my @split = split ' ', $query;
+    return {
+        label => $query,
+        url   => 'https://duckduckgo.com/?q=' . (join '+', @split) . '&ia=answer',
+    };
+}
+
+my $infobox = [ { heading => "Related Queries", },
+                build_infobox_element('mac address 14:D6:4D:DA:79:6A'),
+                build_infobox_element('ethernet address 00/00-03.ff:ff:FF'),
+              ];
+
 handle remainder => sub {
     # Ensure rand is seeded for each process
     srand();
@@ -23,10 +37,11 @@ handle remainder => sub {
     return "Here's a random MAC address: $address", structured_answer => {
         data => {
             title => $address,
-            subtitle => 'Random MAC Address'
+            description => 'Random MAC Address',
+            infoboxData => $infobox
         },
         templates => {
-            group => 'text'
+            group => 'info'
         }    
     };
 };

--- a/lib/DDG/Goodie/MacAddress.pm
+++ b/lib/DDG/Goodie/MacAddress.pm
@@ -18,6 +18,20 @@ sub fmt_mac {
     $mac;
 }
 
+sub build_infobox_element {
+    my $query = shift;
+    my @split = split ' ', $query;
+    return {
+        label => $query,
+        url   => 'https://duckduckgo.com/?q=' . (join '+', @split) . '&ia=answer',
+    };
+}
+
+my $infobox = [ { heading => "Related Queries", },
+                build_infobox_element('generate mac address'),
+                build_infobox_element('random mac address'),
+              ];
+
 handle remainder => sub {
     return unless $_;
     return unless $_ =~ m|^[-.:/ 0-9a-f]+$|i;
@@ -48,15 +62,16 @@ handle remainder => sub {
     my $text_answer = "The OUI, ".fmt_mac($oui).", for this NIC is assigned to $name";
     return $text_answer, structured_answer => {
         data => {
-            name   => $owner,
+            title   => $owner,
             result => \@lines,
-            input  => fmt_mac($_)
+            input  => fmt_mac($_),
+            infoboxData => $infobox
         },
         templates => {
             options => {
                 content => 'DDH.mac_address.content',
             },
-            group => 'text'
+            group => 'info'
         }
     };
 };

--- a/lib/DDG/Goodie/MacAddress.pm
+++ b/lib/DDG/Goodie/MacAddress.pm
@@ -71,7 +71,7 @@ handle remainder => sub {
             options => {
                 content => 'DDH.mac_address.content',
             },
-            group => 'info'
+            group => 'text'
         }
     };
 };

--- a/t/GenerateMAC.t
+++ b/t/GenerateMAC.t
@@ -17,10 +17,20 @@ sub build_test
     return test_zci(re(qr/^$text_start$mac_regxp$/), structured_answer => {
         data => {
             title => re($mac_regxp),
-            subtitle => "Random MAC Address"
+            description => "Random MAC Address",
+            infoboxData => [
+                {heading => "Related Queries",},
+                {
+                    label => 'mac address 14:D6:4D:DA:79:6A',
+                    url => 'https://duckduckgo.com/?q=mac+address+14:D6:4D:DA:79:6A&ia=answer'
+                }, {
+                    label => 'ethernet address 00/00-03.ff:ff:FF',
+                    url => 'https://duckduckgo.com/?q=ethernet+address+00/00-03.ff:ff:FF&ia=answer'
+                },
+            ]
         },
         templates => {
-            group => 'text'
+            group => 'info'
         }
     });
 }

--- a/t/GenerateMAC.t
+++ b/t/GenerateMAC.t
@@ -30,7 +30,7 @@ sub build_test
             ]
         },
         templates => {
-            group => 'info'
+            group => 'text'
         }
     });
 }

--- a/t/MacAddress.t
+++ b/t/MacAddress.t
@@ -14,12 +14,22 @@ sub build_test
     my($text, $name, $lines, $input) = @_;
     return test_zci($text, structured_answer => {
         data => {
-            name   => $name,
+            title   => $name,
             result => $lines,
-            input  => $input
+            input  => $input,
+            infoboxData => [
+                {heading => "Related Queries",},
+                {
+                    label => 'generate mac address',
+                    url => 'https://duckduckgo.com/?q=generate+mac+address&ia=answer'
+                }, {
+                    label => 'random mac address',
+                    url => 'https://duckduckgo.com/?q=random+mac+address&ia=answer'
+                },
+            ]
         },
         templates => {
-            group => 'text',
+            group => 'info',
             options => {
                 content => 'DDH.mac_address.content'
             }

--- a/t/MacAddress.t
+++ b/t/MacAddress.t
@@ -29,7 +29,7 @@ sub build_test
             ]
         },
         templates => {
-            group => 'info',
+            group => 'text',
             options => {
                 content => 'DDH.mac_address.content'
             }


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [X] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [X] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

After a discussion with @GuiltyDolphin and @edgesince84, this is a suggested change to highlight similar Instant Answers the user might be interested in. Both IAs currently use the text template meaning space is available for an infobox for this purpose, similar to the [Caesar cipher IA](https://duckduckgo.com/?q=how+to+use+a+caesar+cipher&ia=answer).

###### People to notify (@mention interested parties)
@GuiltyDolphin @moollaza 

---

https://duck.co/ia/view/generate_mac
https://duck.co/ia/view/mac_address