### PR TITLE
Add Hangeul Cheat Sheet

### DIFF
--- a/share/goodie/cheat_sheets/json/hangeul.json
+++ b/share/goodie/cheat_sheets/json/hangeul.json
@@ -4,7 +4,7 @@
     "description": "Letters of the Korean Alphabet",
 
     "metadata": {
-        "sourceUrl" : "http://www.omniglot.com/charts/print/hangeul.pdf"
+        "sourceUrl" : "https://en.wikipedia.org/wiki/Hangul"
     },
 
     "aliases": [

--- a/share/goodie/cheat_sheets/json/hangeul.json
+++ b/share/goodie/cheat_sheets/json/hangeul.json
@@ -8,7 +8,7 @@
     },
 
     "aliases": [
-        "hangeul", "hangul", "korean alphabet", "korean language", "choson gul", "choson'gul", "choson muntcha", "choson muncha"
+        "hangul", "korean alphabet", "korean language", "choson gul", "choson'gul", "choson muntcha", "choson muncha"
     ],
 
     "template_type": "code",

--- a/share/goodie/cheat_sheets/json/hangeul.json
+++ b/share/goodie/cheat_sheets/json/hangeul.json
@@ -15,12 +15,12 @@
     "template_type": "code",
 
     "section_order": [
-        "Consonanants (자음/子音)",
+        "Consonants (자음/子音)",
         "Vowels (모음/母音)"
     ],
 
     "sections": {
-        "Consonanants (자음/子音)": [
+        "Consonants (자음/子音)": [
             {
                 "key": "ㄱ",
                 "val": "Giyeok (기역): g [k]"

--- a/share/goodie/cheat_sheets/json/hangeul.json
+++ b/share/goodie/cheat_sheets/json/hangeul.json
@@ -4,11 +4,12 @@
     "description": "Letters of the Korean Alphabet",
 
     "metadata": {
-        "sourceUrl" : "https://en.wikipedia.org/wiki/Hangul"
+        "sourceUrl" : "https://en.wikipedia.org/wiki/Hangul",
+        "sourceName" : "Wikipedia"
     },
 
     "aliases": [
-        "hangul", "korean alphabet", "korean language", "choson gul", "choson'gul", "choson muntcha", "choson muncha"
+        "hangul", "korean alphabet", "choson gul", "choson'gul", "choson muntcha", "choson muncha"
     ],
 
     "template_type": "code",

--- a/share/goodie/cheat_sheets/json/hangeul.json
+++ b/share/goodie/cheat_sheets/json/hangeul.json
@@ -26,20 +26,12 @@
                 "val": "Giyeok (기역): g [k]"
             },
             {
-                "key": "ㅋ",
-                "val": "Kiuek (키읔): k [kʰ]"
-            },
-            {
                 "key": "ㄴ",
                 "val": "Nieun (니은): n [n]"
             },
             {
                 "key": "ㄷ",
                 "val": "Digeut (디귿): d [t]"
-            },
-            {
-                "key": "ㅌ",
-                "val": "Tieut (티읕): t [tʰ]"
             },
             {
                 "key": "ㄹ",
@@ -54,12 +46,12 @@
                 "val": "Bieup (비읍): b [p]"
             },
             {
-                "key": "ㅍ",
-                "val": "Pieup (피읖): p [pʰ]"
-            },
-            {
                 "key": "ㅅ",
                 "val": "Shiot (시옷): s [s]"
+            },
+            {
+                "key": "ㅇ",
+                "val": "Ieung (이응): ng [ʔ, ŋ]"
             },
             {
                 "key": "ㅈ",
@@ -70,8 +62,16 @@
                 "val": "Chieut (치읓): ch [tɕʰ]"
             },
             {
-                "key": "ㅇ",
-                "val": "Ieung (이응): ng [ʔ, ŋ]"
+                "key": "ㅋ",
+                "val": "Kiuek (키읔): k [kʰ]"
+            },
+            {
+                "key": "ㅌ",
+                "val": "Tieut (티읕): t [tʰ]"
+            },
+            {
+                "key": "ㅍ",
+                "val": "Pieup (피읖): p [pʰ]"
             },
             {
                 "key": "ㅎ",
@@ -84,48 +84,20 @@
                 "val": "a [a]"
             },
             {
-                "key": "ㅐ",
-                "val": "ae [æ]"
-            },
-            {
                 "key": "ㅑ",
                 "val": "ya [ja]"
-            },
-            {
-                "key": "ㅒ",
-                "val": "yae [jæ]"
             },
             {
                 "key": "ㅓ",
                 "val": "eo [ʌ]"
             },
             {
-                "key": "ㅔ",
-                "val": "e [e]"
-            },
-            {
                 "key": "ㅕ",
                 "val": "yeo [jʌ]"
             },
             {
-                "key": "ㅖ",
-                "val": "ye [je]"
-            },
-            {
                 "key": "ㅗ",
                 "val": "o [o]"
-            },
-            {
-                "key": "ㅘ",
-                "val": "wa [wa]"
-            },
-            {
-                "key": "ㅙ",
-                "val": "wae [wæ]"
-            },
-            {
-                "key": "ㅚ",
-                "val": "oe [we]"
             },
             {
                 "key": "ㅛ",
@@ -136,18 +108,6 @@
                 "val": "u [u]"
             },
             {
-                "key": "ㅝ",
-                "val": "wo [wʌ]"
-            },
-            {
-                "key": "ㅞ",
-                "val": "we [we]"
-            },
-            {
-                "key": "ㅟ",
-                "val": "wi [wi]"
-            },
-            {
                 "key": "ㅠ",
                 "val": "yu [ju]"
             },
@@ -156,13 +116,54 @@
                 "val": "eu [ŭ]"
             },
             {
+                "key": "ㅣ",
+                "val": "i [i]"
+            },
+            {
+                "key": "ㅔ",
+                "val": "e [e]"
+            },
+            {
+                "key": "ㅖ",
+                "val": "ye [je]"
+            },
+            {
+                "key": "ㅐ",
+                "val": "ae [æ]"
+            },
+            {
+                "key": "ㅒ",
+                "val": "yae [jæ]"
+            },
+            {
                 "key": "ㅢ",
                 "val": "ui [ɨj]"
             },
             {
-                "key": "ㅣ",
-                "val": "i [i]"
+                "key": "ㅘ",
+                "val": "wa [wa]"
+            },
+            {
+                "key": "ㅚ",
+                "val": "oe [we]"
+            },
+            {
+                "key": "ㅙ",
+                "val": "wae [wæ]"
+            },
+            {
+                "key": "ㅝ",
+                "val": "wo [wʌ]"
+            },
+            {
+                "key": "ㅟ",
+                "val": "wi [wi]"
+            },
+            {
+                "key": "ㅞ",
+                "val": "we [we]"
             }
         ]
     }
 }
+

--- a/share/goodie/cheat_sheets/json/hangeul.json
+++ b/share/goodie/cheat_sheets/json/hangeul.json
@@ -1,0 +1,167 @@
+{
+    "id": "hangeul_cheat_sheet",
+    "name": "Hangeul/Hangul",
+    "description": "Letters of the Korean Alphabet",
+
+    "metadata": {
+        "sourceUrl" : "http://www.omniglot.com/charts/print/hangeul.pdf"
+    },
+
+    "aliases": [
+        "hangeul", "hangul", "korean alphabet", "korean language", "choson gul", "choson'gul", "choson muntcha", "choson muncha"
+    ],
+
+    "template_type": "code",
+
+    "section_order": [
+        "Consonanants (자음/子音)",
+        "Vowels (모음/母音)"
+    ],
+
+    "sections": {
+        "Consonanants (자음/子音)": [
+            {
+                "key": "ㄱ",
+                "val": "Giyeok (기역): g [k]"
+            },
+            {
+                "key": "ㅋ",
+                "val": "Kiuek (키읔): k [kʰ]"
+            },
+            {
+                "key": "ㄴ",
+                "val": "Nieun (니은): n [n]"
+            },
+            {
+                "key": "ㄷ",
+                "val": "Digeut (디귿): d [t]"
+            },
+            {
+                "key": "ㅌ",
+                "val": "Tieut (티읕): t [tʰ]"
+            },
+            {
+                "key": "ㄹ",
+                "val": "Rieul (리을): r [r, l]"
+            },
+            {
+                "key": "ㅁ",
+                "val": "Mieum (미음): m [m]"
+            },
+            {
+                "key": "ㅂ",
+                "val": "Bieup (비읍): b [p]"
+            },
+            {
+                "key": "ㅍ",
+                "val": "Pieup (피읖): p [pʰ]"
+            },
+            {
+                "key": "ㅅ",
+                "val": "Shiot (시옷): s [s]"
+            },
+            {
+                "key": "ㅈ",
+                "val": "Jieut (지읒): j [tɕ]"
+            },
+            {
+                "key": "ㅊ",
+                "val": "Chieut (치읓): ch [tɕʰ]"
+            },
+            {
+                "key": "ㅇ",
+                "val": "Ieung (이응): ng [ʔ, ŋ]"
+            },
+            {
+                "key": "ㅎ",
+                "val": "Hieut (히읗): h [h]"
+            }
+        ],
+        "Vowels (모음/母音)": [
+            {
+                "key": "ㅏ",
+                "val": "a [a]"
+            },
+            {
+                "key": "ㅐ",
+                "val": "ae [æ]"
+            },
+            {
+                "key": "ㅑ",
+                "val": "ya [ja]"
+            },
+            {
+                "key": "ㅒ",
+                "val": "yae [jæ]"
+            },
+            {
+                "key": "ㅓ",
+                "val": "eo [ʌ]"
+            },
+            {
+                "key": "ㅔ",
+                "val": "e [e]"
+            },
+            {
+                "key": "ㅕ",
+                "val": "yeo [jʌ]"
+            },
+            {
+                "key": "ㅖ",
+                "val": "ye [je]"
+            },
+            {
+                "key": "ㅗ",
+                "val": "o [o]"
+            },
+            {
+                "key": "ㅘ",
+                "val": "wa [wa]"
+            },
+            {
+                "key": "ㅙ",
+                "val": "wae [wæ]"
+            },
+            {
+                "key": "ㅚ",
+                "val": "oe [we]"
+            },
+            {
+                "key": "ㅛ",
+                "val": "yo [jo]"
+            },
+            {
+                "key": "ㅜ",
+                "val": "u [u]"
+            },
+            {
+                "key": "ㅝ",
+                "val": "wo [wʌ]"
+            },
+            {
+                "key": "ㅞ",
+                "val": "we [we]"
+            },
+            {
+                "key": "ㅟ",
+                "val": "wi [wi]"
+            },
+            {
+                "key": "ㅠ",
+                "val": "yu [ju]"
+            },
+            {
+                "key": "ㅡ",
+                "val": "eu [ŭ]"
+            },
+            {
+                "key": "ㅢ",
+                "val": "ui [ɨj]"
+            },
+            {
+                "key": "ㅣ",
+                "val": "i [i]"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [x] New Instant Answer
    - [x] Cheat Sheets: **`New Hangeul Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [ ] Improvement
    - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

Hangeul lists all of the letters that comprise the Korean alphabet (hangeul/hangul), along with their names and pronunciation. These letters can be assembled in order to read and write in Korean.

###### Which issues (if any) does this fix?

Correct ID

Appended "_cheat_sheet" to name.

###### People to notify (@mention interested parties)

@daxtheduck 

---

Instant Answer Page: https://duck.co/ia/view/hangeul_cheat_sheet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @mention
