### PR TITLE
CheatSheets: Support column specification

### DIFF
--- a/share/goodie/cheat_sheets/cheat_sheets.js
+++ b/share/goodie/cheat_sheets/cheat_sheets.js
@@ -13,7 +13,7 @@ DDH.cheat_sheets.build = function(ops) {
         };
 
         // Change number of columns to show, if mentioned in the cheat sheet
-        if (columns)
+        if (columns && columns >= 0 && columns <= 4)
             showColumns = columns;
 
         $.each(section_order, function(i, section) {
@@ -157,10 +157,12 @@ DDH.cheat_sheets.build = function(ops) {
                     }
                 };
 
-            // Update CSS for 2 columns layout
-            if (showColumns == 2) {
-                masonryOps.columnWidth = 450;
-                $section.css('width', '450px');
+            // Update CSS for the specified columns layout
+            // only if number of columns is different from 3 (default)
+            if (showColumns != 3) {
+                var new_width = 885 / showColumns;
+                masonryOps.columnWidth = new_width;
+                $section.css('width', new_width);
             }
 
             // Removes all tr's after the 3rd before masonry fires

--- a/share/goodie/cheat_sheets/cheat_sheets.js
+++ b/share/goodie/cheat_sheets/cheat_sheets.js
@@ -2,12 +2,19 @@ DDH.cheat_sheets = DDH.cheat_sheets || {};
 
 DDH.cheat_sheets.build = function(ops) {
 
-    Spice.registerHelper('cheatsheets_ordered', function(sections, section_order, template_type, options) {
+    // Set number of columns to 3, by default
+    var showColumns = 3;
+
+    Spice.registerHelper('cheatsheets_ordered', function(sections, section_order, columns, template_type, options) {
         var result = "";
         var template = {
           type: template_type,
           path: template_type ? 'DDH.cheat_sheets.' + template_type : 'DDH.cheat_sheets.keyboard'
         };
+
+        // Change number of columns to show, if mentioned in the cheat sheet
+        if (columns)
+            showColumns = columns;
 
         $.each(section_order, function(i, section) {
            if (sections[section]){
@@ -149,6 +156,12 @@ DDH.cheat_sheets.build = function(ops) {
                         $container.masonry(masonryOps);
                     }
                 };
+
+            // Update CSS for 2 columns layout
+            if (showColumns == 2) {
+                masonryOps.columnWidth = 450;
+                $section.css('width', '450px');
+            }
 
             // Removes all tr's after the 3rd before masonry fires
             if ($container.hasClass("compressed")) {

--- a/share/goodie/cheat_sheets/cheat_sheets.js
+++ b/share/goodie/cheat_sheets/cheat_sheets.js
@@ -13,7 +13,7 @@ DDH.cheat_sheets.build = function(ops) {
         };
 
         // Change number of columns to show, if mentioned in the cheat sheet
-        if (columns && columns >= 0 && columns <= 4)
+        if (columns && columns >= 1 && columns <= 4)
             showColumns = columns;
 
         $.each(section_order, function(i, section) {

--- a/share/goodie/cheat_sheets/detail.handlebars
+++ b/share/goodie/cheat_sheets/detail.handlebars
@@ -2,7 +2,7 @@
 <h4 class="c-base__sub">{{description}}</h4>
 
 <div class="cheatsheet__container compressed" >
-    {{#cheatsheets_ordered sections section_order template_type}}
+    {{#cheatsheets_ordered sections section_order columns template_type}}
       <div class="cheatsheet__section {{template.type}}{{#if showhide}} showhide is-hidden {{/if}}">
       <h6 class="cheatsheet__title tx-clr--slate">{{name}}</h6>
         {{{include template.path}}}


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [ ] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [ ] Enhancement: **``**
- [x] Non–Instant Answer
    - [x] Other (Role, Template, Test, Documentation, etc.): **`Make cheat sheets great (flexible) again`**

###### Description of changes
@moollaza as we discussed a week ago, I finally found time to hustle with this and found one of the many possible ways to make cheat sheets more flexible regarding number of columns (which is currently fixed at 3). Let's discuss this further to see if there's a better way to make this happen.

As of now, the cheat sheet can now contain this new property to change the number of columns in the cheat sheet.
```javascript
{
...


"columns": 2,


...
}
```

The logic for now, works for 2 columns (can be very easily extended for 1 column as well).

###### People to notify (@mention interested parties)
@moollaza 

----

https://duck.co/ia/view/cheat_sheets