### PR TITLE
KDE shortucuts improved

### DIFF
--- a/share/goodie/cheat_sheets/json/kde.json
+++ b/share/goodie/cheat_sheets/json/kde.json
@@ -38,6 +38,9 @@
             "val": "Copy selected text or items to the clipboard",
             "key": "[Ctrl] [C]"
         }, {
+            "val": "Paste contents of clipboard at cursor",
+            "key": "[Ctrl] [V]"
+        }, {
             "val": "Undo the last action",
             "key": "[Ctrl] [Z]"
         }, {

--- a/share/goodie/cheat_sheets/json/kde.json
+++ b/share/goodie/cheat_sheets/json/kde.json
@@ -35,6 +35,9 @@
             "val": "View menu",
             "key": "[Alt] [V]"
         }, {
+            "val": "Cut the selected area and store it in the clipboard",
+            "key": "[Ctrl] [X]"
+        }, {
             "val": "Copy selected text or items to the clipboard",
             "key": "[Ctrl] [C]"
         }, {

--- a/share/goodie/cheat_sheets/json/kde.json
+++ b/share/goodie/cheat_sheets/json/kde.json
@@ -32,11 +32,11 @@
             "val": "Edit menu",
             "key": "[Alt] [E]"
         }, {
+            "val": "View menu",
+            "key": "[Alt] [V]"
+        }, {
             "val": "Copy selected text or items to the clipboard",
             "key": "[Ctrl] [C]"
-        }, {
-            "val": "View menu",
-            "key": "[Ctrl] [V]"
         }, {
             "val": "Undo the last action",
             "key": "[Ctrl] [Z]"


### PR DESCRIPTION
<!-- DO NOT REMOVE -->
KDE cheat sheet: 

- fix "View menu" shortcut

- add "Paste" shortcut

- add "Cut" shortcut

---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/kde_cheat_sheet
<!-- FILL THIS IN:                           ^^^^ -->
