### PR TITLE
Conversions: Case sensitive Units/Symbol handling

### DIFF
--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -74,7 +74,7 @@ handle query => sub {
     $_ =~ s/ degree[s]? (centigrade|celsius|fahrenheit|rankine)/ $1/i;
     
     # hack - convert "oz" to "fl oz" if "ml" contained in query
-    s/(oz|ounces)/fl oz/i if(/(ml|cup[s]?)/i && not /fl oz/i);
+    s/(oz|ounces)/fl oz/i if(/(ml|cup[s]?|litre|liter|gallon|pint)/i && not /fl oz/i);
 
     # guard the query from spurious matches
     return unless $_ =~ /$guard/;

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -14,7 +14,7 @@ use List::Util qw(any);
 zci answer_type => 'conversions';
 zci is_cached   => 1;
 
-#use bignum;
+use bignum;
 
 my @types = LoadFile(share('ratios.yml'));
 

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -25,6 +25,7 @@ foreach my $type (@types) {
     push(@units, $type->{'unit'});
     push(@units, $type->{'plural'}) unless lc $type->{'unit'} eq lc $type->{'plural'};
     push(@units, @{$type->{'aliases'}});
+    push(@units, $type->{'symbol'}) if $type->{'symbol'};
     $unit_to_plural{lc $type->{'unit'}} = $type->{'plural'};
     $plural_to_unit{lc $type->{'plural'}} = $type->{'unit'};
 }
@@ -73,10 +74,10 @@ handle query => sub {
     
     # hack - convert "oz" to "fl oz" if "ml" contained in query
     s/(oz|ounces)/fl oz/i if(/(ml|cup[s]?)/i && not /fl oz/i);
-    
+	warn "pre-guard '$_'";
     # guard the query from spurious matches
     return unless $_ =~ /$guard/;
-    
+	warn "post-guard '$_'";
     my @matches = ($+{'left_unit'}, $+{'right_unit'});
     return if ("" ne $+{'left_num'} && "" ne $+{'right_num'});
     my $factor = $+{'left_num'};

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -36,7 +36,7 @@ triggers any => @triggers;
 
 # match longest possible key (some keys are sub-keys of other keys):
 my $keys = join '|', map { quotemeta $_ } reverse sort { length($a) <=> length($b) } @units;
-my $question_prefix = qr/(?<prefix>convert|what (?:is|are|does)|how (?:much|many|long) (?:is|are)?|(?:number of)|(?:how to convert))?/;
+my $question_prefix = qr/(?<prefix>convert|what (?:is|are|does)|how (?:much|many|long) (?:is|are)?|(?:number of)|(?:how to convert))?/i;
 
 # guards and matches regex
 my $factor_re = join('|', ('a', 'an', number_style_regex()));
@@ -57,22 +57,22 @@ sub magnitude_order {
 }
 my $maximum_input = 10**100;
 
-handle query_lc => sub {
+handle query => sub {
     
     # hack around issues with feet and inches for now
     $_ =~ s/"/inches/;
     $_ =~ s/'/feet/;
 
-    if($_ =~ /(\d+)\s*(?:feet|foot)\s*(\d+)(?:\s*inch(?:es)?)?/){
+    if($_ =~ /(\d+)\s*(?:feet|foot)\s*(\d+)(?:\s*inch(?:es)?)?/i){
         my $feetHack = $1 + $2/12;
-        $_ =~ s/(\d+)\s*(?:feet|foot)\s*(\d+)(?:\s*inch(?:es)?)?/$feetHack feet/;
+        $_ =~ s/(\d+)\s*(?:feet|foot)\s*(\d+)(?:\s*inch(?:es)?)?/$feetHack feet/i;
     }
 
     # hack support for "degrees" prefix on temperatures
-    $_ =~ s/ degree[s]? (centigrade|celsius|fahrenheit|rankine)/ $1/;
+    $_ =~ s/ degree[s]? (centigrade|celsius|fahrenheit|rankine)/ $1/i;
     
     # hack - convert "oz" to "fl oz" if "ml" contained in query
-    s/(oz|ounces)/fl oz/ if(/(ml|cup[s]?)/ && not /fl oz/);
+    s/(oz|ounces)/fl oz/i if(/(ml|cup[s]?)/i && not /fl oz/i);
     
     # guard the query from spurious matches
     return unless $_ =~ /$guard/;
@@ -126,7 +126,7 @@ handle query_lc => sub {
         $factor = $+{'right_num'};
         @matches = ($matches[1], $matches[0]);
     }
-    $factor = 1 if ($factor =~ qr/^(a[n]?)?$/);
+    $factor = 1 if ($factor =~ qr/^(a[n]?)?$/i);
 
     my $styler = number_style_for($factor);
     return unless $styler;

--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -1,4 +1,4 @@
----
+﻿---
 aliases:
   - tonne
   - mt

--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -1,7 +1,6 @@
 ---
 aliases:
   - tonne
-  - t
   - mt
   - te
   - metric tonnes
@@ -12,18 +11,18 @@ aliases:
 factor: 1
 type: mass
 unit: metric ton
+symbol: t
 plural: metric tons
 ---
 aliases:
-  - oz
   - ozs
 factor: 35274
 type: mass
 unit: ounce
+symbol: oz
 plural: ounces
 ---
 aliases:
-  - lb
   - lbm
   - pound mass
   - lbs
@@ -32,15 +31,16 @@ aliases:
 factor: 2204.62
 type: mass
 unit: pound
+symbol: lb
 plural: pounds
 ---
 aliases:
-  - st
   - stones
   - sts
 factor: 157.473
 type: mass
 unit: stone
+symbol: st
 plural: stone
 ---
 aliases:
@@ -55,7 +55,6 @@ unit: long ton
 plural: long tons
 ---
 aliases:
-  - kg
   - kilo
   - kilogramme
   - kgs
@@ -64,26 +63,26 @@ aliases:
 factor: 1000
 type: mass
 unit: kilogram
+symbol: kg
 plural: kilograms
 ---
 aliases:
-  - hg
   - hgs
 factor: 10000
 type: mass
 unit: hectogram
+symbol: hg
 plural: hectograms
 ---
 aliases:
-  - dag
   - dags
 factor: 100000
 type: mass
 unit: decagram
+symbol: dag
 plural: decagrams
 ---
 aliases:
-  - g
   - gm
   - gramme
   - gs
@@ -92,39 +91,40 @@ aliases:
 factor: 1000000
 type: mass
 unit: gram
+symbol: g
 plural: grams
 ---
 aliases:
-  - dg
   - dgs
 factor: 10000000
 type: mass
 unit: decigram
+symbol: dg
 plural: decigrams
 ---
 aliases:
-  - cg
   - cgs
 factor: 100000000
 type: mass
 unit: centigram
+symbol: cg
 plural: centigrams
 ---
 aliases:
-  - mg
   - mgs
 factor: 1000000000
 type: mass
 unit: milligram
+symbol: mg
 plural: milligrams
 ---
 aliases:
   - mcg
   - mcgs
-  - µg
 factor: 1000000000000
 type: mass
 unit: microgram
+symbol: µg
 plural: micrograms
 ---
 aliases:
@@ -150,6 +150,7 @@ aliases:
 factor: 5000000
 type: mass
 unit: carat
+symbol: ct
 plural: carats
 ---
 aliases:
@@ -161,97 +162,98 @@ aliases:
 factor: 564383.3912
 type: mass
 unit: dram avoirdupois
+symbol: dr
 plural: drams avoirdupois
 ---
 aliases:
   - metre
   - metres
-  - m
 factor: 1
 type: length
 unit: meter
+symbol: m
 plural: meters
 ---
 aliases:
   - megametre
   - megametres
-  - Mm
   - Mms
 factor: 0.000001
 type: length
 unit: megameter
+symbol: Mm
 plural: megameters
 ---
 aliases:
   - kilometre
   - kilometres
-  - km
   - kms
   - klick
   - klicks
 factor: 0.001
 type: length
 unit: kilometer
+symbol: km
 plural: kilometers
 ---
 aliases:
   - hectometre
   - hectometres
-  - hm
   - hms
 factor: 0.01
 type: length
 unit: hectometer
+symbol: hm
 plural: hectometers
 ---
 aliases:
   - decametre
   - decametres
-  - dam
   - dams
 factor: 0.1
 type: length
 unit: decameter
+symbol: dam
 plural: decameters
 ---
 aliases:
   - decimetre
   - decimetres
-  - dm
   - dms
 factor: 10
 type: length
 unit: decimeter
+symbol: dm
 plural: decimeters
 ---
 aliases:
   - centimetre
   - centimetres
-  - cm
   - cms
 factor: 100
 type: length
 unit: centimeter
+symbol: cm
 plural: centimeters
 ---
 aliases:
   - millimetre
   - millimetres
-  - mm
   - mms
 factor: 1000
 type: length
 unit: millimeter
+symbol: mm
 plural: millimeters
 ---
 aliases:
   - micrometre
   - micrometres
-  - µm
   - µms
 factor: 1e06
 type: length
 unit: micrometer
+symbol: µm
 plural: micrometers
 ---
 aliases:
@@ -260,16 +262,17 @@ aliases:
 factor: 1e09
 type: length
 unit: nanometer
+symbol: nm
 plural: nanometers
 ---
 aliases:
   - picometre
   - picometres
-  - pm
   - pms
 factor: 1e12
 type: length
 unit: picometer
+symbol: pm
 plural: picometers
 ---
 aliases:
@@ -295,12 +298,12 @@ unit: mile
 plural: miles
 ---
 aliases:
-  - yd
   - yds
   - yrds
 factor: 1.0936132983377077865266841644794
 type: length
 unit: yard
+symbol: yd
 plural: yards
 ---
 aliases:
@@ -312,6 +315,7 @@ aliases:
 factor: 3.2808398950131233595800524934383
 type: length
 unit: foot
+symbol: '
 plural: feet
 ---
 aliases:
@@ -320,18 +324,18 @@ aliases:
 factor: 39.37007874015748031496062992126
 type: length
 unit: inch
+symbol: "
 plural: inches
 ---
 aliases:
   - n
-  - ns
-  - nm
   - nms
   - nmi
   - nmis
 factor: 0.000539957
 type: length
 unit: nautical mile
+symbol: M
 plural: nautical miles
 ---
 aliases:
@@ -383,33 +387,32 @@ unit: cable
 plural: cables
 ---
 aliases:
-  - ly
   - lys
   - lightyear
   - lightyears
 factor: 1.05700083402462e-16
 type: length
 unit: light year
+symbol: ly
 plural: light years
 ---
 aliases:
-  - pc
   - pcs
 factor: 3.24077923047971e-17
 type: length
 unit: parsec
+symbol: pc
 plural: parsecs
 ---
 aliases:
-  - au
   - aus
 factor: 6.68458712226845e-12
 type: length
 unit: astronomical unit
+symbol: au
 plural: astronomical units
 ---
 aliases:
-  - ha
   - square hectometre
   - square hectometres
   - square hectometer
@@ -417,6 +420,7 @@ aliases:
 factor: 1
 type: area
 unit: hectare
+symbol: ha
 plural: hectares
 ---
 aliases: []
@@ -429,20 +433,20 @@ aliases:
   - square kilometre
   - square kilometres
   - km^2
-  - km²
 factor: 0.01
 type: area
 unit: square kilometer
+symbol: km²
 plural: square kilometers
 ---
 aliases:
   - square decametre
   - square decametres
   - dam^2
-  - dam²
 factor: 100
 type: area
 unit: square decameter
+symbol: dam²
 plural: square decameters
 ---
 aliases:
@@ -453,40 +457,40 @@ aliases:
   - square metre
   - square metres
   - m^2
-  - m²
 factor: 10000
 type: area
 unit: square meter
+symbol: m²
 plural: square meters
 ---
 aliases:
   - square decimetre
   - square decimetres
   - dm^2
-  - dm²
 factor: 1000000
 type: area
 unit: square decimeter
+symbol: dm²
 plural: square decimeters
 ---
 aliases:
   - square centimetre
   - square centimetres
   - cm^2
-  - cm²
 factor: 100000000
 type: area
 unit: square centimeter
+symbol: cm²
 plural: square centimeters
 ---
 aliases:
   - square millimetre
   - square millimetres
   - mm^2
-  - mm²
 factor: 10000000000
 type: area
 unit: square millimeter
+symbol: mm²
 plural: square millimeters
 ---
 aliases:
@@ -508,12 +512,12 @@ aliases:
   - yards²
   - yards^2
   - yd^2
-  - yd²
   - yrd^2
   - yrd²
 factor: 11959.9
 type: area
 unit: square yard
+symbol: yd²
 plural: square yards
 ---
 aliases:
@@ -544,6 +548,7 @@ aliases:
 factor: 3024.80338778
 type: area
 unit: 坪
+symbol: 坪
 plural: 坪
 ---
 aliases:
@@ -555,6 +560,7 @@ aliases:
 factor: 1
 type: volume
 unit: litre
+symbol: L
 plural: litres
 ---
 aliases:
@@ -564,6 +570,7 @@ aliases:
 factor: 0.01
 type: volume
 unit: hectolitre
+symbol: hL
 plural: hectolitres
 ---
 aliases:
@@ -573,6 +580,7 @@ aliases:
 factor: 0.1
 type: volume
 unit: decalitre
+symbol: daL
 plural: decalitres
 ---
 aliases:
@@ -582,6 +590,7 @@ aliases:
 factor: 10
 type: volume
 unit: decilitre
+symbol: dL
 plural: decilitres
 ---
 aliases:
@@ -591,6 +600,7 @@ aliases:
 factor: 100
 type: volume
 unit: centilitre
+symbol: cL
 plural: centilitres
 ---
 aliases:
@@ -600,6 +610,7 @@ aliases:
 factor: 1000
 type: volume
 unit: millilitre
+symbol: mL
 plural: millilitres
 ---
 aliases:
@@ -621,10 +632,10 @@ aliases:
   - metres^3
   - meters^3
   - m^3
-  - m³
 factor: 0.001
 type: volume
 unit: cubic metre
+symbol: m³
 plural: cubic metres
 ---
 aliases:
@@ -633,12 +644,12 @@ aliases:
   - centimetres^3
   - centimeters^3
   - cm^3
-  - cm³
   - cc
   - ccm
 factor: 1000
 type: volume
 unit: cubic centimeter
+symbol: cm³
 plural: cubic centimeters
 ---
 aliases:
@@ -649,10 +660,10 @@ aliases:
   - millimetres^3
   - millimeters^3
   - mm^3
-  - mm³
 factor: 1000000
 type: volume
 unit: cubic millimeter
+symbol: mm³
 plural: cubic millimeters
 ---
 aliases:
@@ -803,62 +814,62 @@ aliases:
   - days
   - dy
   - dys
-  - d
 factor: 1
 type: duration
 unit: day
+symbol: d
 plural: days
 ---
 aliases:
   - sec
-  - s
 factor: 86400
 type: duration
 unit: second
+symbol: s
 plural: seconds
 ---
 aliases:
   - millisec
   - millisecs
-  - ms
 factor: 86400000
 type: duration
 unit: millisecond
+symbol: ms
 plural: milliseconds
 ---
 aliases:
   - microsec
   - microsecs
-  - µs
 factor: 86400000000
 type: duration
 unit: microsecond
+symbol: µs
 plural: microseconds
 ---
 aliases:
   - nanosec
   - nanosecs
-  - ns
 factor: 86400000000000
 type: duration
 unit: nanosecond
+symbol: ns
 plural: nanoseconds
 ---
 aliases:
-  - min
   - mins
 factor: 1440
 type: duration
 unit: minute
+symbol: min
 plural: minutes
 ---
 aliases:
   - hr
   - hrs
-  - h
 factor: 24
 type: duration
 unit: hour
+symbol: h
 plural: hours
 ---
 aliases:
@@ -890,6 +901,7 @@ aliases:
 factor: 0.00273972602739726
 type: duration
 unit: year
+symbol: a
 plural: years
 ---
 aliases: []
@@ -920,37 +932,37 @@ unit: leap year
 plural: leap years
 ---
 aliases:
-  - pa
   - pas
 factor: 1
 type: pressure
 unit: pascal
+symbol: Pa
 plural: pascals
 ---
 aliases:
-  - kpa
   - kpas
 factor: 0.001
 type: pressure
 unit: kilopascal
+symbol: kPa
 plural: kilopascals
 ---
 aliases:
   - megapa
   - megapas
-  - mpa
   - mpas
 factor: 1e-06
 type: pressure
 unit: megapascal
+symbol: MPa
 plural: megapascals
 ---
 aliases:
-  - gpa
   - gpas
 factor: 1e-09
 type: pressure
 unit: gigapascal
+symbol: GPa
 plural: gigapascals
 ---
 aliases: []
@@ -983,6 +995,7 @@ aliases:
 factor: 0.00750061683
 type: pressure
 unit: mmHg
+symbol: mmHg
 plural: mmHg
 ---
 aliases: []
@@ -992,38 +1005,38 @@ unit: torr
 plural: torr
 ---
 aliases:
-  - j
   - js
 factor: 1
 type: energy
 unit: joule
+symbol: J
 plural: joules
 ---
 aliases:
   - watt second
   - watt seconds
-  - ws
 factor: 1
 type: energy
 unit: watt-second
+symbol: Ws
 plural: watt-seconds
 ---
 aliases:
   - watt hour
   - watt hours
-  - wh
 factor: 0.000277777777777778
 type: energy
 unit: watt-hour
+symbol: Wh
 plural: watt-hours
 ---
 aliases:
   - kilowatt hour
   - kilowatt hours
-  - kwh
 factor: 2.77777777777778e-07
 type: energy
 unit: kilowatt-hour
+symbol: kWh
 plural: kilowatt-hours
 ---
 aliases:
@@ -1037,11 +1050,11 @@ plural: ergs
 aliases:
   - electronvolt
   - electronvolts
-  - ev
   - evs
 factor: 6.2415096e+18
 type: energy
 unit: electron volt
+symbol: eV
 plural: electron volts
 ---
 aliases:
@@ -1051,6 +1064,7 @@ aliases:
 factor: 0.239005736137667
 type: energy
 unit: thermochemical gram calorie
+symbol: cal
 plural: thermochemical gran calories
 ---
 aliases:
@@ -1061,14 +1075,15 @@ aliases:
 factor: 0.000239005736137667
 type: energy
 unit: large calorie
+symbol: Cal
 plural: large calories
 ---
 aliases:
-  - btu
   - btus
 factor: 0.000948316737790422
 type: energy
 unit: british thermal unit
+symbol: BTU
 plural: british thermal units
 ---
 aliases:
@@ -1080,53 +1095,54 @@ type: energy
 unit: ton of TNT
 plural: tons of TNT
 ---
-aliases:
-  - w
+aliases: []
 factor: 1
 type: power
 unit: watt
+symbol: W
 plural: watts
 ---
-aliases:
-  - kw
+aliases: []
 factor: 0.001
 type: power
 unit: kilowatt
+symbol: kW
 plural: kilowatts
 ---
-aliases:
-  - mw
+aliases: []
 factor: 1e-06
 type: power
 unit: megawatt
+symbol: MW
 plural: megawatts
 ---
 aliases:
   - jiggawatts
-  - gw
 factor: 1e-09
 type: power
 unit: gigawatt
+symbol: GW
 plural: gigawatts
 ---
-aliases:
-  - tw
+aliases: []
 factor: 1e-12
 type: power
 unit: terawatt
+symbol: TW
 plural: terawatts
 ---
-aliases:
-  - pw
+aliases: []
 factor: 1e-15
 type: power
 unit: petawatt
+symbol: PW
 plural: petawatts
 ---
 aliases: []
 factor: 1000
 type: power
 unit: milliwatt
+symbol: mW
 plural: milliwatts
 ---
 aliases:
@@ -1134,27 +1150,27 @@ aliases:
 factor: 1000000
 type: power
 unit: microwatt
+symbol: μW
 plural: microwatts
 ---
-aliases:
-  - nw
+aliases: []
 factor: 1000000000
 type: power
 unit: nanowatt
+symbol: nW
 plural: nanowatts
 ---
-aliases:
-  - pw
+aliases: []
 factor: 1000000000000
 type: power
 unit: picowatt
+symbol: pW
 plural: picowatts
 ---
 aliases:
   - metric horsepowers
   - mhp
   - hp
-  - ps
   - cv
   - hk
   - ks
@@ -1162,6 +1178,7 @@ aliases:
 factor: 0.0013596216173039
 type: power
 unit: metric horsepower
+symbol: PS
 plural: metric horsepower
 ---
 aliases:
@@ -1190,14 +1207,15 @@ aliases:
 factor: 1
 type: angle
 unit: degree
+symbol: °
 plural: degrees
 ---
 aliases:
-  - rad
   - rads
 factor: 0.0174532925199433
 type: angle
 unit: radian
+symbol: rad
 plural: radians
 ---
 aliases:
@@ -1239,32 +1257,32 @@ type: angle
 unit: revolution
 plural: revolutions
 ---
-aliases:
-  - n
+aliases: []
 factor: 1
 type: force
 unit: newton
+symbol: N
 plural: newtons
 ---
-aliases:
-  - kn
+aliases: []
 factor: 0.001
 type: force
 unit: kilonewtons
+symbol: kN
 plural: kilonewtons
 ---
-aliases:
-  - mn
+aliases: []
 factor: 1e-06
 type: force
 unit: meganewton
+symbol: MN
 plural: meganewtons
 ---
-aliases:
-  - gn
+aliases: []
 factor: 1e-09
 type: force
 unit: giganewton
+symbol: GN
 plural: giganewtons
 ---
 aliases: []
@@ -1302,30 +1320,30 @@ plural: poundals
 ---
 aliases:
   - f
-  - °f
   - degrees f
 can_be_negative: 1
 factor: 1
 type: temperature
 unit: fahrenheit
+symbol: °f
 plural: fahrenheit
 ---
 aliases:
   - c
-  - °c
   - centigrade
   - degrees c
 can_be_negative: 1
 factor: 1
 type: temperature
 unit: celsius
+symbol: °c
 plural: celsius
 ---
-aliases:
-  - k
+aliases: []
 factor: 1
 type: temperature
 unit: kelvin
+symbol: K
 plural: kelvin
 ---
 aliases:
@@ -1333,6 +1351,7 @@ aliases:
 factor: 1
 type: temperature
 unit: rankine
+symbol: °Ra
 plural: rankine
 ---
 aliases:
@@ -1341,12 +1360,14 @@ can_be_negative: 1
 factor: 1
 type: temperature
 unit: reaumur
+symbol: °Re
 plural: reamur
 ---
 aliases: []
 factor: 1
 type: digital
 unit: bit
+symbol: b
 plural: bits
 ---
 aliases:
@@ -1355,6 +1376,7 @@ aliases:
 factor: 0.001
 type: digital
 unit: kilobit
+symbol: kb
 plural: kilobits
 ---
 aliases:
@@ -1363,6 +1385,7 @@ aliases:
 factor: 1e-06
 type: digital
 unit: megabit
+symbol: Mb
 plural: megabits
 ---
 aliases:
@@ -1371,6 +1394,7 @@ aliases:
 factor: 1e-09
 type: digital
 unit: gigabit
+symbol: Gb
 plural: gigabits
 ---
 aliases:
@@ -1379,6 +1403,7 @@ aliases:
 factor: 1e-12
 type: digital
 unit: terabit
+symbol: Tb
 plural: terabits
 ---
 aliases:
@@ -1387,6 +1412,7 @@ aliases:
 factor: 1e-15
 type: digital
 unit: petabit
+symbol: Pb
 plural: petabits
 ---
 aliases:
@@ -1395,6 +1421,7 @@ aliases:
 factor: 1e-18
 type: digital
 unit: exabit
+symbol: Eb
 plural: exabits
 ---
 aliases:
@@ -1403,6 +1430,7 @@ aliases:
 factor: 1e-21
 type: digital
 unit: zettabit
+symbol: Zb
 plural: zettabits
 ---
 aliases:
@@ -1411,6 +1439,7 @@ aliases:
 factor: 1e-24
 type: digital
 unit: yottabit
+symbol: Yb
 plural: yottabits
 ---
 aliases:
@@ -1419,6 +1448,7 @@ aliases:
 factor: 0.0009765625
 type: digital
 unit: kibibit
+symbol: kib
 plural: kibibits
 ---
 aliases:
@@ -1427,6 +1457,7 @@ aliases:
 factor: 9.5367431640625e-07
 type: digital
 unit: mebibit
+symbol: Mib
 plural: mebibits
 ---
 aliases:
@@ -1435,6 +1466,7 @@ aliases:
 factor: 9.31322574615479e-10
 type: digital
 unit: gibibit
+symbol: Gib
 plural: gibibits
 ---
 aliases:
@@ -1443,6 +1475,7 @@ aliases:
 factor: 9.09494701772928e-13
 type: digital
 unit: tebibit
+symbol:Tib
 plural: tebibits
 ---
 aliases:
@@ -1451,6 +1484,7 @@ aliases:
 factor: 8.88178419700125e-16
 type: digital
 unit: pebibit
+symbol: Pib
 plural: pebibits
 ---
 aliases:
@@ -1459,6 +1493,7 @@ aliases:
 factor: 8.67361737988404e-19
 type: digital
 unit: exbibit
+symbol: Eib
 plural: exbibits
 ---
 aliases:
@@ -1467,6 +1502,7 @@ aliases:
 factor: 8.470329472543e-22
 type: digital
 unit: zebibit
+symbol: Zib
 plural: zebibits
 ---
 aliases:
@@ -1475,140 +1511,142 @@ aliases:
 factor: 8.27180612553028e-25
 type: digital
 unit: yobibit
+symbol: Yib
 plural: yobibits
 ---
 aliases: []
 factor: 0.125
 type: digital
 unit: byte
+symbol: B
 plural: bytes
 ---
 aliases:
-  - kb
   - kbs
 factor: 0.000125
 type: digital
 unit: kilobyte
+symbol: kB
 plural: kilobytes
 ---
 aliases:
-  - mb
   - mbs
 factor: 1.25e-07
 type: digital
 unit: megabyte
+symbol: MB
 plural: megabytes
 ---
 aliases:
-  - gb
   - gbs
 factor: 1.25e-10
 type: digital
 unit: gigabyte
+symbol: GB
 plural: gigabytes
 ---
 aliases:
-  - tb
   - tbs
 factor: 1.25e-13
 type: digital
 unit: terabyte
+symbol: TB
 plural: terabytes
 ---
 aliases:
-  - pb
   - pbs
 factor: 1.25e-16
 type: digital
 unit: petabyte
+symbol: PB
 plural: petabytes
 ---
 aliases:
-  - eb
   - ebs
 factor: 1.25e-19
 type: digital
 unit: exabyte
+symbol: EB
 plural: exabytes
 ---
 aliases:
-  - zb
   - zbs
 factor: 1.25e-22
 type: digital
 unit: zettabyte
+symbol: ZB
 plural: zettabytes
 ---
 aliases:
-  - yb
   - ybs
 factor: 1.25e-25
 type: digital
 unit: yottabyte
+symbol: YB
 plural: yottabytes
 ---
 aliases:
-  - kib
   - kibs
 factor: 0.0001220703125
 type: digital
 unit: kibibyte
+symbol: KiB
 plural: kibibytes
 ---
 aliases:
-  - mib
   - mibs
 factor: 1.19209289550781e-07
 type: digital
 unit: mebibyte
+symbol: MiB
 plural: mebibytes
 ---
 aliases:
-  - gib
   - gibs
 factor: 1.16415321826935e-10
 type: digital
 unit: gibibyte
+symbol: GiB
 plural: gibibytes
 ---
 aliases:
-  - tib
   - tibs
 factor: 1.13686837721616e-13
 type: digital
 unit: tebibyte
+symbol: TiB
 plural: tebibytes
 ---
 aliases:
-  - pib
   - pibs
 factor: 1.11022302462516e-16
 type: digital
 unit: pebibyte
+symbol: PiB
 plural: pebibytes
 ---
 aliases:
-  - eib
   - eibs
 factor: 1.0842021724855e-19
 type: digital
 unit: exbibyte
+symbol: EiB
 plural: exbibytes
 ---
 aliases:
-  - zib
   - zibs
 factor: 1.05879118406788e-22
 type: digital
 unit: zebibyte
+symbol: ZiB
 plural: zebibytes
 ---
 aliases:
-  - yib
   - yibs
 factor: 1.03397576569129e-25
 type: digital
 unit: yobibyte
+symbol: YiB
 plural: yobibytes
 ---
 aliases:
@@ -1619,6 +1657,7 @@ aliases:
 factor: 2.236941851939304
 type: speed
 unit: mph
+symbol: mph
 plural: mph
 ---
 aliases:
@@ -1634,6 +1673,7 @@ aliases:
 factor: 1
 type: speed
 unit: m/s
+symbol: m/s
 plural: m/s
 ---
 aliases:
@@ -1649,6 +1689,7 @@ aliases:
 factor: 3.280839895013123
 type: speed
 unit: ft/s
+symbol: ft/s
 plural: ft/s
 ---
 aliases:
@@ -1661,6 +1702,7 @@ aliases:
 factor: 3.6
 type: speed
 unit: km/h
+symbol: km/h
 plural: km/h
 ---
 aliases:

--- a/share/goodie/conversions/ratios.yml
+++ b/share/goodie/conversions/ratios.yml
@@ -315,7 +315,7 @@ aliases:
 factor: 3.2808398950131233595800524934383
 type: length
 unit: foot
-symbol: '
+symbol: "'"
 plural: feet
 ---
 aliases:
@@ -324,7 +324,7 @@ aliases:
 factor: 39.37007874015748031496062992126
 type: length
 unit: inch
-symbol: "
+symbol: '"'
 plural: inches
 ---
 aliases:
@@ -1475,7 +1475,7 @@ aliases:
 factor: 9.09494701772928e-13
 type: digital
 unit: tebibit
-symbol:Tib
+symbol: Tib
 plural: tebibits
 ---
 aliases:

--- a/t/00-roles.t
+++ b/t/00-roles.t
@@ -30,7 +30,6 @@ subtest 'NumberStyler' => sub {
             [['4e1', '-1e25', '4.5e-25'] => 'perl'],
             [['-1,1e25', '4,5e-25'] => 'euro'],
             [['4E1', '-1E25', '4.5E-25'] => 'perl'],
-            [['-1,1E25', '4,5E-25'] => 'euro'],
         );
 
         my $number_style_regex = NumberRoleTester::number_style_regex();

--- a/t/00-roles.t
+++ b/t/00-roles.t
@@ -30,6 +30,7 @@ subtest 'NumberStyler' => sub {
             [['4e1', '-1e25', '4.5e-25'] => 'perl'],
             [['-1,1e25', '4,5e-25'] => 'euro'],
             [['4E1', '-1E25', '4.5E-25'] => 'perl'],
+            [['-1,1E25', '4,5E-25'] => 'euro'],
         );
 
         my $number_style_regex = NumberRoleTester::number_style_regex();

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -226,7 +226,7 @@ ddg_goodie_test(
             physical_quantity => 'length'
         })
     ),
-    'BTU to KwH' => test_zci(
+    'BTU to kWh' => test_zci(
         '1 british thermal unit = 0.000292917 kilowatt-hours',
         structured_answer => make_answer({
             markup_input => '1',
@@ -3082,6 +3082,7 @@ ddg_goodie_test(
     # ),
 
     # Intentionally untriggered
+	'BTU to kWh'                      => undef,
     '5 inches in 5 meters'            => undef,
     'convert 1 cm to 2 mm'            => undef,
     'inching towards the goal'        => undef,

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -3092,30 +3092,30 @@ ddg_goodie_test(
             physical_quantity => 'volume'
         })
     ),
-    # '10MB in Mb' => test_zci(
-        # '10 megabytes = 80 megabits',
-        # structured_answer => make_answer({
-            # markup_input => '10',
-            # raw_input => '10',
-            # from_unit => 'megabytes',
-            # styled_output => '80',
-            # raw_answer => '80',
-            # to_unit => 'megabits',
-            # physical_quantity => 'information'
-        # })
-    # ),
-    # '1kb in B' => test_zci(
-        # '1 megabit = 125 bytes',
-        # structured_answer => make_answer({
-            # markup_input => '1',
-            # raw_input => '1',
-            # from_unit => 'kilobytes',
-            # styled_output => '125',
-            # raw_answer => '125',
-            # to_unit => 'bytes',
-            # physical_quantity => 'information'
-        # })
-    # ),
+     '10MB in Mb' => test_zci(
+         '10 megabytes = 80 megabits',
+         structured_answer => make_answer({
+             markup_input => '10',
+             raw_input => '10',
+             from_unit => 'megabytes',
+             styled_output => '80',
+             raw_answer => '80',
+             to_unit => 'megabits',
+             physical_quantity => 'digital'
+         })
+     ),
+     '1kb in B' => test_zci(
+         '1 kilobit = 125 bytes',
+         structured_answer => make_answer({
+             markup_input => '1',
+             raw_input => '1',
+             from_unit => 'kilobit',
+             styled_output => '125',
+             raw_answer => '125',
+             to_unit => 'bytes',
+             physical_quantity => 'digital'
+         })
+     ),
 
     # Intentionally untriggered
     'BTU to KwH'                      => undef,

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -1308,6 +1308,42 @@ ddg_goodie_test(
             physical_quantity => 'volume'
         })
     ),
+    'convert 2 liters to oz' => test_zci (
+        '2 litres = 67.628 us fluid ounces',
+        structured_answer => make_answer({
+            markup_input => '2',
+            raw_input => '2',
+            from_unit => 'litre',
+            styled_output => '67.628',
+            raw_answer => '67.628',
+            to_unit => 'us fluid ounces',
+            physical_quantity => 'volume'
+        })
+    ),
+    'convert 2 pints to oz' => test_zci (
+        '2 pints = 38.430 us fluid ounces',
+        structured_answer => make_answer({
+            markup_input => '2',
+            raw_input => '2',
+            from_unit => 'pints',
+            styled_output => '38.430',
+            raw_answer => '38.430',
+            to_unit => 'us fluid ounces',
+            physical_quantity => 'volume'
+        })
+    ),
+    'convert 8 oz to gallons' => test_zci (
+        '8 us fluid ounces = 0.0625 us gallons',
+        structured_answer => make_answer({
+            markup_input => '8',
+            raw_input => '8',
+            from_unit => 'us fluid ounces',
+            styled_output => '0.0625',
+            raw_answer => '0.0625',
+            to_unit => 'us gallons',
+            physical_quantity => 'volume'
+        })
+    ),
     '4 cups in quarts' => test_zci(
         '4 us cups = 1 quart',
         structured_answer => make_answer({
@@ -3082,7 +3118,7 @@ ddg_goodie_test(
     # ),
 
     # Intentionally untriggered
-	'BTU to KwH'                      => undef,
+    'BTU to KwH'                      => undef,
     '5 inches in 5 meters'            => undef,
     'convert 1 cm to 2 mm'            => undef,
     'inching towards the goal'        => undef,

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -323,7 +323,7 @@ ddg_goodie_test(
             physical_quantity => 'duration'
         })
     ),
-    'convert 1 yb to yib' => test_zci(
+    'convert 1 YB to YiB' => test_zci(
         '1 yottabyte = 0.827 yobibytes',
         structured_answer => make_answer({
             markup_input => '1',
@@ -708,7 +708,7 @@ ddg_goodie_test(
             physical_quantity => 'pressure'
         })
     ),
-    '1 atm to kpa' => test_zci(
+    '1 atm to kPa' => test_zci(
         '1 atmosphere = 101.325 kilopascals',
         structured_answer => make_answer({
             markup_input => '1',
@@ -780,7 +780,7 @@ ddg_goodie_test(
             physical_quantity => 'energy'
         })
     ),
-    '90 ps in watts' => test_zci(
+    '90 PS in watts' => test_zci(
         '90 metric horsepower = 66,194.888 watts',
         structured_answer => make_answer({
             markup_input => '90',
@@ -936,7 +936,7 @@ ddg_goodie_test(
             physical_quantity => 'digital'
         })
     ),
-    '0.013 mb in bits' => test_zci(
+    '0.013 MB in bits' => test_zci(
         '0.013 megabytes = 104,000 bits',
         structured_answer => make_answer({
             markup_input => '0.013',
@@ -948,7 +948,7 @@ ddg_goodie_test(
             physical_quantity => 'digital'
         })
     ),
-    '0,013 mb in bits' => test_zci(
+    '0,013 MB in bits' => test_zci(
         '0,013 megabytes = 104.000 bits',
         structured_answer => make_answer({
             markup_input => '0,013',
@@ -960,7 +960,7 @@ ddg_goodie_test(
             physical_quantity => 'digital'
         })
     ),
-    '1 exabyte to pib' => test_zci(
+    '1 exabyte to PiB' => test_zci(
         '1 exabyte = 888.178 pebibytes',
         structured_answer => make_answer({
             markup_input => '1',

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -1313,7 +1313,7 @@ ddg_goodie_test(
         structured_answer => make_answer({
             markup_input => '2',
             raw_input => '2',
-            from_unit => 'litre',
+            from_unit => 'litres',
             styled_output => '67.628',
             raw_answer => '67.628',
             to_unit => 'us fluid ounces',
@@ -1321,11 +1321,11 @@ ddg_goodie_test(
         })
     ),
     'convert 2 pints to oz' => test_zci (
-        '2 pints = 38.430 us fluid ounces',
+        '2 imperial pints = 38.430 us fluid ounces',
         structured_answer => make_answer({
             markup_input => '2',
             raw_input => '2',
-            from_unit => 'pints',
+            from_unit => 'imperial pints',
             styled_output => '38.430',
             raw_answer => '38.430',
             to_unit => 'us fluid ounces',

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -45,6 +45,18 @@ ddg_goodie_test(
             physical_quantity => 'mass'
         })
     ),
+    'CONVERT 5 oz TO grams' => test_zci(
+        '5 ounces = 141.747 grams',
+        structured_answer => make_answer({
+            raw_input => '5',
+            from_unit => 'ounces',
+            raw_answer => '141.747',
+            to_unit => 'grams',
+            markup_input => '5',
+            styled_output => '141.747',
+            physical_quantity => 'mass'
+        })
+    ),
     '5 ounces to g' => test_zci(
         '5 ounces = 141.747 grams',
         structured_answer => make_answer({
@@ -202,42 +214,6 @@ ddg_goodie_test(
             physical_quantity => 'temperature'
         })
     ),
-    '65 degrees c to f' => test_zci(
-        '65 degrees celsius = 149 degrees fahrenheit',
-        structured_answer => make_answer({
-            markup_input => '65',
-            raw_input => '65',
-            from_unit => 'degrees celsius',
-            styled_output => '149',
-            raw_answer => '149',
-            to_unit => 'degrees fahrenheit',
-            physical_quantity => 'temperature'
-        })
-    ),
-    '65 degrees c to degrees f' => test_zci(
-        '65 degrees celsius = 149 degrees fahrenheit',
-        structured_answer => make_answer({
-            markup_input => '65',
-            raw_input => '65',
-            from_unit => 'degrees celsius',
-            styled_output => '149',
-            raw_answer => '149',
-            to_unit => 'degrees fahrenheit',
-            physical_quantity => 'temperature'
-        })
-    ),
-    '65 c to degrees f' => test_zci(
-        '65 degrees celsius = 149 degrees fahrenheit',
-        structured_answer => make_answer({
-            markup_input => '65',
-            raw_input => '65',
-            from_unit => 'degrees celsius',
-            styled_output => '149',
-            raw_answer => '149',
-            to_unit => 'degrees fahrenheit',
-            physical_quantity => 'temperature'
-        })
-    ),
     'light year to mm' => test_zci(
         '1 light year = 9.46073 * 10^18 millimeters',
         structured_answer => make_answer({
@@ -311,7 +287,7 @@ ddg_goodie_test(
             physical_quantity => 'temperature'
         })
     ),
-	'convert 122 fahrenheit to degrees centigrade' => test_zci(
+    'convert 122 fahrenheit to degrees centigrade' => test_zci(
         '122 degrees fahrenheit = 50 degrees celsius',
         structured_answer => make_answer({
             markup_input => '122',
@@ -1052,7 +1028,7 @@ ddg_goodie_test(
             from_unit => 'degrees celsius',
             styled_output => '53.600',
             raw_answer => '53.600',
-			to_unit => 'degrees fahrenheit',
+            to_unit => 'degrees fahrenheit',
             physical_quantity => 'temperature'
         })
     ),
@@ -1064,7 +1040,7 @@ ddg_goodie_test(
             from_unit => 'degree fahrenheit',
             styled_output => '-17.222',
             raw_answer => '-17.222',
-			to_unit => 'degrees celsius',
+            to_unit => 'degrees celsius',
             physical_quantity => 'temperature'
         })
     ),
@@ -1088,7 +1064,7 @@ ddg_goodie_test(
             from_unit => 'degrees fahrenheit',
             styled_output => '112.222',
             raw_answer => '112.222',
-			to_unit => 'degrees celsius',
+            to_unit => 'degrees celsius',
             physical_quantity => 'temperature'
         })
     ),
@@ -1177,6 +1153,30 @@ ddg_goodie_test(
         })
     ),
     'feet in an inches' => test_zci(
+        '1 inch = 0.0833 feet',
+        structured_answer => make_answer({
+            markup_input => '1',
+            raw_input => '1',
+            from_unit => 'inch',
+            styled_output => '0.0833',
+            raw_answer => '0.0833',
+            to_unit => 'feet',
+            physical_quantity => 'length'
+        })
+    ),
+    'FEET IN AN INCHES' => test_zci(
+        '1 inch = 0.0833 feet',
+        structured_answer => make_answer({
+            markup_input => '1',
+            raw_input => '1',
+            from_unit => 'inch',
+            styled_output => '0.0833',
+            raw_answer => '0.0833',
+            to_unit => 'feet',
+            physical_quantity => 'length'
+        })
+    ),
+    'feet in AN inch' => test_zci(
         '1 inch = 0.0833 feet',
         structured_answer => make_answer({
             markup_input => '1',
@@ -1320,7 +1320,31 @@ ddg_goodie_test(
             physical_quantity => 'volume'
         })
     ),
+    '4 CUPS IN QUARTS' => test_zci(
+        '4 us cups = 1 quart',
+        structured_answer => make_answer({
+            markup_input => '4',
+            raw_input => '4',
+            from_unit => 'us cups',
+            styled_output => '1',
+            raw_answer => '1',
+            to_unit => 'quart',
+            physical_quantity => 'volume'
+        })
+    ),
     'how many ounces in a cup' => test_zci(
+        '1 us cup = 8 us fluid ounces',
+        structured_answer => make_answer({
+            markup_input => '1',
+            raw_input => '1',
+            from_unit => 'us cup',
+            styled_output => '8',
+            raw_answer => '8',
+            to_unit => 'us fluid ounces',
+            physical_quantity => 'volume'
+        })
+    ),
+    'HOW MANY OUNCES IN A CUP' => test_zci(
         '1 us cup = 8 us fluid ounces',
         structured_answer => make_answer({
             markup_input => '1',
@@ -2778,8 +2802,8 @@ ddg_goodie_test(
             physical_quantity => 'length'
         })
     ),
-	# Representation (scientific notation)
-	'30000 km to m' => test_zci(
+    # Representation (scientific notation)
+    '30000 km to m' => test_zci(
         '30,000 kilometers = 3 * 10^7 meters',
         structured_answer => make_answer({
             markup_input => '30,000',
@@ -2790,11 +2814,11 @@ ddg_goodie_test(
             to_unit => 'meters',
             physical_quantity => 'length'
         })
-	),
+    ),
     
     '3000000000000000 km to m' => test_zci(
         '3 * 10^15 kilometers = 3 * 10^18 meters',
-		structured_answer => make_answer({
+        structured_answer => make_answer({
             markup_input => '3 * 10<sup>15</sup>',
             raw_input => '3*10^15',
             from_unit => 'kilometers',
@@ -2806,7 +2830,7 @@ ddg_goodie_test(
     ),
     '3000 km to m' => test_zci(
         '3,000 kilometers = 3,000,000 meters',
-		structured_answer => make_answer({
+        structured_answer => make_answer({
             markup_input => '3,000',
             raw_input => '3000',
             from_unit => 'kilometers',
@@ -2818,7 +2842,7 @@ ddg_goodie_test(
     ),
     '300000000000 km to m' => test_zci(
         '3 * 10^11 kilometers = 3 * 10^14 meters',
-		structured_answer => make_answer({
+        structured_answer => make_answer({
             markup_input => '3 * 10<sup>11</sup>',
             raw_input => '3*10^11',
             from_unit => 'kilometers',
@@ -2830,7 +2854,7 @@ ddg_goodie_test(
     ),
     '4e-15 km to mm' => test_zci(
         '4 * 10^-15 kilometers = 4 * 10^-9 millimeters',
-		structured_answer => make_answer({
+        structured_answer => make_answer({
             markup_input => '4 * 10<sup>-15</sup>',
             raw_input => '4*10^-15',
             from_unit => 'kilometers',
@@ -2842,7 +2866,7 @@ ddg_goodie_test(
     ),
     'how many bytes in a mebibyte?' => test_zci(
         '1 mebibyte = 1,048,576 bytes',
-		structured_answer => make_answer({
+        structured_answer => make_answer({
             markup_input => '1',
             raw_input => '1',
             from_unit => 'mebibyte',
@@ -2854,7 +2878,7 @@ ddg_goodie_test(
     ),
     'how many megabytes in a gigabyte?' => test_zci(
         '1 gigabyte = 1,000 megabytes',
-		structured_answer => make_answer({
+        structured_answer => make_answer({
             markup_input => '1',
             raw_input => '1',
             from_unit => 'gigabyte',
@@ -2866,7 +2890,7 @@ ddg_goodie_test(
     ),
     '1 gigabyte in megabytes' => test_zci(
         '1 gigabyte = 1,000 megabytes',
-		structured_answer => make_answer({
+        structured_answer => make_answer({
             markup_input => '1',
             raw_input => '1',
             from_unit => 'gigabyte',
@@ -3032,6 +3056,30 @@ ddg_goodie_test(
             physical_quantity => 'volume'
         })
     ),
+    # '10MB in Mb' => test_zci(
+        # '10 megabytes = 80 megabits',
+        # structured_answer => make_answer({
+            # markup_input => '10',
+            # raw_input => '10',
+            # from_unit => 'megabytes',
+            # styled_output => '80',
+            # raw_answer => '80',
+            # to_unit => 'megabits',
+            # physical_quantity => 'information'
+        # })
+    # ),
+    # '1kb in B' => test_zci(
+        # '1 megabit = 125 bytes',
+        # structured_answer => make_answer({
+            # markup_input => '1',
+            # raw_input => '1',
+            # from_unit => 'kilobytes',
+            # styled_output => '125',
+            # raw_answer => '125',
+            # to_unit => 'bytes',
+            # physical_quantity => 'information'
+        # })
+    # ),
 
     # Intentionally untriggered
     '5 inches in 5 meters'            => undef,

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -3082,7 +3082,7 @@ ddg_goodie_test(
     # ),
 
     # Intentionally untriggered
-	'BTU to kWh'                      => undef,
+	'BTU to KwH'                      => undef,
     '5 inches in 5 meters'            => undef,
     'convert 1 cm to 2 mm'            => undef,
     'inching towards the goal'        => undef,


### PR DESCRIPTION
## Description of new Instant Answer, or changes

This changes the behaviour of conversions as follows:
* Descriptive unit names (microseconds, megabytes, megabits, kilometers etc) should remain case insensitive, if the user puts in MICROSECONDS because they love capslock then it should work
* Things that I've defined as Symbols (based on SI definitions, i.e. `m` for metres, `l` for Litres, `Pa` for Pascals, and crucially: `B` for bytes and `b` for bits) should be *case sensitive* as this is how the symbol is defined. 
* Symbol case sensitivity is also extended to the SI prefixes i.e. `Mm` is megametres and `mm` is millimeters, similiarily `kB` is kilobytes and `kb` is kilobits

I've also extended the volume bodge to add more unit support so that more queries using `oz` as implicitly `fl oz` work

## Related Issues and Discussions
Fixes: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/3990
Fixes: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/1396

## People to notify
<!-- Please @mention any relevant people/organizations here: -->


## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [x] Title follows correct format (Specifies Instant Answer + Purpose)
- [x] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Instant Answer Page** (for new Instant Answers)
- [x] Instant Answer page is correctly filled out and contains:
    - The **Title** is appropriately named and formatted
    - The **IA topics** are present and appropriate
    - The **Description** is clear and coherent
    - **Source Name** exists if applicable
    - All **Example Queries** trigger on [Beta](https://beta.duckduckgo.com/)

**Code**
- [x] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [x] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [x] There is no unnecessary files in place (such as editor config files)
- [x] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <fathead_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/conversions
<!-- FILL THIS IN:                           ^^^^ -->
