### PR TITLE
ColorPicker: Fixing over eager triggering

### DIFF
--- a/lib/DDG/Goodie/ColorPicker.pm
+++ b/lib/DDG/Goodie/ColorPicker.pm
@@ -33,9 +33,8 @@ handle remainder => sub {
     elsif($remainder =~ /[a-zA-Z ]+/) {
         $remainder =~ s/[ \t]+//g;
         $remainder = lc $remainder;
-        if(defined Color::Library->SVG->color($remainder)) {
-            $color = Color::Library->SVG->color($remainder)->html;
-        }
+        return unless defined Color::Library->SVG->color($remainder);
+        $color = Color::Library->SVG->color($remainder)->html;
     }
     return 'Color Picker',
         structured_answer => {

--- a/t/ColorPicker.t
+++ b/t/ColorPicker.t
@@ -83,6 +83,10 @@ ddg_goodie_test(
     'testing colour picker #e4e4e4' => undef,
     'testing colourpicker #e4e4e4' => undef,
     'testing colorpicker #e4e4e4' => undef,
+    'color picker download' => undef,
+    'colour picker download' => undef,
+    'color picker tutorial' => undef,
+    'colour picker tutorial' => undef
 );
 
 done_testing;


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3788 / https://github.com/duckduckgo/zeroclickinfo-spice/issues/2838 by guaranteeing that the words after the trigger are actual colours

## People to notify
@tagawa 

Just to re-iterate, the metadata for this IA appears to be broken

---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: http://duck.co/ia/view/color_picker
<!-- FILL THIS IN:                           ^^^^ -->
