### PR TITLE
new C Data Types cheat sheet

### DIFF
--- a/share/goodie/cheat_sheets/json/cdata-types.json
+++ b/share/goodie/cheat_sheets/json/cdata-types.json
@@ -1,0 +1,94 @@
+{
+    "id": "cdata_types_cheat_sheet",
+    "name": "C Data Types",
+    "description": "Data Types available in C",
+
+    "metadata": {
+        "sourceName": "cppreference",
+        "sourceUrl" : "http://en.cppreference.com/w/c/language/arithmetic_types"
+    },
+
+    "aliases": [
+        "c data types", "c data types sizes", "c data types size", "data types in c"
+    ],
+
+    "template_type": "code",
+
+    "section_order": [
+        "Integer Type",
+        "Floating Type",
+        "Character Type",
+        "Boolean Type"
+    ],
+
+    "sections": {
+        "Integer Type": [
+            {
+                "key":"short int",
+                "val":"2 Bytes, Range: -32767 to 32767,"
+            },
+            {
+                "key":"unsigned short int",
+                "val":"2 Bytes, Range: 0 to 65535"
+            },
+            {
+                "key":"int",
+                "val":"2 Bytes, Range: -32767 to 32767, "
+            },
+            {
+                "key":"unsigned int",
+                "val":"2 Bytes, Range: 0 to 65535"
+            },
+            {
+                "key":"long int",
+                "val":"4 Bytes, Range: -2,147,483,647 to 2,147,483,647"
+            },
+            {
+                "key":"unsigned long int",
+                "val":"4 Bytes, Range: 0 to 4,294,967,295"
+            },
+            {
+                "key":"long long int",
+                "val":"8 Bytes, Range: -9,223,372,036,854,775,807 to 9,223,372,036,854,775,807"
+            },
+            {
+                "key":"unsigned long long int",
+                "val":"8 Bytes, Range: 0 to 18,446,744,073,709,551,615"
+            }
+        ],
+        "Floating Type": [
+            {
+                "key":"float",
+                "val":"4 Bytes, Max: ±3.402,823,4x10^38, single precision floating point type"
+            },
+            {
+                "key":"double",
+                "val":"8 Bytes, Max: ±1.797,693,134,862,315,7x10^308, double precision floating point type"
+            },
+            {
+                "key":"long double",
+                "val":"8 Bytes, Range: ±1.797,693,134,862,315,7x10^308, extended precision floating point type"
+            }
+        ],
+        "Boolean Type": [
+            {
+                "key": "bool",
+                "val": "type capable of holding one of the two values: 1 and 0 or the macros true or false"
+            }
+        ],
+        "Character Type": [
+            {
+                "key": "signed char",
+                "val": "1 Byte, Range: -127 to 127, type for signed character representation"
+            },
+            {
+                "key": "unsigned char",
+                "val": "1 Byte, Range: 0 to 255, type for unsigned character representation"
+            },
+            {
+                "key": "char",
+                "val": "1 Byte, Range: -127 to 127, type for character representation"
+            }
+        ]
+    }
+}

--- a/share/goodie/cheat_sheets/json/cdata-types.json
+++ b/share/goodie/cheat_sheets/json/cdata-types.json
@@ -18,14 +18,15 @@
         "Integer Type",
         "Floating Type",
         "Character Type",
-        "Boolean Type"
+        "Boolean Type",
+        "Void Type"
     ],
 
     "sections": {
         "Integer Type": [
             {
                 "key":"short int",
-                "val":"2 Bytes, Range: -32768 to 32767,"
+                "val":"2 Bytes, Range: -32768 to 32767"
             },
             {
                 "key":"unsigned short int",
@@ -33,7 +34,7 @@
             },
             {
                 "key":"int",
-                "val":"2 Bytes, Range: -32768 to 32767, "
+                "val":"atleast 2 Bytes, Range: -32768 to 32767"
             },
             {
                 "key":"unsigned int",
@@ -88,6 +89,12 @@
             {
                 "key": "char",
                 "val": "1 Byte, Range: -128 to 127, type for character representation"
+            }
+        ],
+        "Void Type": [
+            {
+                "key": "void",
+                "val": "type for the result of a function that returns normally, but does not provide a result value to its caller"
             }
         ]
     }

--- a/share/goodie/cheat_sheets/json/cdata-types.json
+++ b/share/goodie/cheat_sheets/json/cdata-types.json
@@ -34,7 +34,7 @@
             },
             {
                 "key":"int",
-                "val":"atleast 2 Bytes, Range: -32768 to 32767"
+                "val":"The size of int is wholely dependent on the machine and compiler. For 8 bit or 16 bit machine Size: 2 Bytes, Range: -32,768 to 32,767. For 32 bit or 64 bit machine Size: 4 Bytes, Range: -2,147,483,648 to 2,147,483,647"
             },
             {
                 "key":"unsigned int",

--- a/share/goodie/cheat_sheets/json/cdata-types.json
+++ b/share/goodie/cheat_sheets/json/cdata-types.json
@@ -12,7 +12,7 @@
         "c data types", "c data types sizes", "c data types size", "data types in c"
     ],
 
-    "template_type": "code",
+    "template_type": "terminal",
 
     "section_order": [
         "Integer Type",

--- a/share/goodie/cheat_sheets/json/cdata-types.json
+++ b/share/goodie/cheat_sheets/json/cdata-types.json
@@ -25,7 +25,7 @@
         "Integer Type": [
             {
                 "key":"short int",
-                "val":"2 Bytes, Range: -32767 to 32767,"
+                "val":"2 Bytes, Range: -32768 to 32767,"
             },
             {
                 "key":"unsigned short int",
@@ -33,7 +33,7 @@
             },
             {
                 "key":"int",
-                "val":"2 Bytes, Range: -32767 to 32767, "
+                "val":"2 Bytes, Range: -32768 to 32767, "
             },
             {
                 "key":"unsigned int",
@@ -41,7 +41,7 @@
             },
             {
                 "key":"long int",
-                "val":"4 Bytes, Range: -2,147,483,647 to 2,147,483,647"
+                "val":"4 Bytes, Range: -2,147,483,648 to 2,147,483,647"
             },
             {
                 "key":"unsigned long int",
@@ -49,7 +49,7 @@
             },
             {
                 "key":"long long int",
-                "val":"8 Bytes, Range: -9,223,372,036,854,775,807 to 9,223,372,036,854,775,807"
+                "val":"8 Bytes, Range: -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807"
             },
             {
                 "key":"unsigned long long int",
@@ -67,7 +67,7 @@
             },
             {
                 "key":"long double",
-                "val":"8 Bytes, Range: ±1.797,693,134,862,315,7x10^308, extended precision floating point type"
+                "val":"8 Bytes, Max: ±1.797,693,134,862,315,7x10^308, extended precision floating point type"
             }
         ],
         "Boolean Type": [
@@ -79,7 +79,7 @@
         "Character Type": [
             {
                 "key": "signed char",
-                "val": "1 Byte, Range: -127 to 127, type for signed character representation"
+                "val": "1 Byte, Range: -128 to 127, type for signed character representation"
             },
             {
                 "key": "unsigned char",
@@ -87,7 +87,7 @@
             },
             {
                 "key": "char",
-                "val": "1 Byte, Range: -127 to 127, type for character representation"
+                "val": "1 Byte, Range: -128 to 127, type for character representation"
             }
         ]
     }


### PR DESCRIPTION
## Type of Change
- [X] New Instant Answer
  - [X] Cheat Sheet
- [ ] Improvement
  - [ ] Bug fix
  - [ ] Enhancement
- [ ] Non–Instant Answer
  - [ ] Other (Role, Template, Test, Documentation, etc.)
## Description of new Instant Answer, or changes

Adds a new Cheat Sheet for C Data Types including int, short, float, etc.
## People to notify

<!-- Please @mention any relevant people/organizations here:-->

@moollaza 
@rasikapohankar 
---

IA: [https://duck.co/ia/view/c_data_types_cheat_sheet](https://duck.co/ia/view/c_data_types_cheat_sheet)
Forum Topic: [https://forum.duckduckhack.com/t/new-c-data-types-cheat-sheet/1047](https://forum.duckduckhack.com/t/new-c-data-types-cheat-sheet/1047)
