### PR TITLE
Sublime-text cheat sheet : Added shortcut for jumping to matching bracket

### DIFF
--- a/share/goodie/cheat_sheets/json/sublime-text.json
+++ b/share/goodie/cheat_sheets/json/sublime-text.json
@@ -73,6 +73,9 @@
             "key":"[Ctrl] [G]",
             "val":"Goto Line"
           }, {
+            "key":"[Ctrl] [M]",
+            "val":"Jump to matching bracket"
+          }, {
             "key":"[Ctrl] [R]",
             "val":"Goto symbol (function name, table, etc.)"
           }, {


### PR DESCRIPTION
Cheat Sheet URL: [here](https://duckduckgo.com/?q=sublime+text+cheat+sheet&t=h_&iax=1&ia=cheatsheet)

The cheat sheet is missing the shortcut: **[Ctrl] + [M]** and hence, is added by this pull request.

This shortcut is used to _jump to the matching bracket_.