### PR TITLE
CheatSheets: make no metadata a warning

### DIFF
--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -76,7 +76,21 @@ sub verify_meta {
     my @tests;
     my $id = $json->{id};
     my $meta = DDG::Meta::Data->get_ia(id => $id);
-    push(@tests, {msg => "No Instant Answer page found with ID '$id'", critical => 1, pass => defined $meta});
+    my $msg = <<EOM;
+
+Cheat sheet with ID "$id" not found in metadata.  To be included, you'll need to:
+
+    1. Create an instant answer page (https://duck.co/ia)
+    2. Open a pull request on GitHub (https://github.com/duckduckgo/zeroclickinfo-goodies/pulls)
+
+#2 is necessary to have the dev_milestone updated from "planning" to "development" automatically.
+
+EOM
+    push(@tests, {
+        msg => $msg,
+        critical => 0,
+        pass => defined $meta
+    });
     return @tests;
 }
 

--- a/t/CheatSheets/CheatSheetsJSON.t
+++ b/t/CheatSheets/CheatSheetsJSON.t
@@ -80,10 +80,10 @@ sub verify_meta {
 
 Cheat sheet with ID "$id" not found in metadata.  To be included, you'll need to:
 
-    1. Create an instant answer page (https://duck.co/ia)
-    2. Open a pull request on GitHub (https://github.com/duckduckgo/zeroclickinfo-goodies/pulls)
+    1. Create an instant answer page (https://duck.co/ia/new_ia)
+    2. Open a pull request on GitHub (http://docs.duckduckhack.com/submitting/pull-request.html)
 
-#2 is necessary to have the dev_milestone updated from "planning" to "development" automatically.
+#2 is necessary to have the IA Page move from the "planning" stage to "development" automatically.
 
 EOM
     push(@tests, {


### PR DESCRIPTION
1. The metadata check doesn't need to be `critical`.
2. More information on how to get a cheat sheet in the metadata feed.

IA page: https://duck.co/ia/view/cheat_sheets