### PR TITLE
Requests Cheat Sheet: Fix incorrect property name

### DIFF
--- a/share/goodie/cheat_sheets/json/requests.json
+++ b/share/goodie/cheat_sheets/json/requests.json
@@ -51,7 +51,7 @@
                 "val": "Get a Python dictionary of response header name:value pairs"
             },
             {
-                "key": "response.json",
+                "key": "response.cookies",
                 "val": "Get a Python dictionary of response cookie name:value pairs"
             }
         ],


### PR DESCRIPTION
###### What does your Pull Request do (check all that apply)?

Choose the most relevant items and use the following title template to name
your Pull Request.

- [ ] New Instant Answer
    - [ ] Cheat Sheets: **`New {Cheat Sheet Name} Cheat Sheet`**
    - [ ] Other: **`New {IA Name} Instant Answer`**
- [x] Improvement
    - [x] Bug fix: **`{IA Name}: Fix {Issue number or one-line description}`**
    - [ ] Enhancement: **`{IA Name}: {Description of Improvements}`**
- [ ] Non–Instant Answer
    - [ ] Other (Role, Template, Test, Documentation, etc.): **`{GoodieRole/Templates/Tests/Docs}: {Short Description}`**

###### Description of changes

The current version lists `response.json` as the appropriate way to get the cookies from a response, when it is in fact `response.cookies`.

Updates `response.json` to `response.cookies` in the `Headers and Cookies` section

---

Instant Answer Page: https://duck.co/ia/view/requests_cheat_sheet

[Maintainer](http://docs.duckduckhack.com/maintaining/guidelines.html): @daneah