### PR TITLE
TimezoneConverter: Remove moreAt so that there's no extra space at the bottom of the IA

### DIFF
--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -178,7 +178,10 @@ handle query => sub {
             subtitle => "Convert Timezone: ".html_enc($input_string)
         },
         templates => {
-            group => 'text'
+            group => 'text',
+            options => {
+                moreAt => false,
+            }
         }
     };
 };

--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -180,7 +180,7 @@ handle query => sub {
         templates => {
             group => 'text',
             options => {
-                moreAt => false,
+                moreAt => 0,
             }
         }
     };

--- a/t/TimezoneConverter.t
+++ b/t/TimezoneConverter.t
@@ -18,7 +18,10 @@ sub build_test {
            subtitle => "Convert Timezone: $input"
        },
        templates => {
-           group => 'text'
+           group => 'text',
+           options => {
+               moreAt => 0,
+           }
        }
     });
 }


### PR DESCRIPTION
<img width="1792" alt="screen shot 2016-08-11 at 11 18 50 am" src="https://cloud.githubusercontent.com/assets/81969/17593887/651e113c-5fb5-11e6-8d0a-281be3598192.png">

IA Page: https://duck.co/ia/view/timezone_converter
Maintainer: @GlitchMr
