### PR TITLE
Timer: switch back to handling data obj as array

### DIFF
--- a/share/goodie/timer/timer.js
+++ b/share/goodie/timer/timer.js
@@ -433,7 +433,7 @@ DDH.timer.build = function(ops) {
         hasShown = true;
 
         var lastUpdate = new Date().getTime(),
-            enteredTime = parseInt(ops.data.time),
+            enteredTime = parseInt(ops.data[0].time),
             $dom = DDH.getDOM('timer'),
             oldTitle = document.title;
 


### PR DESCRIPTION
## Description of new Instant Answer, or changes

I broke the handling of the time input data In a recent PR I made + merged. This fixes the bug I introduced.

## Related Issues
Fixes #4035 

The `data` obj is initially created as an object which I noticed when I wrote the new code on [line13](https://github.com/duckduckgo/zeroclickinfo-goodies/compare/zaahir/fix-timer-js?expand=1#diff-337bb630aab5f2688c25d7201e0bdfbaR13).

When I saw we were referencing `data` as an array, I thought this was a bug and changed it.

I now realize `data` later becomes an array to handle multiple timers.

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/timer
<!-- FILL THIS IN:                           ^^^^ -->
