### PR TITLE
Unicode: Make '+' character in unicode codepoint query optional.

### DIFF
--- a/lib/DDG/Goodie/Unicode.pm
+++ b/lib/DDG/Goodie/Unicode.pm
@@ -9,7 +9,7 @@ use Unicode::Char ();              # For name -> codepoint lookup
 use Encode qw/encode_utf8/;
 
 use constant {
-    CODEPOINT_RE => qr/^ \s* (?:U \+|\\(?:u|x{(?=.*}))) (?<codepoint> [a-f0-9]{4,6})}? \s* $/xi,
+    CODEPOINT_RE => qr/^ \s* (?:U \+?|\\(?:u|x{(?=.*}))) (?<codepoint> [a-f0-9]{4,6})}? \s* $/xi,
     NAME_RE      => qr/^ (?<name> [A-Z][A-Z\s]+) $/xi,
     CHAR_RE      => qr/^ \s* (?<char> .) \s* $/x,
     UNICODE_RE   => qr/^ (?:unicode|emoji|utf-(?:8|16|32)) \s+ (.+) $/xi,

--- a/t/Unicode.t
+++ b/t/Unicode.t
@@ -17,9 +17,11 @@ ddg_goodie_test(
         # Raw query, "U+XXXX"
         'U+263A' => test_zci("\x{263A} U+263A WHITE SMILING FACE, decimal: 9786, HTML: &#9786;, UTF-8: 0xE2 0x98 0xBA, block: Miscellaneous Symbols"),
         '\u263A' => test_zci("\x{263A} U+263A WHITE SMILING FACE, decimal: 9786, HTML: &#9786;, UTF-8: 0xE2 0x98 0xBA, block: Miscellaneous Symbols"),
+        'u263A' => test_zci("\x{263A} U+263A WHITE SMILING FACE, decimal: 9786, HTML: &#9786;, UTF-8: 0xE2 0x98 0xBA, block: Miscellaneous Symbols"),
 
         # Same should work with the "unicode" start trigger too
         'unicode U+263B' => test_zci("\x{263B} U+263B BLACK SMILING FACE, decimal: 9787, HTML: &#9787;, UTF-8: 0xE2 0x98 0xBB, block: Miscellaneous Symbols"),
+        'unicode u263B' => test_zci("\x{263B} U+263B BLACK SMILING FACE, decimal: 9787, HTML: &#9787;, UTF-8: 0xE2 0x98 0xBB, block: Miscellaneous Symbols"),
 
         # Lookup by name, "unicode LATIN SMALL LETTER A WITH CIRCUMFLEX"
         "unicode White Smiling Face" => test_zci("\x{263A} U+263A WHITE SMILING FACE, decimal: 9786, HTML: &#9786;, UTF-8: 0xE2 0x98 0xBA, block: Miscellaneous Symbols"),


### PR DESCRIPTION
Unicode: Make '+' character in unicode codepoint query optional so that, for example, both u+263A and u263A would work.

Sometimes people don't include the + when writing about unicode, or in file names (such as image files for an emoji font) and copying that into duckduckgo should still yield the unicode instant answer.

## Description of new Instant Answer, or changes
In Unicode instant answer, make + in unicode codepoint query optional so that, for example, both u+263A and u263A would work.

## Related Issues and Discussions


## People to notify


## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [x] Title follows correct format (Specifies Instant Answer + Purpose)
- [x] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Instant Answer Page** (for new Instant Answers)
- [ ] Instant Answer page is correctly filled out and contains:
    - The **Title** is appropriately named and formatted
    - The **IA topics** are present and appropriate
    - The **Description** is clear and coherent
    - **Source Name** exists if applicable
    - All **Example Queries** trigger on [Beta](https://beta.duckduckgo.com/)

**Code**
- [ ] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

---

Instant Answer Page: https://duck.co/ia/view/Unicode
