### PR TITLE
Historical Events: Rephrase subtitle to answer & restate question

### DIFF
--- a/lib/DDG/Goodie/HistoricalEvents.pm
+++ b/lib/DDG/Goodie/HistoricalEvents.pm
@@ -23,6 +23,7 @@ foreach my $event ( keys %$events ) {
             # replace _event_ with $article $event
             my $article = $event_obj->{article};
             $query =~ s/_event_/$article $event/;
+            $answer =~ s/_event_/$article $event/;
             $queries{lc $query} = {
                 link => $link,
                 answer => $answer

--- a/lib/DDG/Goodie/HistoricalEvents.pm
+++ b/lib/DDG/Goodie/HistoricalEvents.pm
@@ -19,10 +19,27 @@ foreach my $event ( keys %$events ) {
     my $link = $event_obj->{link};
 
     while ( my($query, $answer) = each %{$event_obj->{queries}} ) {
-        $queries{$query} = {
-            link => $link,
-            answer => $answer
-        };
+        if ($query =~ m/_event_/) {
+            # replace _event_ with $article $event
+            my $article = $event_obj->{article};
+            $query =~ s/_event_/$article $event/;
+            $queries{lc $query} = {
+                link => $link,
+                answer => $answer
+            };
+            # additional trigger without '$article ' for triggering flexibiilty
+            $query =~ s/$article //;
+            $queries{lc $query} = {
+                link => $link,
+                answer => $answer
+            };
+        }
+        else {
+            $queries{$query} = {
+                link => $link,
+                answer => $answer
+            };
+        }
     }
 };
 

--- a/lib/DDG/Goodie/HistoricalEvents.pm
+++ b/lib/DDG/Goodie/HistoricalEvents.pm
@@ -48,12 +48,12 @@ my @triggers = map { ("$_", "$_?") } keys %queries;
 
 triggers start => @triggers;
 
-handle remainder => sub {
+handle remainder_lc => sub {
 
     # ensure no remainder, query == trigger
     return if $_;
 
-    my $query = $req->matched_trigger;
+    my $query = lc $req->matched_trigger;
     $query =~ s/\?//;
     my $answer = $queries{$query}{answer};
     my $link = $queries{$query}{link};

--- a/share/goodie/historical_events/events.yml
+++ b/share/goodie/historical_events/events.yml
@@ -2,25 +2,27 @@
 # List of historical events, along with Wikipedia link
 Holocaust:
     link: https://en.wikipedia.org/wiki/The_Holocaust
+    article: the
     queries:
-        is the holocaust real: the Holocaust is real
-        is the holocaust true: the Holocaust is true
-        was the holocaust real: the Holocaust was real
-        was the holocaust true: the Holocaust was true
-        did the holocaust happen: the Holocaust happened
-        did the holocaust really happen: the Holocaust happened
-        did the holocaust actually happen: the Holocaust happened
+        is _event_ real: the Holocaust is real
+        is _event_ true: the Holocaust is true
+        was _event_ real: the Holocaust was real
+        was _event_ true: the Holocaust was true
+        did _event_ happen: the Holocaust happened
+        did _event_ really happen: the Holocaust happened
+        did _event_ actually happen: the Holocaust happened
 
 Moon landing:
     link: https://en.wikipedia.org/wiki/Moon_landing
+    article: the
     queries:
-        is the moon landing real: the Moon landing is real
-        is the moon landing true: the Moon landing is true
-        was the moon landing real: the Moon landing was real
-        was the moon landing true: the Moon landing was true
-        did the moon landing happen: the Moon landing happened
-        did the moon landing actually happen: the Moon landing happened
-        did the moon landing really happen: the Moon landing happened
+        is _event_ real: the Moon landing is real
+        is _event_ true: the Moon landing is true
+        was _event_ real: the Moon landing was real
+        was _event_ true: the Moon landing was true
+        did _event_ happen: the Moon landing happened
+        did _event_ actually happen: the Moon landing happened
+        did _event_ really happen: the Moon landing happened
         did we land on the moon: we did land on the Moon
         did we really land on the moon: we did land on the Moon
         did we actually land on the moon: we did land on the Moon

--- a/share/goodie/historical_events/events.yml
+++ b/share/goodie/historical_events/events.yml
@@ -4,25 +4,25 @@ Holocaust:
     link: https://en.wikipedia.org/wiki/The_Holocaust
     article: the
     queries:
-        is _event_ real: the Holocaust is real
-        is _event_ true: the Holocaust is true
-        was _event_ real: the Holocaust was real
-        was _event_ true: the Holocaust was true
-        did _event_ happen: the Holocaust happened
-        did _event_ really happen: the Holocaust happened
-        did _event_ actually happen: the Holocaust happened
+        is _event_ real: _event_ is real
+        is _event_ true: _event_ is true
+        was _event_ real: _event_ was real
+        was _event_ true: _event_ was true
+        did _event_ happen: _event_ happened
+        did _event_ really happen: _event_ happened
+        did _event_ actually happen: _event_ happened
 
 Moon landing:
     link: https://en.wikipedia.org/wiki/Moon_landing
     article: the
     queries:
-        is _event_ real: the Moon landing is real
-        is _event_ true: the Moon landing is true
-        was _event_ real: the Moon landing was real
-        was _event_ true: the Moon landing was true
-        did _event_ happen: the Moon landing happened
-        did _event_ actually happen: the Moon landing happened
-        did _event_ really happen: the Moon landing happened
+        is _event_ real: _event_ is real
+        is _event_ true: _event_ is true
+        was _event_ real: _event_ was real
+        was _event_ true: _event_ was true
+        did _event_ happen: _event_ happened
+        did _event_ actually happen: _event_ happened
+        did _event_ really happen: _event_ happened
         did we land on the moon: we did land on the Moon
         did we really land on the moon: we did land on the Moon
         did we actually land on the moon: we did land on the Moon

--- a/share/goodie/historical_events/events.yml
+++ b/share/goodie/historical_events/events.yml
@@ -1,35 +1,26 @@
 ---
 # List of historical events, along with Wikipedia link
-holocaust:
+Holocaust:
     link: https://en.wikipedia.org/wiki/The_Holocaust
-    article: the
-    prefixes:
-        is:
-            - 'real'
-            - 'true'
-        was:
-            - 'real'
-            - 'true'
-        did:
-            - 'happen'
-            - 'really happen'
-            - 'actually happen'
-moon landing:
+    queries:
+        is the holocaust real: the Holocaust is real
+        is the holocaust true: the Holocaust is true
+        was the holocaust real: the Holocaust was real
+        was the holocaust true: the Holocaust was true
+        did the holocaust happen: the Holocaust happened
+        did the holocaust really happen: the Holocaust happened
+        did the holocaust actually happen: the Holocaust happened
+
+Moon landing:
     link: https://en.wikipedia.org/wiki/Moon_landing
-    article: the
-    prefixes:
-        is:
-            - 'real'
-            - 'true'
-        was:
-            - 'real'
-            - 'true'
-        did:
-            - 'happen'
-            - 'really happen'
-            - 'actually happen'
-land on the moon:
-    link: https://en.wikipedia.org/wiki/Moon_landing
-    article: we
-    prefixes:
-        did:
+    queries:
+        is the moon landing real: the Moon landing is real
+        is the moon landing true: the Moon landing is true
+        was the moon landing real: the Moon landing was real
+        was the moon landing true: the Moon landing was true
+        did the moon landing happen: the Moon landing happened
+        did the moon landing actually happen: the Moon landing happened
+        did the moon landing really happen: the Moon landing happened
+        did we land on the moon: we did land on the Moon
+        did we really land on the moon: we did land on the Moon
+        did we actually land on the moon: we did land on the Moon

--- a/share/goodie/historical_events/historical_events.css
+++ b/share/goodie/historical_events/historical_events.css
@@ -1,0 +1,3 @@
+.zci--historical_events .c-info__title {
+    font-size: 1.73611rem;
+}

--- a/t/HistoricalEvents.t
+++ b/t/HistoricalEvents.t
@@ -42,6 +42,7 @@ ddg_goodie_test(
     [qw( DDG::Goodie::HistoricalEvents )],
 
     'is the moon landing real'              => build_test('the Moon landing is real', $moon_landing_url),
+    'is the Moon Landing real'              => build_test('the Moon landing is real', $moon_landing_url),
     'was the moon landing real?'            => build_test('the Moon landing was real', $moon_landing_url),
     'did the moon landing happen'           => build_test('the Moon landing happened', $moon_landing_url),
     'did the moon landing really happen'    => build_test('the Moon landing happened', $moon_landing_url),

--- a/t/HistoricalEvents.t
+++ b/t/HistoricalEvents.t
@@ -12,12 +12,12 @@ zci is_cached   => 1;
 sub build_structured_answer {
     my ($subtitle, $link) = @_;
 
-    return "Yes: $link",
+    return "Yes, $subtitle: $link",
         structured_answer => {
 
             data => {
                 title => 'Yes',
-                subtitle => "$subtitle",
+                subtitle => $subtitle,
                 url => $link
             },
 
@@ -41,21 +41,22 @@ my $holocaust_url = "https://en.wikipedia.org/wiki/The_Holocaust";
 ddg_goodie_test(
     [qw( DDG::Goodie::HistoricalEvents )],
 
-    'is the moon landing real'              => build_test('is the moon landing real?', $moon_landing_url),
-    'was the moon landing real?'            => build_test('was the moon landing real?', $moon_landing_url),
-    'did the moon landing happen'           => build_test('did the moon landing happen?', $moon_landing_url),
-    'did the moon landing really happen'    => build_test('did the moon landing really happen?', $moon_landing_url),
-    'did the moon landing actually happen'  => build_test('did the moon landing actually happen?', $moon_landing_url),
+    'is the moon landing real'              => build_test('the Moon landing is real', $moon_landing_url),
+    'was the moon landing real?'            => build_test('the Moon landing was real', $moon_landing_url),
+    'did the moon landing happen'           => build_test('the Moon landing happened', $moon_landing_url),
+    'did the moon landing really happen'    => build_test('the Moon landing happened', $moon_landing_url),
+    'did the moon landing actually happen'  => build_test('the Moon landing happened', $moon_landing_url),
 
-    'did we land on the moon'               => build_test('did we land on the moon?', $moon_landing_url),
-    'did we land on the moon?'              => build_test('did we land on the moon?', $moon_landing_url),
+    'did we land on the moon'               => build_test('we did land on the Moon', $moon_landing_url),
+    'did we land on the moon?'              => build_test('we did land on the Moon', $moon_landing_url),
+    'did we really land on the moon?'       => build_test('we did land on the Moon', $moon_landing_url),
 
 
-    'is the holocaust real'                 => build_test('is the holocaust real?', $holocaust_url),
-    'was the holocaust real?'               => build_test('was the holocaust real?', $holocaust_url),
-    'did the holocaust happen'              => build_test('did the holocaust happen?', $holocaust_url),
-    'did the holocaust really happen'       => build_test('did the holocaust really happen?', $holocaust_url),
-    'did the holocaust actually happen'     => build_test('did the holocaust actually happen?', $holocaust_url),
+    'is the holocaust real'                 => build_test('the Holocaust is real', $holocaust_url),
+    'was the holocaust real?'               => build_test('the Holocaust was real', $holocaust_url),
+    'did the holocaust happen'              => build_test('the Holocaust happened', $holocaust_url),
+    'did the holocaust really happen'       => build_test('the Holocaust happened', $holocaust_url),
+    'did the holocaust actually happen'     => build_test('the Holocaust happened', $holocaust_url),
 
     'when was the holocaust' => undef,
     'is the moon landing a hoax?' => undef,

--- a/t/HistoricalEvents.t
+++ b/t/HistoricalEvents.t
@@ -45,6 +45,7 @@ ddg_goodie_test(
     'was the moon landing real?'            => build_test('the Moon landing was real', $moon_landing_url),
     'did the moon landing happen'           => build_test('the Moon landing happened', $moon_landing_url),
     'did the moon landing really happen'    => build_test('the Moon landing happened', $moon_landing_url),
+    'did moon landing really happen'        => build_test('the Moon landing happened', $moon_landing_url),
     'did the moon landing actually happen'  => build_test('the Moon landing happened', $moon_landing_url),
 
     'did we land on the moon'               => build_test('we did land on the Moon', $moon_landing_url),
@@ -53,8 +54,10 @@ ddg_goodie_test(
 
 
     'is the holocaust real'                 => build_test('the Holocaust is real', $holocaust_url),
+    'is holocaust real'                     => build_test('the Holocaust is real', $holocaust_url),
     'was the holocaust real?'               => build_test('the Holocaust was real', $holocaust_url),
     'did the holocaust happen'              => build_test('the Holocaust happened', $holocaust_url),
+    'did holocaust happen'                  => build_test('the Holocaust happened', $holocaust_url),
     'did the holocaust really happen'       => build_test('the Holocaust happened', $holocaust_url),
     'did the holocaust actually happen'     => build_test('the Holocaust happened', $holocaust_url),
 


### PR DESCRIPTION
## Description of new Instant Answer, or changes
- Improved subtitle to be less redundant
- simplified code, but made the YAML much more verbose
  - we can change this later, but this seems like the simplest solution
- increased font size of title
- allow for triggering with or without articles like `the` in query

## People to notify
@b2ddg @nilnilnil @MariagraziaAlastra 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/historical_events
<!-- FILL THIS IN:                           ^^^^ -->
