### PR TITLE
Fixes: #3575: added forum.duckduckhack.com to the Quack and Hack Cheat Sheet 

### DIFF
--- a/share/goodie/cheat_sheets/json/quackhack.json
+++ b/share/goodie/cheat_sheets/json/quackhack.json
@@ -26,6 +26,9 @@
         }, {
             "val": "email: open@duckduckgo.com",
             "key": "Need help and nobody's around?"
+        }, {
+            "val": "http://forum.duckduckhack.com",
+            "key": "Join the discussion"
         }], 
         "Examples": [{
             "val": "https://duck.co/ia?repo=goodies",


### PR DESCRIPTION
Fixes: #3575: added forum.duckduckhack.com to the Quack and Hack Cheat Sheet 

---

Instant Answer Page: http://duck.co/ia/view/quackhack_cheat_sheet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @zekiel 

