### PR TITLE
CheatSheets: Use metadata to replace some fields.

### DIFF
--- a/lib/DDG/Goodie/CheatSheets.pm
+++ b/lib/DDG/Goodie/CheatSheets.pm
@@ -6,6 +6,7 @@ use DDG::Goodie;
 use DDP;
 use File::Find::Rule;
 use YAML::XS qw(LoadFile);
+use DDG::Meta::Data;
 
 no warnings 'uninitialized';
 
@@ -140,10 +141,15 @@ handle remainder_lc => sub {
     # the current id.
     return unless $lookup->{$data->{template_type}} || $lookup->{$data->{id}};
 
+    my $meta = DDG::Meta::Data->get_ia(id => $data->{id});
+
     return 'Cheat Sheet', structured_answer => {
         id         => 'cheat_sheets',
         dynamic_id => $data->{id},
-        data       => $data,
+        data       => {
+            %$data,
+            meta => $meta,
+        },
         templates  => {
             group   => 'base',
             item    => 0,

--- a/lib/DDG/Goodie/CheatSheets.pm
+++ b/lib/DDG/Goodie/CheatSheets.pm
@@ -141,7 +141,7 @@ handle remainder_lc => sub {
     # the current id.
     return unless $lookup->{$data->{template_type}} || $lookup->{$data->{id}};
 
-    my $meta = DDG::Meta::Data->get_ia(id => $data->{id});
+    my $meta = DDG::Meta::Data->get_ia(id => $data->{id}) or return;
 
     return 'Cheat Sheet', structured_answer => {
         id         => 'cheat_sheets',

--- a/lib/DDG/Goodie/CheatSheets.pm
+++ b/lib/DDG/Goodie/CheatSheets.pm
@@ -6,7 +6,6 @@ use DDG::Goodie;
 use DDP;
 use File::Find::Rule;
 use YAML::XS qw(LoadFile);
-use DDG::Meta::Data;
 
 no warnings 'uninitialized';
 
@@ -141,16 +140,10 @@ handle remainder_lc => sub {
     # the current id.
     return unless $lookup->{$data->{template_type}} || $lookup->{$data->{id}};
 
-    my $meta = DDG::Meta::Data->get_ia(id => $data->{id}) or return;
-    $meta->{name} =~ s/\s*cheat sheet\s*//i;
-
     return 'Cheat Sheet', structured_answer => {
         id         => 'cheat_sheets',
         dynamic_id => $data->{id},
-        data       => {
-            %$data,
-            meta => $meta,
-        },
+        data       => $data,
         templates  => {
             group   => 'base',
             item    => 0,

--- a/lib/DDG/Goodie/CheatSheets.pm
+++ b/lib/DDG/Goodie/CheatSheets.pm
@@ -142,6 +142,7 @@ handle remainder_lc => sub {
     return unless $lookup->{$data->{template_type}} || $lookup->{$data->{id}};
 
     my $meta = DDG::Meta::Data->get_ia(id => $data->{id}) or return;
+    $meta->{name} =~ s/\s*cheat sheet\s*//i;
 
     return 'Cheat Sheet', structured_answer => {
         id         => 'cheat_sheets',

--- a/share/goodie/cheat_sheets/cheat_sheets.js
+++ b/share/goodie/cheat_sheets/cheat_sheets.js
@@ -101,7 +101,13 @@ DDH.cheat_sheets.build = function(ops) {
 
     var wasShown = false; // keep track whether onShow was run yet
 
+    // Use metadata from DDH.cheat_sheet_id
+    var data = ops.data;
+    data.meta = DDH[ops.dynamic_id].meta;
+    data.meta.name = data.meta.name.replace(/\s*cheat sheet\s*/i, '');
+
     return {
+        data: data,
         onShow: function() {
             // make sure this function is only run once, the first time
             // the IA is shown otherwise things will get initialized more than once

--- a/share/goodie/cheat_sheets/detail.handlebars
+++ b/share/goodie/cheat_sheets/detail.handlebars
@@ -1,20 +1,20 @@
-<h3 class="c-base__title">{{name}}</h3>
-<h4 class="c-base__sub">{{description}}</h4>
+<h3 class="c-base__title">{{meta.name}}</h3>
+<h4 class="c-base__sub">{{meta.description}}</h4>
 
 <div class="cheatsheet__container compressed" >
     {{#cheatsheets_ordered sections section_order template_type}}
       <div class="cheatsheet__section {{template.type}}{{#if showhide}} showhide is-hidden {{/if}}">
-      <h6 class="cheatsheet__title tx-clr--slate">{{name}}</h6>
+      <h6 class="cheatsheet__title tx-clr--slate">{{meta.name}}</h6>
         {{{include template.path}}}
       </div>
     {{/cheatsheets_ordered}}
 </div>
 
 <div class="cheatsheet__footer c-list__links">
-    <a class="c-list__link  chomp--link  {{#if metadata.sourceUrl}}sep--after{{/if}} can-expand">
+    <a class="c-list__link  chomp--link  {{#if meta.src_url}}sep--after{{/if}} can-expand">
         <i class="chomp--link__icn"></i>
         <span class="chomp--link__mr">Show More</span>
         <span class="chomp--link__ls">Show Less</span>
     </a>
-    <span>{{{moreAt metadata 'none' className="c-list__link"}}}</span>
+    <span>{{{moreAt meta.src_url meta.src_name className="c-list__link"}}}</span>
 </div>


### PR DESCRIPTION
###### Description of changes

See #3023 for more information.

In short: Replace fields like `Description` and `Name` with fields generated from the metadata.
###### Which issues (if any) does this fix?

Resolves #3023.
###### People to notify (@mention interested parties)

@moollaza @zachthompson @duckduckgo/community-leaders 

---

Instant Answer Page: https://duck.co/ia/view/cheat_sheets

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @zachthompson 
