### PR TITLE
Calculator: Use strings in NOSHIFT_KEYCODES to prevent handling 0 as false

### DIFF
--- a/share/goodie/calculator/calculator.js
+++ b/share/goodie/calculator/calculator.js
@@ -34,16 +34,16 @@ DDH.calculator = DDH.calculator || {};
     var NOSHIFT_KEYCODES = {
         8: "C_OPT",
         13: "=",
-        48: 0,
-        49: 1,
-        50: 2,
-        51: 3,
-        52: 4,
-        53: 5,
-        54: 6,
-        55: 7,
-        56: 8,
-        57: 9,
+        48: "0",
+        49: "1",
+        50: "2",
+        51: "3",
+        52: "4",
+        53: "5",
+        54: "6",
+        55: "7",
+        56: "8",
+        57: "9",
         67: "C_OPT",
         69: "e",
         88: "×",
@@ -685,7 +685,7 @@ DDH.calculator = DDH.calculator || {};
                 }
             }
         }
-        
+
         // Factorials (!) shouldn't follow an operand
         if(element === "!" && ( Utils.isOperand(display.value[display.value.length-1]) || Utils.isOperand(display.value[display.value.length-2]) )) {
             return false;


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Wrapping the numeric values of the `NOSHIFT_KEYCODES` object in quotes so we handle them as strings. This prevents the 0 value from being interpreted as `false`. Using strings is OK because we use `$.isNumeric()` to check the values which can handle a string of digits.


## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [ ] Title follows correct format (Specifies Instant Answer + Purpose)
- [ ] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Instant Answer Page** (for new Instant Answers)
- [ ] Instant Answer page is correctly filled out and contains:
    - The **Title** is appropriately named and formatted
    - The **IA topics** are present and appropriate
    - The **Description** is clear and coherent
    - **Source Name** exists if applicable
    - All **Example Queries** trigger on [Beta](https://beta.duckduckgo.com/)

**Code**
- [ ] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/calculator
<!-- FILL THIS IN:                           ^^^^ -->
