### PR TITLE
New LHC Apocalypse Checker Instant Answer

### DIFF
--- a/lib/DDG/Goodie/HasLHCDestroyedWorld.pm
+++ b/lib/DDG/Goodie/HasLHCDestroyedWorld.pm
@@ -16,7 +16,7 @@ triggers any => 'has the large hadron collider destroyed the world',
 # Handle statement
 handle remainder => sub {
 
-    return "plain text response",
+    return "Nope.",
         structured_answer => {
             id => 'has_lhcdestroyed_world',
             name => 'Answer',

--- a/lib/DDG/Goodie/HasLHCDestroyedWorld.pm
+++ b/lib/DDG/Goodie/HasLHCDestroyedWorld.pm
@@ -1,0 +1,38 @@
+package DDG::Goodie::HasLHCDestroyedWorld;
+
+# ABSTRACT: Has the Large Hadron Collider destroyed the world yet? Nope.
+
+use DDG::Goodie;
+use strict;
+
+zci answer_type => 'has_lhcdestroyed_world';
+zci is_cached => 1;
+
+triggers any => 'has the large hadron collider destroyed the world',
+                'has the lhc destroyed the world',
+                'has the large hadron collider destroyed the earth',
+                'has the lhc destroyed the earth';
+
+# Handle statement
+handle remainder => sub {
+
+    return "plain text response",
+        structured_answer => {
+            id => 'has_lhcdestroyed_world',
+            name => 'Answer',
+            data => {
+                title => "Has it?",
+                subtitle => "Nope."
+            },
+            meta => {
+                sourceName => "Has the Large Hadron Collider destroyed the world yet?",
+                sourceUrl => "http://hasthelargehadroncolliderdestroyedtheworldyet.com/"
+            },
+            templates => {
+                group => "text",
+                moreAt => 1
+            }
+        };
+};
+
+1;

--- a/t/HasLHCDestroyedWorld.t
+++ b/t/HasLHCDestroyedWorld.t
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use DDG::Test::Goodie;
+
+zci answer_type => "has_lhcdestroyed_world";
+zci is_cached   => 1;
+
+ddg_goodie_test(
+    [qw( DDG::Goodie::HasLHCDestroyedWorld )],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'example query' => test_zci('query'),
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'bad example query' => undef,
+);
+
+done_testing;

--- a/t/HasLHCDestroyedWorld.t
+++ b/t/HasLHCDestroyedWorld.t
@@ -8,7 +8,9 @@ use DDG::Test::Goodie;
 zci answer_type => "has_lhcdestroyed_world";
 zci is_cached   => 1;
 
-my $result = {
+# The one structured answer containing the message, "Nope."
+my @no = (
+    "Nope.",
     structured_answer => {
         id => 'has_lhcdestroyed_world',
         name => 'Answer',
@@ -25,23 +27,23 @@ my $result = {
             moreAt => 1
         }
     }
-}
+);
 
 ddg_goodie_test(
     [qw( DDG::Goodie::HasLHCDestroyedWorld )],
-    'has the large hadron collider destroyed the world yet' => test_zci($result),
-    'has the large hadron collider destroyed the world' => test_zci($result),
-    'has the lhc destroyed the world yet' => test_zci($result),
-    'has the lhc destroyed the world' => test_zci($result),
-    'has the large hadron collider destroyed the earth yet' => test_zci($result),
-    'has the large hadron collider destroyed the earth' => test_zci($result),
-    'has the lhc destroyed the earth yet' => test_zci($result),
-    'has the lhc destroyed the earth' => test_zci($result),
+    'has the large hadron collider destroyed the world yet' => test_zci(@no),
+    'has the large hadron collider destroyed the world'     => test_zci(@no),
+    'has the lhc destroyed the world yet'                   => test_zci(@no),
+    'has the lhc destroyed the world'                       => test_zci(@no),
+    'has the large hadron collider destroyed the earth yet' => test_zci(@no),
+    'has the large hadron collider destroyed the earth'     => test_zci(@no),
+    'has the lhc destroyed the earth yet'                   => test_zci(@no),
+    'has the lhc destroyed the earth'                       => test_zci(@no),
 
 
-    'large hadron collider' => undef,
-    'could the large hadron collider destroyed the world' => undef,
-    'will the large hadron collider destroy the earth' => undef
+    'large hadron collider'                                 => undef,
+    'could the large hadron collider destroyed the world'   => undef,
+    'will the large hadron collider destroy the earth'      => undef
 );
 
 done_testing;

--- a/t/HasLHCDestroyedWorld.t
+++ b/t/HasLHCDestroyedWorld.t
@@ -8,15 +8,40 @@ use DDG::Test::Goodie;
 zci answer_type => "has_lhcdestroyed_world";
 zci is_cached   => 1;
 
+my $result = {
+    structured_answer => {
+        id => 'has_lhcdestroyed_world',
+        name => 'Answer',
+        data => {
+            title => "Has it?",
+            subtitle => "Nope."
+        },
+        meta => {
+            sourceName => "Has the Large Hadron Collider destroyed the world yet?",
+            sourceUrl => "http://hasthelargehadroncolliderdestroyedtheworldyet.com/"
+        },
+        templates => {
+            group => "text",
+            moreAt => 1
+        }
+    }
+}
+
 ddg_goodie_test(
     [qw( DDG::Goodie::HasLHCDestroyedWorld )],
-    # At a minimum, be sure to include tests for all:
-    # - primary_example_queries
-    # - secondary_example_queries
-    'example query' => test_zci('query'),
-    # Try to include some examples of queries on which it might
-    # appear that your answer will trigger, but does not.
-    'bad example query' => undef,
+    'has the large hadron collider destroyed the world yet' => test_zci($result),
+    'has the large hadron collider destroyed the world' => test_zci($result),
+    'has the lhc destroyed the world yet' => test_zci($result),
+    'has the lhc destroyed the world' => test_zci($result),
+    'has the large hadron collider destroyed the earth yet' => test_zci($result),
+    'has the large hadron collider destroyed the earth' => test_zci($result),
+    'has the lhc destroyed the earth yet' => test_zci($result),
+    'has the lhc destroyed the earth' => test_zci($result),
+
+
+    'large hadron collider' => undef,
+    'could the large hadron collider destroyed the world' => undef,
+    'will the large hadron collider destroy the earth' => undef
 );
 
 done_testing;


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.
- [x] New Instant Answer
  - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
  - [x] Other: **`New {IA Name} Instant Answer`**
- [ ] Improvement
  - [ ] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
  - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
  - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**
###### Description of changes

Adds an easter egg that determines whether the Large Hadron Collider has destroyed the world yet. Just for giggles; reject it if you don't like it, because it only took about an hour of my time.
###### Related Issues or Discussions

N/A
###### People to notify

@mention any relevant people/organizations

---

Instant Answer Page: https://duck.co/ia/view/has_the_large_hadron_collider_destroyed_the_world_yet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @mention
