### PR TITLE
Array Sorting Cheat Sheet: Improvements

### DIFF
--- a/share/goodie/cheat_sheets/json/array-sorting.json
+++ b/share/goodie/cheat_sheets/json/array-sorting.json
@@ -1,58 +1,67 @@
 {
     "id": "array_sorting_cheat_sheet",
     "name": "Array Sorting Algorithms",
-    "description": "Summary of Big-O time complexities for Array Sorting Algorithms",
+    "description": "Summary of Big-O time and memory complexities for Array Sorting Algorithms when n = size of array, k = range of elements",
     "metadata": {
         "sourceName": "Wikipedia",
         "sourceUrl": "https://en.wikipedia.org/wiki/Sorting_algorithm"
     },
     "aliases": [
-        "array sorting algorithms", "array sorting algorithm", "sorting complexity"
-
+        "array sorting", "array sorting algorithms", "array sorting algorithm", "sorting complexity", "sorting time complexity", "sorting memory complexity", "sorting algorithmic complexity", "sorting time", "sorting memory", "sorting algorithm",
+        "array sort", "array sort algorithms", "array sort algorithm", "sort complexity", "sort time complexity", "sort memory complexity", "sort algorithmic complexity", "sort time", "sort memory", "sort algorithm"
     ],
     "template_type": "code",
     "section_order": [
         "Quick Sort",
         "Merge Sort",
         "Heap Sort",
-        "Tim Sort",
         "Bubble Sort",
         "Insertion Sort",
         "Selection Sort",
-        "Tree Sort",
-        "Shell Sort",
         "Bucket Sort",
         "Radix Sort",
         "Counting Sort",
+        "Tim Sort",
+        "Shell Sort",
+        "Tree Sort",
+        "Comb Sort",
         "Cube Sort"
     ],
     "sections": {
         "Quick Sort": [
             {
-                "val": "n log( n )",
+                "val": "n ⋅ log( n )",
                 "key": "Best"
             },
             {
-                "val": "n log( n )",
+                "val": "n ⋅ log( n )",
                 "key": "Average"
             },
             {
                 "val": "n²",
                 "key": "Worst"
+            },
+            {
+                "val": "n",
+                "key": "Auxiliary memory"
             }
         ],
         "Merge Sort": [
             {
-                "val": "n log( n )",
+                "val": "n ⋅ log( n )",
                 "key": "Best"
             },
             {
-                "val": "n log( n )",
+                "val": "n ⋅ log( n )",
                 "key": "Average"
             },
             {
-                "val": "n log( n )",
+                "val": "n ⋅ log( n )",
                 "key": "Worst"
+            },
+            {
+                "val": "n",
+                "key": "Auxiliary memory"
             }
         ],
         "Tim Sort": [
@@ -62,25 +71,33 @@
             },
             {
                 "key":"Average",
-                "val":"n log( n )"
+                "val":"n ⋅ log( n )"
             },
             {
                 "key":"Worst",
-                "val":"n log( n )"
+                "val":"n ⋅ log( n )"
+            },
+            {
+                "val": "n",
+                "key": "Auxiliary memory"
             }
         ],
         "Heap Sort": [
             {
-                "val": "n log( n )",
+                "val": "n ⋅ log( n )",
                 "key": "Best"
             },
             {
-                "val": "n log( n )",
+                "val": "n ⋅ log( n )",
                 "key": "Average"
             },
             {
-                "val": "n log( n )",
+                "val": "n ⋅ log( n )",
                 "key": "Worst"
+            },
+            {
+                "val": "Constant",
+                "key": "Auxiliary memory"
             }
         ],
         "Bubble Sort": [
@@ -95,6 +112,10 @@
             {
                 "val": "n²",
                 "key": "Worst"
+            },
+            {
+                "val": "Constant",
+                "key": "Auxiliary memory"
             }
         ],
         "Insertion Sort": [
@@ -109,6 +130,10 @@
             {
                 "val": "n²",
                 "key": "Worst"
+            },
+            {
+                "val": "Constant",
+                "key": "Auxiliary memory"
             }
         ],
         "Selection Sort": [
@@ -123,20 +148,28 @@
             {
                 "val": "n²",
                 "key": "Worst"
+            },
+            {
+                "val": "Constant",
+                "key": "Auxiliary memory"
             }
         ],
         "Tree Sort": [
             {
                 "key":"Best",
-                "val":"n log( n )"
+                "val":"n ⋅ log( n )"
             },
             {
                 "key":"Average",
-                "val":"n log( n )"
+                "val":"n ⋅ log( n )"
             },
             {
                 "key":"Worst",
                 "val":"n²"
+            },
+            {
+                "key":"Auxiliary memory",
+                "val":"n"
             }
         ],
         "Shell Sort": [
@@ -145,12 +178,16 @@
                 "key": "Best"
             },
             {
-                "val": "( n log( n ) )²",
+                "val": "( n ⋅ log( n ) )²",
                 "key": "Average"
             },
             {
-                "val": "( n log( n ) )²",
+                "val": "( n ⋅ log( n ) )²",
                 "key": "Worst"
+            },
+            {
+                "val": "Constant",
+                "key": "Auxiliary memory"
             }
         ],
         "Bucket Sort": [
@@ -165,20 +202,28 @@
             {
                 "val": "n²",
                 "key": "Worst"
+            },
+            {
+                "val": "n ⋅ k",
+                "key": "Auxiliary memory"
             }
         ],
         "Radix Sort": [
             {
-                "val": "nk",
+                "val": "n ⋅ k",
                 "key": "Best"
             },
             {
-                "val": "nk",
+                "val": "n ⋅ k",
                 "key": "Average"
             },
             {
-                "val": "nk",
+                "val": "n ⋅ k",
                 "key": "Worst"
+            },
+            {
+                "val": "n + k",
+                "key": "Auxiliary memory"
             }
         ],
         "Counting Sort": [
@@ -193,6 +238,28 @@
             {
                 "key":"Worst",
                 "val":"n + k"
+            },
+            {
+                "key":"Auxiliary memory",
+                "val":"n + k"
+            }
+        ],
+        "Comb Sort": [
+            {
+                "key":"Best ",
+                "val":"n ⋅ log( n )"
+            },
+            {
+                "key":"Average",
+                "val":"n² / 2ᵖ where p = number of increments"
+            },
+            {
+                "key":"Worst",
+                "val":"n²"
+            },
+            {
+                "key":"Auxiliary memory",
+                "val":"Constant"
             }
         ],
         "Cube Sort": [
@@ -202,11 +269,15 @@
             },
             {
                 "key":"Average",
-                "val":"n log( n )"
+                "val":"n ⋅ log( n )"
             },
             {
                 "key":"Worst",
-                "val":"n log( n )"
+                "val":"n ⋅ log( n )"
+            },
+            {
+                "key":"Auxiliary memory",
+                "val":"n"
             }
         ]
     }

--- a/share/goodie/cheat_sheets/json/array-sorting.json
+++ b/share/goodie/cheat_sheets/json/array-sorting.json
@@ -7,7 +7,7 @@
         "sourceUrl": "https://en.wikipedia.org/wiki/Sorting_algorithm"
     },
     "aliases": [
-        "array sorting", "array sorting algorithms", "array sorting algorithm", "sorting complexity", "sorting time complexity", "sorting memory complexity", "sorting algorithmic complexity", "sorting time", "sorting memory", "sorting algorithm",
+        "array sorting algorithms", "array sorting algorithm", "sorting complexity", "sorting time complexity", "sorting memory complexity", "sorting algorithmic complexity", "sorting time", "sorting memory", "sorting algorithm",
         "array sort", "array sort algorithms", "array sort algorithm", "sort complexity", "sort time complexity", "sort memory complexity", "sort algorithmic complexity", "sort time", "sort memory", "sort algorithm"
     ],
     "template_type": "code",
@@ -246,7 +246,7 @@
         ],
         "Comb Sort": [
             {
-                "key":"Best ",
+                "key":"Best",
                 "val":"n ⋅ log( n )"
             },
             {


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
{IA Name}: {Description of change}

If this is a New Instant Answer:
New {IA Name} Spice

If this is something else:
{Tests/Docs/Other}: {Short Description}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
- Better triggers. The cheat sheet seemed to be seriously under triggering to me.
- Added auxiliary memory complexity to all sorts already in cheat sheet.
- Added information about variables used in description. The information doesn't make a lot of sense without these.
- Re-arranged sorts in order of popularity. Slightly opinionated, order as in wikipedia and GeeksforGeeks page.
- Used multiplication symbol ⋅ to show multiplication properly. Earlier notation seemed unclear.
- Added information about comb sort from [wikipedia](https://en.wikipedia.org/wiki/Comb_sort). 

Note: Someone also needs to modify the description on the IA page.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@mintsoft 
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/array_sorting_cheat_sheet
<!-- FILL THIS IN:                           ^^^^ -->