### PR TITLE
Conversions: Adding support for n'm" format

### DIFF
--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -60,9 +60,9 @@ handle query_lc => sub {
     $_ =~ s/"/inches/;
     $_ =~ s/'/feet/;
 
-    if($_ =~ /(\d+)\s*(?:feet|foot)\s*(\d+)\s*inch(?:es)?/){
+    if($_ =~ /(\d+)\s*(?:feet|foot)\s*(\d+)(?:\s*inch(?:es)?)?/){
         my $feetHack = $1 + $2/12;
-        $_ =~ s/(\d+)\s*(?:feet|foot)\s*(\d+)\s*inch(?:es)?/$feetHack feet/;
+        $_ =~ s/(\d+)\s*(?:feet|foot)\s*(\d+)(?:\s*inch(?:es)?)?/$feetHack feet/;
     }
 
     # hack support for "degrees" prefix on temperatures

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -65,11 +65,6 @@ handle query_lc => sub {
         $_ =~ s/(\d+)\s*feet\s*(\d+)\s*inches/$feetHack feet/;
     }
 
-    # hack around issues with feet and inches for now
-    $_ =~ s/"/inches/;
-    $_ =~ s/'/feet/;
-
-    
     # hack support for "degrees" prefix on temperatures
     $_ =~ s/ degree[s]? (centigrade|celsius|fahrenheit|rankine)/ $1/;
     

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -60,9 +60,9 @@ handle query_lc => sub {
     $_ =~ s/"/inches/;
     $_ =~ s/'/feet/;
 
-    if($_ =~ /(\d+)\s*feet\s*(\d+)\s*inches/){
+    if($_ =~ /(\d+)\s*(?:feet|foot)\s*(\d+)\s*inch(?:es)?/){
         my $feetHack = $1 + $2/12;
-        $_ =~ s/(\d+)\s*feet\s*(\d+)\s*inches/$feetHack feet/;
+        $_ =~ s/(\d+)\s*(?:feet|foot)\s*(\d+)\s*inch(?:es)?/$feetHack feet/;
     }
 
     # hack support for "degrees" prefix on temperatures

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -55,10 +55,21 @@ sub magnitude_order {
 my $maximum_input = 10**100;
 
 handle query_lc => sub {
+    
     # hack around issues with feet and inches for now
     $_ =~ s/"/inches/;
     $_ =~ s/'/feet/;
 
+    if($_ =~ /(\d+)\s*feet\s*(\d+)\s*inches/){
+        my $feetHack = $1 + $2/12;
+        $_ =~ s/(\d+)\s*feet\s*(\d+)\s*inches/$feetHack feet/;
+    }
+
+    # hack around issues with feet and inches for now
+    $_ =~ s/"/inches/;
+    $_ =~ s/'/feet/;
+
+    
     # hack support for "degrees" prefix on temperatures
     $_ =~ s/ degree[s]? (centigrade|celsius|fahrenheit|rankine)/ $1/;
     

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -130,6 +130,30 @@ ddg_goodie_test(
             physical_quantity => 'length'
         })
     ),
+    q`6 foot 3 inches in metres` => test_zci(
+        '6.25 feet = 1.905 meters',
+        structured_answer => make_answer({
+            markup_input => '6.25',
+            raw_input => '6.25',
+            from_unit => 'feet',
+            styled_output => '1.905',
+            raw_answer => '1.905',
+            to_unit => 'meters',
+            physical_quantity => 'length'
+        })
+    ),
+    q`6 foot 3 in metres` => test_zci(
+        '6.25 feet = 1.905 meters',
+        structured_answer => make_answer({
+            markup_input => '6.25',
+            raw_input => '6.25',
+            from_unit => 'feet',
+            styled_output => '1.905',
+            raw_answer => '1.905',
+            to_unit => 'meters',
+            physical_quantity => 'length'
+        })
+    ),
     'convert 0.111 stone to pound' => test_zci(
         '0.111 stone = 1.554 pounds',
         structured_answer => make_answer({

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -118,6 +118,18 @@ ddg_goodie_test(
             physical_quantity => 'length'
         })
     ),
+    q`5'7" in inches` => test_zci(
+        '5.583333333333333 feet = 57 inches',
+        structured_answer => make_answer({
+            markup_input => '5.583333333333333',
+            raw_input => '5.583333333333333',
+            from_unit => 'feet',
+            styled_output => '57',
+            raw_answer => '57',
+            to_unit => 'inches',
+            physical_quantity => 'length'
+        })
+    ),
     'convert 5 kelvin to fahrenheit' => test_zci(
         '5 kelvin = -450.670 degrees fahrenheit',
         structured_answer => make_answer({

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -94,6 +94,42 @@ ddg_goodie_test(
             physical_quantity => 'mass'
         })
     ),
+    q`5' 7" in inches` => test_zci(
+        '5.5833333333333333333333333333333333333333 feet = 67 inches',
+        structured_answer => make_answer({
+            markup_input => '5.5833333333333333333333333333333333333333',
+            raw_input => '5.5833333333333333333333333333333333333333',
+            from_unit => 'feet',
+            styled_output => '67',
+            raw_answer => '67',
+            to_unit => 'inches',
+            physical_quantity => 'length'
+        })
+    ),
+    q`5feet 7inches in inches` => test_zci(
+        '5.5833333333333333333333333333333333333333 feet = 67 inches',
+        structured_answer => make_answer({
+            markup_input => '5.5833333333333333333333333333333333333333',
+            raw_input => '5.5833333333333333333333333333333333333333',
+            from_unit => 'feet',
+            styled_output => '67',
+            raw_answer => '67',
+            to_unit => 'inches',
+            physical_quantity => 'length'
+        })
+    ),
+    q`5 feet 7 inches in inches` => test_zci(
+        '5.5833333333333333333333333333333333333333 feet = 67 inches',
+        structured_answer => make_answer({
+            markup_input => '5.5833333333333333333333333333333333333333',
+            raw_input => '5.5833333333333333333333333333333333333333',
+            from_unit => 'feet',
+            styled_output => '67',
+            raw_answer => '67',
+            to_unit => 'inches',
+            physical_quantity => 'length'
+        })
+    ),
     'convert 0.111 stone to pound' => test_zci(
         '0.111 stone = 1.554 pounds',
         structured_answer => make_answer({

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -119,13 +119,13 @@ ddg_goodie_test(
         })
     ),
     q`5'7" in inches` => test_zci(
-        '5.583333333333333 feet = 57 inches',
+        '5.5833333333333333333333333333333333333333 feet = 67 inches',
         structured_answer => make_answer({
-            markup_input => '5.583333333333333',
-            raw_input => '5.583333333333333',
+            markup_input => '5.5833333333333333333333333333333333333333',
+            raw_input => '5.5833333333333333333333333333333333333333',
             from_unit => 'feet',
-            styled_output => '57',
-            raw_answer => '57',
+            styled_output => '67',
+            raw_answer => '67',
             to_unit => 'inches',
             physical_quantity => 'length'
         })

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -106,7 +106,7 @@ ddg_goodie_test(
             physical_quantity => 'length'
         })
     ),
-    q`5feet 7inches in inches` => test_zci(
+    q`5feet 7inch in inches` => test_zci(
         '5.5833333333333333333333333333333333333333 feet = 67 inches',
         structured_answer => make_answer({
             markup_input => '5.5833333333333333333333333333333333333333',
@@ -118,7 +118,7 @@ ddg_goodie_test(
             physical_quantity => 'length'
         })
     ),
-    q`5 feet 7 inches in inches` => test_zci(
+    q`5 foot 7 inches in inches` => test_zci(
         '5.5833333333333333333333333333333333333333 feet = 67 inches',
         structured_answer => make_answer({
             markup_input => '5.5833333333333333333333333333333333333333',


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Introduces support for queries like:
* 5 feet 3 inches in metres
* 6 foot 1 in inches
* 3'6" in cm

## Related Issues and Discussions
fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3875
and fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3433
and fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/1118
but not https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3317 (would be a different PR)

## People to notify
@bsstoner 
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/conversions
