### PR TITLE
Roman Numerals: Remove repeated \s* in character set.

### DIFF
--- a/lib/DDG/Goodie/Roman.pm
+++ b/lib/DDG/Goodie/Roman.pm
@@ -14,7 +14,7 @@ zci answer_type => "roman_numeral_conversion";
 
 handle remainder => sub {
     my $in = uc shift;
-    $in =~ s/(?:\s*|in|to|numerals?|number|\s*)//gi;
+    $in =~ s/(?:\s*|in|to|numerals?|number)//gi;
 
     return unless $in;
 


### PR DESCRIPTION
- [x] Improvement
     - [x] Enhancement: **`Roman Numerals: Remove redundant \s* in character set.`**


###### People to notify

@duckduckgo/community-leaders 


---

Instant Answer Page: https://duck.co/ia/view/roman
