### PR TITLE
Conversions.pm: Switch group from 'text' to 'base'.

### DIFF
--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -184,7 +184,7 @@ handle query_lc => sub {
               physical_quantity => $result->{'type'}
           },
           templates => {
-              group => 'text',
+              group => 'base',
               options => {
                   content => 'DDH.conversions.content'
               }

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -22,7 +22,7 @@ sub make_answer(%){
             physical_quantity => $input->{'physical_quantity'}
         },
         templates => {
-            group => 'text',
+            group => 'base',
             options => {
                 content => 'DDH.conversions.content'
             }


### PR DESCRIPTION
Whenever we're adding a custom template, we always have to use the `base` template because it looks wonky when we use anything else. Notice the extra margins that are added:

Before:
<img width="1564" alt="screen shot 2016-08-08 at 2 36 29 pm" src="https://cloud.githubusercontent.com/assets/81969/17491520/f5183836-5d75-11e6-8a8f-28e30098c736.png">

After:
<img width="1564" alt="screen shot 2016-08-08 at 2 36 15 pm" src="https://cloud.githubusercontent.com/assets/81969/17491519/f50d0fc4-5d75-11e6-92a3-0aec06e12088.png">

Instant Answer Page: https://duck.co/ia/view/conversions

