### PR TITLE
Conversions: Improving triggering for degrees [cf]

### DIFF
--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -1303,6 +1303,7 @@ plural: poundals
 aliases:
   - f
   - °f
+  - degrees f
 can_be_negative: 1
 factor: 1
 type: temperature
@@ -1313,6 +1314,7 @@ aliases:
   - c
   - °c
   - centigrade
+  - degrees c
 can_be_negative: 1
 factor: 1
 type: temperature

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -198,7 +198,19 @@ ddg_goodie_test(
             from_unit => 'kelvin',
             styled_output => '-450.670',
             raw_answer => '-450.670',
-			to_unit => 'degrees fahrenheit',
+            to_unit => 'degrees fahrenheit',
+            physical_quantity => 'temperature'
+        })
+    ),
+    '65 degrees c to f' => test_zci(
+        '65 degrees celsius = 149 degrees fahrenheit',
+        structured_answer => make_answer({
+            markup_input => '65',
+            raw_input => '65',
+            from_unit => 'degrees celsius',
+            styled_output => '149',
+            raw_answer => '149',
+            to_unit => 'degrees fahrenheit',
             physical_quantity => 'temperature'
         })
     ),

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -214,6 +214,30 @@ ddg_goodie_test(
             physical_quantity => 'temperature'
         })
     ),
+    '65 degrees c to degrees f' => test_zci(
+        '65 degrees celsius = 149 degrees fahrenheit',
+        structured_answer => make_answer({
+            markup_input => '65',
+            raw_input => '65',
+            from_unit => 'degrees celsius',
+            styled_output => '149',
+            raw_answer => '149',
+            to_unit => 'degrees fahrenheit',
+            physical_quantity => 'temperature'
+        })
+    ),
+    '65 c to degrees f' => test_zci(
+        '65 degrees celsius = 149 degrees fahrenheit',
+        structured_answer => make_answer({
+            markup_input => '65',
+            raw_input => '65',
+            from_unit => 'degrees celsius',
+            styled_output => '149',
+            raw_answer => '149',
+            to_unit => 'degrees fahrenheit',
+            physical_quantity => 'temperature'
+        })
+    ),
     'light year to mm' => test_zci(
         '1 light year = 9.46073 * 10^18 millimeters',
         structured_answer => make_answer({


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Previously `convert 65 c to f` worked however `convert 65 degrees c to f` didn't. This remedies that :)


## Related Issues and Discussions
Fixes: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3918

## People to notify
@bsstoner 

<!-- DO NOT REMOVE -->
---

Instant Answer Page: https://duck.co/ia/view/conversions
