### PR TITLE
js_minify: remove the dotted outline border from the button when it pressed in firefox

### DIFF
--- a/share/goodie/js_minify/js_minify.css
+++ b/share/goodie/js_minify/js_minify.css
@@ -17,6 +17,7 @@
     cursor: default;
 }
 
+<<<<<<< b7a73754210185594d945716aedde5cc8486fcba
 
 /* Mobile */
 .is-mobile .zci--js_minify .js_minify--action_box {
@@ -27,6 +28,16 @@
     padding-left: 0;
     padding-right: 0;
     width: 100%;
+=======
+.js_minify__action::-moz-focus-inner {
+    border: none;
+}
+
+.zci--js_minify #js_minify__input,
+.zci--js_minify #js_minify__output {
+    width: 45%;
+    font-family: 'monospace';
+>>>>>>> remove the dotted outline border from the button in firefox
 }
 
 .is-mobile .zci--js_minify .btn {


### PR DESCRIPTION
- [x] Improvement
  - [x] Enhancement: **`JsMinify: added a new css style rule to remove the dotted border when you click on the button in firefox (really small change)`**
###### Description of changes

added a new css style rule to remove the dotted border when you click on the button in firefox (really small change)
###### People to notify

@sahildua2305

---

Instant Answer Page: https://duck.co/ia/view/js_minify
