### PR TITLE
Grep Cheat Sheet: Adds file and directory options

### DIFF
--- a/share/goodie/cheat_sheets/json/grep.json
+++ b/share/goodie/cheat_sheets/json/grep.json
@@ -17,10 +17,10 @@
     "section_order": [
         "Basic Usage",
         "Options",
+        "File and directory selection",
+        "Examples",
         "RE Wildcards",
-        "RE Anchors",
-        "Examples"
-        
+        "RE Anchors"
     ],
 
     "sections": {
@@ -168,6 +168,36 @@
             {
                 "key": "grep '$f' example.txt",
                 "val": "Returns all strings which end with 'f' in the file example.txt"
+            }
+        ],
+        "File and directory selection": [
+            {
+                "key": "-a",
+                "val": "Process a binary file as if it were text"
+            },
+            {
+                "key": "-D action",
+                "val": "'If an input file is a device, FIFO, or socket, use 'action' to process it"
+            },
+            {
+                "key": "-d action",
+                "val": "If an input file is a directory, use 'action' to process it"
+            },
+            {
+                "key": "-r",
+                "val": "For each directory operand, read and process all files in that directory, recursively"
+            },
+            {
+                "key": "-R",
+                "val": "For each directory operand, read and process all files in that directory, recursively, following all symbolic links"
+            },
+            {
+                "key": "--exclude=glob",
+                "val": "Skip any command-line file with a name suffix that matches the pattern 'glob', using wildcard matching"
+            },
+            {
+                "key": "--include=glob",
+                "val": "Search only files whose name matches 'glob', using wildcard matching"
             }
         ]
     }


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Adds file and directory options for grep from the [GNU grep manual](https://www.gnu.org/software/grep/manual/grep.html)

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #3944 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@laurengarcia @adityabhushan 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/grep_cheat_sheet
<!-- FILL THIS IN:                           ^^^^ -->