### PR TITLE
LinuxCheatSheet: Added Unix as one of the alias

### DIFF
--- a/share/goodie/cheat_sheets/json/linux.json
+++ b/share/goodie/cheat_sheets/json/linux.json
@@ -8,7 +8,8 @@
     },
     "aliases" :[
 	"gnu linux",
-	"gnu/linux"
+	"gnu/linux",
+	"unix"
     ],
     "template_type": "terminal",
     "section_order": [


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Adding unix in alias list.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #3812

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@crashrane 
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/linux_cheat_sheet
<!-- FILL THIS IN:                           ^^^^ -->
