### PR TITLE
Improve triggering of Roman Numerals

### DIFF
--- a/lib/DDG/Goodie/Roman.pm
+++ b/lib/DDG/Goodie/Roman.pm
@@ -14,7 +14,7 @@ zci answer_type => "roman_numeral_conversion";
 
 handle remainder => sub {
     my $in = uc shift;
-    $in =~ s/\s*(?:numeral|number)\s*//i;
+    $in =~ s/(?:\s*|in|numerals?|number|\s*)//gi;
 
     return unless $in;
 

--- a/t/Roman.t
+++ b/t/Roman.t
@@ -32,6 +32,8 @@ ddg_goodie_test(
     'roman numeral MCCCXXXVII' => build_test('1337 (roman numeral conversion)', 'MCCCXXXVII', '1337'),
     'roman 1337' => build_test('MCCCXXXVII (roman numeral conversion)', '1337', 'MCCCXXXVII'),
     'roman IV' => build_test('4 (roman numeral conversion)', 'IV', '4'),
+    '10 in roman numeral' => build_test('X (roman numeral conversion)', '10', 'X'),
+    '11 in roman numerals' => build_test('XI (roman numeral conversion)', '11', 'XI'),
 );
 
 done_testing;


### PR DESCRIPTION
Improvement
Bug fix: **`Roman Numerals: Proposed Fix 3484`**

###### Description of changes

Add more tests.
Improve regex so that queries like `10 in roman numerals` trigger.

Fixes #3484 - Add tests for this issue and improve regex so that the query now triggers correctly.

@GuiltyDolphin @moollaza 


---

Instant Answer Page: https://duck.co/ia/view/roman

