### PR TITLE
ParcelForce: Should not trigger for non-UK parcels

### DIFF
--- a/lib/DDG/Goodie/Parcelforce.pm
+++ b/lib/DDG/Goodie/Parcelforce.pm
@@ -24,7 +24,7 @@ triggers query_nowhitespace_nodash => qr/
 handle query_nowhitespace_nodash => sub {
     my $parcel_number = $+{parcel_number};
 
-    if ($parcel_number && $parcel_number !~ /^(isbn|luhn)/i) {
+    if ($parcel_number && $parcel_number !~ /^(isbn|luhn|kb)/i) {
 
         return $parcel_number,
             heading => 'Parcelforce Tracking',

--- a/lib/DDG/Goodie/Parcelforce.pm
+++ b/lib/DDG/Goodie/Parcelforce.pm
@@ -14,7 +14,7 @@ my $tracking_qr = qr/package|parcel|track(?:ing|)|num(?:ber|)|\#/i;
 
 # note: parcelforce format listed at http://www.parcelforce.com/help-information/frequently-asked-questions/track-parcel#2
 my $parcel
-    = qr/[A-Z]{2}[0-9]{7}|[A-Z]{4}[0-9]{10}|[A-Z]{2}[0-9]{9}GB|[0-9]{12}|[A-Z]{2}[0-9]{9}[A-Z]{2}/i;
+    = qr/[A-Z]{2}[0-9]{7}|[A-Z]{4}[0-9]{10}|[A-Z]{2}[0-9]{9}GB|[0-9]{12}/i;
 triggers query_nowhitespace_nodash => qr/
                                         ^$rm_qr.*?(?<parcel_number>$parcel)$|
                                         ^(?<parcel_number>$parcel).*?$rm_qr$|

--- a/t/Parcelforce.t
+++ b/t/Parcelforce.t
@@ -30,7 +30,8 @@ ddg_goodie_test(
             qq(Track this parcel at <a href="http://www.parcelforce.com/track-trace?trackNumber=PBTM8237263001">Parcelforce</a>.)
     ),
     'luhn 1234554651' => undef,
-    'cc737873589FR' => undef
+    'cc737873589FR' => undef,
+    'KB2553549' => undef
 );
 
 done_testing;

--- a/t/Parcelforce.t
+++ b/t/Parcelforce.t
@@ -29,7 +29,8 @@ ddg_goodie_test(
         html =>
             qq(Track this parcel at <a href="http://www.parcelforce.com/track-trace?trackNumber=PBTM8237263001">Parcelforce</a>.)
     ),
-    'luhn 1234554651' => undef
+    'luhn 1234554651' => undef,
+    'cc737873589FR' => undef
 );
 
 done_testing;


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Works around https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3900 so that only GB$ codes will trigger parcelforce

Same is also true for https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3986 as `^KB\d` is *possibly* a valid parcelforce tracking number, however it's far more likely that that the user is after a Microsoft KB article. 

## Related Issues and Discussions
Fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3900
Fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3986

## People to notify
@bsstoner  @zappe

---

Instant Answer Page: https://duck.co/ia/view/parcelforce

