### PR TITLE
Conversions: Increases threshold before exponent notation

### DIFF
--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -153,7 +153,7 @@ handle query_lc => sub {
 
         # We only display it in exponent form if it's above a certain number.
         # We also want to display numbers from 0 to 1 in exponent form.
-        if($result->{'result'} > 1_000_000 || abs($result->{'result'}) < 1) {
+        if($result->{'result'} > 9_999_999 || abs($result->{'result'}) < 1) {
             $formatted_result = (sprintf "%.${precision}g", $result->{'result'});
         }
     }

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -780,12 +780,12 @@ ddg_goodie_test(
             physical_quantity => 'power'
         })
     ),
-    '10 gigawatt in horsepower' => test_zci(
-        '10 gigawatt = 1.34 * 10^7 horsepower',
+    '10 gigawatts in horsepower' => test_zci(
+        '10 gigawatts = 1.34 * 10^7 horsepower',
         structured_answer => make_answer({
             markup_input => '10',
             raw_input => '10',
-            from_unit => 'gigawatt',
+            from_unit => 'gigawatts',
             styled_output => '1.34 * 10<sup>7</sup>',
             raw_answer => '1.34*10^7',
             to_unit => 'horsepower',

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -2769,7 +2769,7 @@ ddg_goodie_test(
         })
     ),
     '3000 km to m' => test_zci(
-        '3,000 kilometers = 3 * 10^6 meters',
+        '3,000 kilometers = 3,000,000 meters',
 		structured_answer => make_answer({
             markup_input => '3,000',
             raw_input => '3000',
@@ -2805,7 +2805,7 @@ ddg_goodie_test(
         })
     ),
     'how many bytes in a mebibyte?' => test_zci(
-        '1 mebibyte = 1,048,576 megabytes',
+        '1 mebibyte = 1,048,576 bytes',
 		structured_answer => make_answer({
             markup_input => '1',
             raw_input => '1',


### PR DESCRIPTION
My particular concern is:
  When I query: "bytes in 1 mib"
  I want a precise response: "1,048,576 bytes"
  ...instead of "1.05 * 10^6 bytes"

Beyond that, generally, I believe that most people who can cognitively handle numbers up to 1MM can also handle any number with a seven digit integer-part/characteristic (http://math.stackexchange.com/a/64045/92444). Ideally, the decision should be made based on the number of characters in the significand (https://en.wikipedia.org/wiki/Significand) but that's beyond what I have time for at the moment (especially given how rusty my perl is) ;) .

<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->


## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/conversions
