### PR TITLE
Remove use of several vars on global scope

### DIFF
--- a/share/goodie/cheat_sheets/cheat_sheets.js
+++ b/share/goodie/cheat_sheets/cheat_sheets.js
@@ -16,7 +16,7 @@ DDH.cheat_sheets.build = function(ops) {
 
                if (i === 0 ){
                    showhide = false;
-               } else if ( i === 1 && !is_mobile ){
+               } else if ( i === 1 && !DDG.device.isMobile ){
                    showhide = false;
                }
 

--- a/share/goodie/frequency_spectrum/frequency_spectrum.js
+++ b/share/goodie/frequency_spectrum/frequency_spectrum.js
@@ -3,7 +3,7 @@ DDH.frequency_spectrum = DDH.frequency_spectrum || {};
 (function(DDH) {
     "use strict";
     // Get the marker label and tag
-    var markerlabel, markertag, started;
+    var markerlabel, markertag, started, bbox;
     
     function start() {
         markerlabel = document.getElementById("marker_label");

--- a/share/goodie/game2048/game2048.js
+++ b/share/goodie/game2048/game2048.js
@@ -317,7 +317,7 @@ DDH.game2048.build = function(ops) {
     return {
         onShow: function() {
             //Hide this goodie on mobile devices for now
-            if(is_mobile || is_mobile_device) {
+            if(DDG.device.isMobile || DDG.device.isMobileDevice) {
                 DDH.spice_tabs.game2048.hideLink();
                 DDH.spice_tabs.game2048.hide();
                 return;


### PR DESCRIPTION
Unlike https://github.com/duckduckgo/zeroclickinfo-spice/pull/2885 this can be merged pretty much immediately.

I also fixed an undeclared `bbox` variable in the Frequency Spectrum IA. There's another error with an undeclared variable there, but I don't know enough about what it's meant to do to easily fix it. I'm gonna create an issue for the maintainer.

cc @bsstoner @bbraithwaite 
