### PR TITLE
DuckDuckGo Syntax Cheat Sheet: Add alias

### DIFF
--- a/share/goodie/cheat_sheets/json/duckduckgo-syntax.json
+++ b/share/goodie/cheat_sheets/json/duckduckgo-syntax.json
@@ -10,7 +10,9 @@
   "aliases": [
     "ddg search",
     "duck duck go search",
-    "duckduckgo search"
+    "duckduckgo search",
+    "duckduckgo search syntax"
+    "duck duck go search syntax",
   ],
   "section_order": [
     "Triggers",
@@ -40,7 +42,7 @@
       },
       {
         "key": "!a blink182",
-        "val": "Use ! to search other sites' search engines directly. We call these bangs. (!a blink182 searches Amazon.com for blink182)"
+        "val": "Use ! to search other sites' search engines directly. We call these !Bangs. (!a blink182 searches Amazon.com for blink182)"
       }
     ],
     "Group search terms": [
@@ -79,8 +81,8 @@
     ],
     "Drop terms": [
       {
-        "key": "Apple - mango",
-        "val": "Use minus (-) before a word or phrase to have it not appear in results. Excluded words must be the last words in the search"
+        "key": "Apple -mango",
+        "val": "Use minus (-) before a word or quoted phrase to have it not appear in results. Excluded words must be the last words in the search"
       }
     ],
     "Safe search": [


### PR DESCRIPTION
## Description of new Instant Answer, or changes
- Adds the alias "duckduckgo search syntax", "duck duck go search syntax"
- correct "bangs" to "!Bangs"
- correct drop terms example

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/duckduckgo_syntax_cheat_sheet
<!-- FILL THIS IN:                           ^^^^ -->
