### PR TITLE
POTUS: Triggering is way too keen

### DIFF
--- a/lib/DDG/Goodie/POTUS.pm
+++ b/lib/DDG/Goodie/POTUS.pm
@@ -24,11 +24,11 @@ handle remainder => sub {
       (^who\s+(?<iswas>is|was)\s*(?:the\s*)?(?<num>.*?)$)
       |(^(?<num>.*)$)
     /gix;
-   use Data::Dump qw(dump); 
-    my $num = $+{num}; 
-    warn($num);
-    $num = $prez_count if $num eq "";
-    $num = words2nums($num) if words2nums($num);
+    
+    my $num;
+    $num = $prez_count if $+{num} eq "";
+    $num = $prez_count -1 if $+{num} eq "" and $+{iswas} eq "was";
+    $num = words2nums($+{num}) if words2nums($+{num});
     return unless $num;
 
     my $index = $num - 1;

--- a/lib/DDG/Goodie/POTUS.pm
+++ b/lib/DDG/Goodie/POTUS.pm
@@ -16,15 +16,19 @@ zci is_cached   => 1;
 
 my @presidents = @{LoadFile(share('presidents.yml'))};
 my $prez_count = scalar @presidents;
+my $potus_or_president = qr/(potus|president of the (us|united states))/i;
 
-handle remainder => sub {
+handle query_lc => sub {
     my $rem = shift;
 
-    $rem =~ /
-      (^who\s+(?<iswas>is|was)\s*(?:the\s*)?(?<num>.*?)$)
-      |(^(?<num>.*)$)
-    /gix;
-    
+    # workaround for president-elect of the united states being classed as a trigger
+    $rem =~ s/(^$potus_or_president\s)|(\s$potus_or_president\s?[\?]?$)//i;
+
+    $rem =~ /^
+      (who\s+(?<iswas>is|was)\s*(?:the\s*)?(?<num>.*))
+      |(?<num>.*)
+    $/gix or return;
+
     my $num;
     $num = $prez_count if $+{num} eq "";
     $num = $prez_count -1 if $+{num} eq "" and $+{iswas} eq "was";

--- a/lib/DDG/Goodie/POTUS.pm
+++ b/lib/DDG/Goodie/POTUS.pm
@@ -20,16 +20,15 @@ my $prez_count = scalar @presidents;
 handle remainder => sub {
     my $rem = shift;
 
-    $rem =~ s/
-      |who\s+(is|was)\s*(the\s+)?
-      |^POTUS\s+
-      |\s+(POTUS|president\s+of\s+the\s+united\s+states)$
-      |^(POTUS|president\s+of\s+the\s+united\s+states)\s+
-    //gix;
-
-    my $num = ($rem =~ /^\d+$/);
-    $num = $prez_count if $rem eq "";
-    $num = words2nums($rem) if words2nums($rem);
+    $rem =~ /
+      (^who\s+(?<iswas>is|was)\s*(?:the\s*)?(?<num>.*?)$)
+      |(^(?<num>.*)$)
+    /gix;
+   use Data::Dump qw(dump); 
+    my $num = $+{num}; 
+    warn($num);
+    $num = $prez_count if $num eq "";
+    $num = words2nums($num) if words2nums($num);
     return unless $num;
 
     my $index = $num - 1;

--- a/lib/DDG/Goodie/POTUS.pm
+++ b/lib/DDG/Goodie/POTUS.pm
@@ -19,12 +19,11 @@ my $prez_count = scalar @presidents;
 my $potus_or_president = qr/(potus|president of the (us|united states))/i;
 
 handle query_lc => sub {
-    my $rem = shift;
 
     # workaround for president-elect of the united states being classed as a trigger
-    $rem =~ s/(^$potus_or_president\s)|(\s$potus_or_president\s?[\?]?$)//i;
+    s/(^$potus_or_president\s)|(\s$potus_or_president\s?[\?]?$)//i;
 
-    $rem =~ /^
+    /^
       (who\s+(?<iswas>is|was)\s*(?:the\s*)?(?<num>.*))
       |(?<num>.*)
     $/gix or return;

--- a/lib/DDG/Goodie/POTUS.pm
+++ b/lib/DDG/Goodie/POTUS.pm
@@ -21,13 +21,17 @@ handle remainder => sub {
     my $rem = shift;
     return if $rem =~ /vice/i;
     $rem =~ s/
-      |who\s+(is|was)\s+the\s+
+      |who\s+(is|was)\s*(the\s+)?
       |^POTUS\s+
       |\s+(POTUS|president\s+of\s+the\s+united\s+states)$
       |^(POTUS|president\s+of\s+the\s+united\s+states)\s+
     //gix;
 
-    my $num = ($rem =~ /^\d+$/) ? $rem : words2nums($rem) || $prez_count;
+    my $num = ($rem =~ /^\d+$/);
+    $num = $prez_count if $rem eq "";
+    $num = words2nums($rem) if words2nums($rem);
+    return unless $num;
+
     my $index = $num - 1;
     return if $index < 0 or $index > $#presidents;
 

--- a/lib/DDG/Goodie/POTUS.pm
+++ b/lib/DDG/Goodie/POTUS.pm
@@ -19,7 +19,7 @@ my $prez_count = scalar @presidents;
 
 handle remainder => sub {
     my $rem = shift;
-    return if $rem =~ /vice/i;
+
     $rem =~ s/
       |who\s+(is|was)\s*(the\s+)?
       |^POTUS\s+

--- a/t/POTUS.t
+++ b/t/POTUS.t
@@ -38,6 +38,7 @@ ddg_goodie_test(
     'potus 16' => build_test('Abraham Lincoln', 'was', '16th'),
     'who is the vice president of the united states?' => undef,
     'vice president of the united states' => undef,
+    'who is the worst president of the united states' => undef,
     'VPOTUS' => undef
 );
 

--- a/t/POTUS.t
+++ b/t/POTUS.t
@@ -39,6 +39,8 @@ ddg_goodie_test(
     'who is the vice president of the united states?' => undef,
     'vice president of the united states' => undef,
     'who is the worst president of the united states' => undef,
+    'who is the president elect of the united states' => undef,
+    'who is the president-elect of the us' => undef,
     'VPOTUS' => undef
 );
 

--- a/t/POTUS.t
+++ b/t/POTUS.t
@@ -26,6 +26,8 @@ sub build_test
 
 ddg_goodie_test(
     [qw( DDG::Goodie::POTUS)],
+    'who is the president of the united states' => build_test('Donald J. Trump', 'is',"45th"),
+    'who was the president of the united states' => build_test('Barack Obama', 'was', '44th'),
     'who is president of the united states' => build_test('Donald J. Trump', 'is',"45th"),
     'who is the fourth president of the united states' => build_test('James Madison', 'was', '4th'),
     'who is the nineteenth president of the united states' => build_test('Rutherford B. Hayes', 'was','19th'),


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Fixes https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3760


## Related Issues and Discussions
Unfortunately, the regex isn't actually matching the query, it's replacing bits that we don't need so we can pass the remainder on to `words2nums` to convert. This was defaulting to the current president if it couldn't parse, which basically means it would show the current president for anything that isn't "first" "second" etc i.e. "elect" or "vice".

Whether this is worth fixing or not I'll leave up to the community/staff. If this doesn't work/isn't resliant enough, I'd suggest starting from scratch from a guard regex instead.


## People to notify
@moollaza @bsstoner 

---


Instant Answer Page: https://duck.co/ia/view/potus
