### PR TITLE
udating the link to our new documentation

### DIFF
--- a/share/goodie/cheat_sheets/json/skyscanner-apis.json
+++ b/share/goodie/cheat_sheets/json/skyscanner-apis.json
@@ -5,7 +5,7 @@
 
     "metadata": {
         "sourceName": "Skyscanner API documentation",
-        "sourceUrl" : "http://business.skyscanner.net/portal/en-GB/Documentation/ApiOverview"
+        "sourceUrl" : "http://skyscanner.github.io/slate"
     },
 
     "aliases": [


### PR DESCRIPTION
If this is something else:
Docs: we have released new documentation for our APIs so have updated the link in our IA


## Description of new Instant Answer, or changes
Docs: we have released new documentation for our APIs so have updated the link in our IA


## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
IA page: https://duck.co/ia/view/skyscanner_apis_cheat_sheet