### PR TITLE
Fixes #3791 (bug in PostgreSQL cheat sheet)

### DIFF
--- a/share/goodie/cheat_sheets/json/postgresql.json
+++ b/share/goodie/cheat_sheets/json/postgresql.json
@@ -41,39 +41,39 @@
     "PostgreSQL": [
       {
              "key": "\\du",
-             "value": "Lists roles"
+             "val": "Lists roles"
       },
       {
              "key": "\\l",
-             "value": "Lists all the databases"
+             "val": "Lists all the databases"
       },
       {
              "key": "\\dt",
-             "value": "List tables in connected database"
+             "val": "List tables in connected database"
       },
       {
              "key": "\\dn",
-             "value": "List schemas"
+             "val": "List schemas"
       },
       {
              "key": "\\d table",
-             "value": "List columns on table"
+             "val": "List columns on table"
       },
       {
              "key": "\\df",
-             "value": "List functions"
+             "val": "List functions"
       },
       {
              "key": "\\q",
-             "value": "Quit"
+             "val": "Quit"
       },
       {
              "key": "\\dv",
-             "value": "List views"
+             "val": "List views"
       },
       {
              "key": "\\x",
-             "value": "Pretty-format query results"
+             "val": "Pretty-format query results"
       }
     ],
     "User Access": [


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title:

    For a Bug Fix:
    {IA Name}: {Description of change}

    For a New Instant Answer:
    New {IA Name} Goodie

    For anything else:
    {Tests/Docs/Other}: {Short Description} -->


## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
As stated in #3791, there's a bug in PostgreSQL cheat sheet that doesn't display the info about the commands in one section.

## Related Issues and Discussions
<!--  Link related issues here to automatically close them when PR is merged
      E.g. "Fixes #1234" -->

Fixes #3791 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant answer page: https://duck.co/ia/view/postgresql_cheat_sheet
<!-- FILL THIS IN:                           ^^^^ -->

