### PR TITLE
Ace Editor Cheat Sheet: Remove empty string alias

### DIFF
--- a/share/goodie/cheat_sheets/json/ace-editor.json
+++ b/share/goodie/cheat_sheets/json/ace-editor.json
@@ -8,10 +8,6 @@
         "sourceUrl" : "https://github.com/ajaxorg/ace/wiki/Default-Keyboard-Shortcuts"
     },
 
-    "aliases": [
-        ""
-    ],
-
     "template_type": "keyboard",
 
     "section_order": [


### PR DESCRIPTION
###### Description of changes

Removed the empty string alias defined in this cheat sheet's JSON.

###### Which issues (if any) does this fix?

#3517 

###### People to notify (@mention interested parties)

@tagawa 

---

Instant Answer Page: https://duck.co/ia/view/ace_editor_cheat_sheet