### PR TITLE
FlipText: Force start trigger to improve relevancy

### DIFF
--- a/lib/DDG/Goodie/FlipText.pm
+++ b/lib/DDG/Goodie/FlipText.pm
@@ -6,7 +6,7 @@ use DDG::Goodie;
 
 use Text::UpsideDown;
 
-triggers startend => "flip text", "mirror text", "spin text", "rotate text";
+triggers start => "flip text", "mirror text", "spin text", "rotate text";
 
 zci answer_type => "flip_text";
 zci is_cached   => 1;

--- a/t/FlipText.t
+++ b/t/FlipText.t
@@ -37,6 +37,8 @@ ddg_goodie_test(
     'spin text ;hello world;'   => build_test(';hello world;','؛pʃɹoʍ oʃʃǝɥ؛'),
     'spin text [\'hello\']'     => build_test('[\'hello\']','[,oʃʃǝɥ,]'),
     'spin text <<"hello\' % & * () = + . #@!^(/world">>' => build_test('<<"hello\' % & * () = + . #@!^(/world">>','<<„pʃɹoʍ/)∨¡@# ˙ + = () ⁎ ⅋ % ,oʃʃǝɥ„>>'),
+    
+    'photoshop flip text' => undef
 );
 
 done_testing;


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

Switch to `start` trigger to prevent showing on irrelevant queries.

e.g. "photoshop rotate text"

---

Instant Answer Page: https://duck.co/ia/view/flip_text

