### PR TITLE
Apple Mac OS Cheat Sheet: Add macOS as alias.

### DIFF
--- a/share/goodie/cheat_sheets/json/apple-mac-os.json
+++ b/share/goodie/cheat_sheets/json/apple-mac-os.json
@@ -12,7 +12,8 @@
         "mac",
         "apple mac",
         "mac os",
-        "mac osx"
+        "mac osx",
+        "macos"
     ],
     "template_type": "keyboard",
     "section_order": [


### PR DESCRIPTION
[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @AlfonzM

Add "macos" as an alias because the official name of OS X is changed to macOS.

Instant Answer Page: https://duck.co/ia/view/apple_mac_os_cheat_sheet