### PR TITLE
DateRole: Handling 'of' in textual date formats

### DIFF
--- a/lib/DDG/GoodieRole/Dates.pm
+++ b/lib/DDG/GoodieRole/Dates.pm
@@ -352,7 +352,7 @@ sub build_datestring_regex {
     # day-first date formats
     push @regexes, qr#$short_month$date_delim$date_number$date_delim$full_year#i;
     push @regexes, qr#$full_month$date_delim$date_number$date_delim$full_year#i;
-    push @regexes, qr#$date_number[,]?(?: ?$number_suffixes)? (?:$short_month|$full_month)[,]? $full_year#i;
+    push @regexes, qr#$date_number[,]?(?: ?$number_suffixes)? (?:of )?(?:$short_month|$full_month)[,]? $full_year#i;
 
     ## Ambiguous, but potentially valid date formats
     push @regexes, $ambiguous_dates;
@@ -390,7 +390,7 @@ sub parse_formatted_datestring_to_date {
         $d = sprintf('%04d-%02d-%02dT%s%s', $+{'y'}, $short_month_to_number{lc $+{'m'}}, $+{'d'}, $+{'t'}, $tz_offsets{$+{'tz'}});
     }
 
-    $d =~ s/(\d+)\s?$number_suffixes/$1/i;                                       # Strip ordinal text.
+    $d =~ s/(\d+)\s?$number_suffixes(\sof)?/$1/i;                                # Strip ordinal text.
     $d =~ s/,//i;                                                                # Strip any random commas.
     $d =~ s/($full_month)/$full_month_to_short{lc $1}/i;                         # Parser deals better with the shorter month names.
     $d =~ s/^($short_month)$date_delim(\d{1,2})/$2-$short_month_fix{lc $1}/i;    # Switching Jun-01-2012 to 01 Jun 2012

--- a/lib/DDG/GoodieRole/Dates.pm
+++ b/lib/DDG/GoodieRole/Dates.pm
@@ -347,7 +347,7 @@ sub build_datestring_regex {
     # month-first date formats
     push @regexes, qr#$date_number$date_delim$short_month$date_delim$full_year#i;
     push @regexes, qr#$date_number$date_delim$full_month$date_delim$full_year#i;
-    push @regexes, qr#(?:$short_month|$full_month) $date_number(?: ?$number_suffixes)?[,]? $full_year#i;
+    push @regexes, qr#(?:$short_month|$full_month) (?:the )?$date_number(?: ?$number_suffixes)?[,]? $full_year#i;
 
     # day-first date formats
     push @regexes, qr#$short_month$date_delim$date_number$date_delim$full_year#i;
@@ -391,7 +391,7 @@ sub parse_formatted_datestring_to_date {
     }
 
     $d =~ s/(\d+)\s?$number_suffixes/$1/i;                                       # Strip ordinal text.
-    $d =~ s/\sof\s/ /i;                                                          # Strip "of" for 4th of march
+    $d =~ s/(\sof\s)|(\sthe\s)/ /i;                                                          # Strip "of" for "4th of march" and "the" for "march the 4th"
     $d =~ s/,//i;                                                                # Strip any random commas.
     $d =~ s/($full_month)/$full_month_to_short{lc $1}/i;                         # Parser deals better with the shorter month names.
     $d =~ s/^($short_month)$date_delim(\d{1,2})/$2-$short_month_fix{lc $1}/i;    # Switching Jun-01-2012 to 01 Jun 2012

--- a/lib/DDG/GoodieRole/Dates.pm
+++ b/lib/DDG/GoodieRole/Dates.pm
@@ -390,7 +390,8 @@ sub parse_formatted_datestring_to_date {
         $d = sprintf('%04d-%02d-%02dT%s%s', $+{'y'}, $short_month_to_number{lc $+{'m'}}, $+{'d'}, $+{'t'}, $tz_offsets{$+{'tz'}});
     }
 
-    $d =~ s/(\d+)\s?$number_suffixes(\sof)?/$1/i;                                # Strip ordinal text.
+    $d =~ s/(\d+)\s?$number_suffixes/$1/i;                                       # Strip ordinal text.
+    $d =~ s/\sof\s/ /i;                                                          # Strip "of" for 4th of march
     $d =~ s/,//i;                                                                # Strip any random commas.
     $d =~ s/($full_month)/$full_month_to_short{lc $1}/i;                         # Parser deals better with the shorter month names.
     $d =~ s/^($short_month)$date_delim(\d{1,2})/$2-$short_month_fix{lc $1}/i;    # Switching Jun-01-2012 to 01 Jun 2012

--- a/t/00-roles.t
+++ b/t/00-roles.t
@@ -133,6 +133,7 @@ subtest 'Dates' => sub {
             '2038-01-20'        => 2147558400,     # 32-bit signed int UNIX epoch ends 2038-01-19
             '1780-01-20'        => -5994172800,    # Way before 32-bit signed int epoch
             '5th of january 1993' => 726192000,
+            '5 of jan 1993'     => 726192000,
         );
 
         foreach my $test_date (sort keys %dates_to_match) {

--- a/t/00-roles.t
+++ b/t/00-roles.t
@@ -134,6 +134,7 @@ subtest 'Dates' => sub {
             '1780-01-20'        => -5994172800,    # Way before 32-bit signed int epoch
             '5th of january 1993' => 726192000,
             '5 of jan 1993'     => 726192000,
+            'june the 1st 2012' => 1338508800,
         );
 
         foreach my $test_date (sort keys %dates_to_match) {

--- a/t/00-roles.t
+++ b/t/00-roles.t
@@ -132,6 +132,7 @@ subtest 'Dates' => sub {
             '29 feb, 2012'      => 1330473600,
             '2038-01-20'        => 2147558400,     # 32-bit signed int UNIX epoch ends 2038-01-19
             '1780-01-20'        => -5994172800,    # Way before 32-bit signed int epoch
+            '5th of january 1993' => 726192000,
         );
 
         foreach my $test_date (sort keys %dates_to_match) {


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Adds handling for dates in the format `7th of march 2017`. Also as a *bonus* adds `march the 7th 2017`

## Related Issues and Discussions
Related: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3980

## People to notify
@bsstoner @Mailkov 
