### PR TITLE
DatesRole: Adding support for partial time format

### DIFF
--- a/lib/DDG/GoodieRole/Dates.pm
+++ b/lib/DDG/GoodieRole/Dates.pm
@@ -40,6 +40,10 @@ my $full_month          = qr#January|February|March|April|May|June|July|August|S
 my $month_regex         = qr#$full_month|$short_month#;
 my $time_24h            = qr#(?:(?:[0-1][0-9])|(?:2[0-3]))[:]?[0-5][0-9][:]?[0-5][0-9]#i;
 my $time_12h            = qr#(?:(?:0[1-9])|(?:1[012])):[0-5][0-9]:[0-5][0-9]\s?(?:am|pm)#i;
+my $time_with_optional_seconds = qr#
+    (?:(?:[0-1][0-9])|(?:2[0-3]))[:]?[0-5][0-9](?:[:]?[0-5][0-9])? |
+    (?:(?:0[1-9])|(?:1[012])):[0-5][0-9](?::[0-5][0-9])?\s?(?:am|pm)
+#ix;
 my $date_number         = qr#[0-3]?[0-9]#;
 my $full_year           = qr#[0-9]{4}#;
 my $relative_dates      = qr#
@@ -255,7 +259,9 @@ my $descriptive_datestring = qr{
     (?:(?:$date_number)\s?$number_suffixes?\s(?:$month_regex)) | # 18th Jan, 01 October
     (?:(?:$month_regex)\s(?:$date_number)\s?$number_suffixes?) | # Dec 25, July 4th
     (?:$month_regex)                                           | # February, Aug
-    (?:$relative_dates)                                          # next week, last month, this year
+    (?:$relative_dates)                                        |  # next week, last month, this year
+    (?:(?:$date_number)\s?$number_suffixes?\s(?:$month_regex)\s(?:$time_with_optional_seconds)) | # 22 may 08:00
+    (?:(?:$time_with_optional_seconds)\s(?:$date_number)\s?$number_suffixes?\s(?:$month_regex)) # 08:00 22 may
     }ix;
 
 # Used for parse_descriptive_datestring_to_date
@@ -265,7 +271,9 @@ my $descriptive_datestring_matches = qr#
     (?:(?<d>$date_number)\s?$number_suffixes?\s(?<m>$month_regex)) |
     (?:(?<m>$month_regex)\s(?<d>$date_number)\s?$number_suffixes?) |
     (?<m>$month_regex) |
-    (?<r>$relative_dates)
+    (?<r>$relative_dates) |
+    (?:(?<d>$date_number)\s?$number_suffixes?\s(?<m>$month_regex)\s(?<t>$time_with_optional_seconds)) |
+    (?:(?<t>$time_with_optional_seconds)\s(?<d>$date_number)\s?$number_suffixes?\s(?<m>$month_regex))
     #ix;
 
 my $formatted_datestring = build_datestring_regex();
@@ -345,8 +353,10 @@ sub build_datestring_regex {
     push @regexes, $date_standard;
 
     # month-first date formats
-    push @regexes, qr#$date_number$date_delim$short_month$date_delim$full_year#i;
-    push @regexes, qr#$date_number$date_delim$full_month$date_delim$full_year#i;
+    push @regexes, qr#$date_number (?:$full_month|$short_month) $full_year $time_24h#i;
+    push @regexes, qr#$date_number$date_delim$short_month$date_delim$full_year(?: $time_24h)?#i;
+    push @regexes, qr#$date_number$date_delim$full_month$date_delim$full_year(?: $time_24h)?#i;
+
     push @regexes, qr#(?:$short_month|$full_month) (?:the )?$date_number(?: ?$number_suffixes)?[,]? $full_year#i;
 
     # day-first date formats
@@ -374,6 +384,7 @@ sub parse_formatted_datestring_to_date {
     my ($d) = @_;
 
     return unless (defined $d && $d =~ qr/^$formatted_datestring$/);    # Only handle white-listed strings, even if they might otherwise work.
+
     if ($d =~ $ambiguous_dates_matches) {
         # guesswork for ambigous DMY/MDY and switch to ISO
         my ($month, $day, $year) = ($+{'m'}, $+{'d'}, $+{'y'});    # Assume MDY, even though it's crazy, for backward compatibility
@@ -391,7 +402,7 @@ sub parse_formatted_datestring_to_date {
     }
 
     $d =~ s/(\d+)\s?$number_suffixes/$1/i;                                       # Strip ordinal text.
-    $d =~ s/(\sof\s)|(\sthe\s)/ /i;                                                          # Strip "of" for "4th of march" and "the" for "march the 4th"
+    $d =~ s/(\sof\s)|(\sthe\s)/ /i;                                              # Strip "of" for "4th of march" and "the" for "march the 4th"
     $d =~ s/,//i;                                                                # Strip any random commas.
     $d =~ s/($full_month)/$full_month_to_short{lc $1}/i;                         # Parser deals better with the shorter month names.
     $d =~ s/^($short_month)$date_delim(\d{1,2})/$2-$short_month_fix{lc $1}/i;    # Switching Jun-01-2012 to 01 Jun 2012
@@ -476,7 +487,11 @@ sub parse_descriptive_datestring_to_date {
     my $month = $+{'m'};           # Set in each alternative match.
 
     if (my $day = $+{'d'}) {
-        return parse_datestring_to_date("$day $month " . $base_time->year());
+        my $timecomponent = "00:00:00";
+        $timecomponent = $+{'t'} if($+{'t'});
+        $timecomponent .= ":00" if($timecomponent =~ qr/^[0-9]{2}:[0-9]{2}$/);  #Seconds are optional; default to 0 if unspecified
+
+        return parse_datestring_to_date("$day $month " . $base_time->year() . " $timecomponent");
     } elsif (my $relative_dir = $+{'q'}) {
         my $tmp_date = parse_datestring_to_date("01 $month " . $base_time->year());
 

--- a/t/00-roles.t
+++ b/t/00-roles.t
@@ -475,6 +475,8 @@ subtest 'Dates' => sub {
             'jun 21'                    => 961545600,
             'next january'              => 978307200,
             'december'                  => 975628800,
+            '22 may 08:00'		=> 958982401,
+            '08:00 22 may'              => 958982401,
         );
 
         foreach my $test_mixed_date (sort keys %mixed_dates_to_test) {

--- a/t/00-roles.t
+++ b/t/00-roles.t
@@ -141,6 +141,7 @@ subtest 'Dates' => sub {
             '5th of january 1993' => 726192000,
             '5 of jan 1993'     => 726192000,
             'june the 1st 2012' => 1338508800,
+            "11 march 2000 00:00:00" => 952732800
         );
 
         foreach my $test_date (sort keys %dates_to_match) {
@@ -475,11 +476,14 @@ subtest 'Dates' => sub {
             'jun 21'                    => 961545600,
             'next january'              => 978307200,
             'december'                  => 975628800,
-            '22 may 08:00'		=> 958982401,
-            '08:00 22 may'              => 958982401,
+            '22 may 2000 08:00:00'      => 958982400,
+            '22 may 08:00:00'           => 958982400,
+            '22 may 08:00'              => 958982400,
+            '08:00 22 may'              => 958982400,
         );
 
         foreach my $test_mixed_date (sort keys %mixed_dates_to_test) {
+            like($test_mixed_date, qr/^$test_datestring_regex$/, "$test_mixed_date matches the datestring_regex");
             my $parsed_date_object = DatesRoleTester::parse_datestring_to_date($test_mixed_date);
             isa_ok($parsed_date_object, 'DateTime', $test_mixed_date);
             is($parsed_date_object->epoch, $mixed_dates_to_test{$test_mixed_date}, ' ... represents the correct time.');


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Adds support for queries without years but days months and time i.e. "11 may 08:00:00" or "28 feb 23:00"

## Related Issues and Discussions

@moollaza Mentioned that someone attempted to put a trigger in for the countdown timer using this format

## People to notify
@moollaza 

## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [ ] Title follows correct format (Specifies Instant Answer + Purpose)
- [ ] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Instant Answer Page** (for new Instant Answers)
- [ ] Instant Answer page is correctly filled out and contains:
    - The **Title** is appropriately named and formatted
    - The **IA topics** are present and appropriate
    - The **Description** is clear and coherent
    - **Source Name** exists if applicable
    - All **Example Queries** trigger on [Beta](https://beta.duckduckgo.com/)

**Code**
- [ ] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

https://duck.co/ia/view/countdown