### PR TITLE
Roman Numerals: Add more trigger words.

### DIFF
--- a/lib/DDG/Goodie/Roman.pm
+++ b/lib/DDG/Goodie/Roman.pm
@@ -14,7 +14,7 @@ zci answer_type => "roman_numeral_conversion";
 
 handle remainder => sub {
     my $in = uc shift;
-    $in =~ s/(?:\s*|in|numerals?|number|\s*)//gi;
+    $in =~ s/(?:\s*|in|to|numerals?|number|\s*)//gi;
 
     return unless $in;
 

--- a/t/Roman.t
+++ b/t/Roman.t
@@ -34,6 +34,8 @@ ddg_goodie_test(
     'roman IV' => build_test('4 (roman numeral conversion)', 'IV', '4'),
     '10 in roman numeral' => build_test('X (roman numeral conversion)', '10', 'X'),
     '11 in roman numerals' => build_test('XI (roman numeral conversion)', '11', 'XI'),
+    'xiii to arabic' => build_test('13 (roman numeral conversion)', 'XIII', '13'),
+    '20 to roman numerals' => build_test('XX (roman numeral conversion)', '20', 'XX'),
 );
 
 done_testing;


### PR DESCRIPTION

- [x] Improvement
    - [x] Enhancement: **`Roman Numerals: Fix #3592`**

{Short Description}`**

###### Description of changes

Make 'X to roman numerals' or 'X to arabic' trigger.
Proposed fix for this [issue](https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3592)

@duckduckgo/community-leaders 


---

Instant Answer Page: https://duck.co/ia/view/roman

