### PR TITLE
New JavaDoc cheat sheet

### DIFF
--- a/share/goodie/cheat_sheets/json/javadoc.json
+++ b/share/goodie/cheat_sheets/json/javadoc.json
@@ -1,0 +1,93 @@
+
+{
+    "id": "javadoc_cheat_sheet",
+    "name": "JavaDoc",
+    "description": "A set of javaDoc tags",
+    "metadata": {
+        "sourceName": "Oracle",
+        "sourceUrl": "http://www.oracle.com/technetwork/articles/java/index-137868.html"
+    },
+    "template_type": "terminal",
+    "section_order": [  "Global tags",
+                        "Package tags",
+                        "Class and Interface Tags",
+                        "Field Tags",
+                        "Constructor and Method Tags"
+                     ],
+    "sections": {
+        "Global tags" : [
+            {
+                "key" : "@author",
+                "val" : "Describes an author"
+            },
+            {
+                "key" : "@version",
+                "val" : "Provides software version entry"
+            },
+            {
+                "key" : "@see",
+                "val" : "Text entry that points to a reference"
+            },
+            {
+                "key" : "@since",
+                "val" : "Describes when this functionality has first existed"
+            },
+            {
+                "key" : "@docRoot",
+                "val" : "Represents the relative path to the generated document's root directory from any generated page"
+            },
+            {
+                "key" : "@inheritDoc",
+                "val" : "Inherits a comment from the nearest inheritable class or interface"
+            },
+            {
+                "key" : "@link",
+                "val" : "Inserts an in-line link with the visible text label that points to the documentation"
+            },
+            {
+                "key" : "@linkplain",
+                "val" : "the link's label is displayed in plain text"
+            }
+        ],
+        "Package tags": [
+            {
+                "key" : "@serial",
+                "val" : "Used in the doc comment for a default serializable field"
+            }
+        ],
+        "Class and Interface Documentation Tags": [
+            {
+                "val" : "@deprecated",
+                "key" : "Adds a comment indicating that this API should no longer be used"
+            }
+        ],
+        "Field Tags": [
+            {
+                "val" : "@serialField",
+                "key" : "Documents an ObjectStreamField component"
+            },
+            {
+                "val" : "@value",
+                "key" : "Used in the doc comment of a static field"
+            }
+        ],
+        "Constructor and Method Tags": [
+            {
+                "val" : "@return",
+                "key" : "Adds a Returns section with the description text"
+            },
+            {
+                "val" : "@exception",
+                "key" : "Adds a Throws subheading to the generated documentation, with the classname and description text"
+            },
+            {
+                "val" : "@throws",
+                "key" : "The @throws and @exception tags are synonyms."
+            },
+            {
+                "key" : "@serialData",
+                "val" : "Documents the data written by the writeObject() or writeExternal() methods"
+            }
+        ]
+    }
+}

--- a/share/goodie/cheat_sheets/json/javadoc.json
+++ b/share/goodie/cheat_sheets/json/javadoc.json
@@ -57,32 +57,32 @@
         ],
         "Class and Interface Tags": [
             {
-                "val" : "@deprecated",
-                "key" : "Adds a comment indicating that this API should no longer be used"
+                "key" : "@deprecated",
+                "val" : "Adds a comment indicating that this API should no longer be used"
             }
         ],
         "Field Tags": [
             {
-                "val" : "@serialField",
-                "key" : "Documents an ObjectStreamField component"
+                "key" : "@serialField",
+                "val" : "Documents an ObjectStreamField component"
             },
             {
-                "val" : "@value",
-                "key" : "Used in the doc comment of a static field"
+                "key" : "@value",
+                "val" : "Used in the doc comment of a static field"
             }
         ],
         "Constructor and Method Tags": [
             {
-                "val" : "@return",
-                "key" : "Adds a Returns section with the description text"
+                "key" : "@return",
+                "val" : "Adds a Returns section with the description text"
             },
             {
-                "val" : "@exception",
-                "key" : "Adds a Throws subheading to the generated documentation, with the classname and description text"
+                "key" : "@exception",
+                "val" : "Adds a Throws subheading to the generated documentation, with the classname and description text"
             },
             {
-                "val" : "@throws",
-                "key" : "The @throws and @exception tags are synonyms."
+                "key" : "@throws",
+                "val" : "The @throws and @exception tags are synonyms."
             },
             {
                 "key" : "@serialData",

--- a/share/goodie/cheat_sheets/json/javadoc.json
+++ b/share/goodie/cheat_sheets/json/javadoc.json
@@ -55,7 +55,7 @@
                 "val" : "Used in the doc comment for a default serializable field"
             }
         ],
-        "Class and Interface Documentation Tags": [
+        "Class and Interface Tags": [
             {
                 "val" : "@deprecated",
                 "key" : "Adds a comment indicating that this API should no longer be used"


### PR DESCRIPTION
## New JavaDoc Cheat Sheet

This PR creates a cheat sheet listing the various JavaDoc tags.

 _Javadoc_ is a documentation generator created by Sun Microsystems for the Java language (now owned by Oracle Corporation) for generating API documentation in HTML format from Java source code. The tags are used for this purpose.

Check out the cheat sheet : [here](https://beta.duckduckgo.com/?q=javadoc+cheat+sheet&ia=cheatsheet&iax=1)

Cheat Sheet page : [here](https://duck.co/ia/view/javadoc_cheat_sheet)

Developer and Maintainer: [**AdiChat**](https://github.com/AdiChat)


---
https://duck.co/ia/view/javadoc_cheat_sheet
