### PR TITLE
Parcelforce: Triggering on luhn!

### DIFF
--- a/lib/DDG/Goodie/Parcelforce.pm
+++ b/lib/DDG/Goodie/Parcelforce.pm
@@ -24,7 +24,7 @@ triggers query_nowhitespace_nodash => qr/
 handle query_nowhitespace_nodash => sub {
     my $parcel_number = $+{parcel_number};
 
-    if ($parcel_number && $parcel_number !~ /^isbn/i) {
+    if ($parcel_number && $parcel_number !~ /^(isbn|luhn)/i) {
 
         return $parcel_number,
             heading => 'Parcelforce Tracking',

--- a/t/Parcelforce.t
+++ b/t/Parcelforce.t
@@ -28,7 +28,8 @@ ddg_goodie_test(
         heading => 'Parcelforce Tracking',
         html =>
             qq(Track this parcel at <a href="http://www.parcelforce.com/track-trace?trackNumber=PBTM8237263001">Parcelforce</a>.)
-    )
+    ),
+    'luhn 1234554651' => undef
 );
 
 done_testing;


### PR DESCRIPTION
###### Which issues (if any) does this fix?

Fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3391 - this is the same problem as the isbn IA has here; a 4 character a-z followed by a number is valid parcelforce tracking number. 

###### People to notify (@mention interested parties)
@tagawa 

---

Instant Answer Page: http://duck.co/ia/view/parcelforce

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @mintsoft
