### PR TITLE
Molar Mass: Resolve conflicting triggers issue and add new triggers

### DIFF
--- a/lib/DDG/Goodie/MolarMass.pm
+++ b/lib/DDG/Goodie/MolarMass.pm
@@ -23,7 +23,7 @@ handle remainder => sub {
 
     my $remainder = $_;
 
-    $remainder =~ s/(|what is|whats|the|of|for|\?|)//g;
+    $remainder =~ s/(|what is|whats|what\'s|the|of|for|\?|)//g;
     $remainder = trim $remainder;
     
     return unless $remainder;

--- a/lib/DDG/Goodie/MolarMass.pm
+++ b/lib/DDG/Goodie/MolarMass.pm
@@ -23,7 +23,7 @@ handle remainder => sub {
 
     my $remainder = $_;
 
-    $remainder =~ s/(|what is|whats|what\'s|the|of|for|\?|)//g;
+    $remainder =~ s/(what is|whats|what\'s|the|of|for|\?)//g;
     $remainder = trim $remainder;
     
     return unless $remainder;

--- a/lib/DDG/Goodie/MolarMass.pm
+++ b/lib/DDG/Goodie/MolarMass.pm
@@ -7,6 +7,7 @@ use warnings;
 
 use YAML::XS 'LoadFile';
 use Math::Round 'nearest';
+use Text::Trim;
 
 zci answer_type => 'molar_mass';
 zci is_cached => 1;
@@ -14,13 +15,17 @@ zci is_cached => 1;
 my %masses = %{ LoadFile(share('elements.yml')) };
 my %compounds = %{ LoadFile(share('compounds.yml')) };
 
-triggers start => 'molar mass of';
+triggers any => 'molar mass of';
+triggers end => 'molar mass';
 
 # Handle statement
 handle remainder => sub {
 
     my $remainder = $_;
 
+    $remainder =~ s/(|what is|whats|the|of|for|\?|)//g;
+    $remainder = trim $remainder;
+    
     return unless $remainder;
     
     # Check if input is in list of common compounds

--- a/lib/DDG/Goodie/MolarMass.pm
+++ b/lib/DDG/Goodie/MolarMass.pm
@@ -15,8 +15,7 @@ zci is_cached => 1;
 my %masses = %{ LoadFile(share('elements.yml')) };
 my %compounds = %{ LoadFile(share('compounds.yml')) };
 
-triggers any => 'molar mass of';
-triggers end => 'molar mass';
+triggers any => 'molar mass';
 
 # Handle statement
 handle remainder => sub {

--- a/lib/DDG/Goodie/MolarMass.pm
+++ b/lib/DDG/Goodie/MolarMass.pm
@@ -14,7 +14,7 @@ zci is_cached => 1;
 my %masses = %{ LoadFile(share('elements.yml')) };
 my %compounds = %{ LoadFile(share('compounds.yml')) };
 
-triggers start => 'molar mass of', 'atomic mass of', 'atomic weight of';
+triggers start => 'molar mass of';
 
 # Handle statement
 handle remainder => sub {

--- a/t/MolarMass.t
+++ b/t/MolarMass.t
@@ -74,6 +74,12 @@ ddg_goodie_test(
     # Arbitrary Brackets test
     'molar mass of ()()Na(())Cl' => build_test('()()Na(())Cl', '58.4426'),
     
+    # Other Triggers
+    'what is the molar mass of Al2(SO4)3' => build_test_alt('Al2(SO4)3', '342.150876', 'Aluminium Sulfate'),
+    'whats the molar mass of NaCl' => build_test_alt('NaCl', '58.44277', 'Sodium Chloride'),
+    'hydrochloric acid molar mass' => build_test_alt('HCl', '36.46094', 'Hydrochloric Acid'),
+    'whats the molar mass of hydrochloric acid?' => build_test_alt('HCl', '36.46094', 'Hydrochloric Acid'),
+    
     
     
     # ----- Failing tests: ------

--- a/t/MolarMass.t
+++ b/t/MolarMass.t
@@ -50,13 +50,23 @@ sub build_test_alt { test_zci(build_alternate_answer(@_)) }
 ddg_goodie_test(
     [qw( DDG::Goodie::MolarMass )],
 
-    # - primary_example_queries
+    # primary example queries
     'molar mass of H2O' => build_test_alt('H2O', '18.01528', 'Water'),
 
-    # - secondary_example_queries
+    # secondary example queries
     'molar mass of Al2(SO4)3' => build_test_alt('Al2(SO4)3', '342.150876', 'Aluminium Sulfate'),
     'molar mass of NaCl' => build_test_alt('NaCl', '58.44277', 'Sodium Chloride'),
+    'molar mass of HCl' => build_test_alt('HCl', '36.46094', 'Hydrochloric Acid'),
+    'molar mass of Sulfuric Acid' => build_test_alt('H2SO4', '98.07848', 'Sulfuric Acid'),
     
+    # lowercase example queries
+    'molar mass of al2(so4)3' => build_test_alt('Al2(SO4)3', '342.150876', 'Aluminium Sulfate'),
+    'molar mass of nacl' => build_test_alt('NaCl', '58.44277', 'Sodium Chloride'),
+    'molar mass of sulfuric acid' => build_test_alt('H2SO4', '98.07848', 'Sulfuric Acid'),
+    'molar mass of h2so4' => build_test_alt('H2SO4', '98.07848', 'Sulfuric Acid'),
+    'molar mass of hcl' => build_test_alt('HCl', '36.46094', 'Hydrochloric Acid'),
+    
+    # edge case tests
     'molar mass of Uuo2' => build_test('Uuo2', '588'),
     'molar mass of C2H3NaO2' => build_test('C2H3NaO2', '82.0347'),
     'molar mass of Al123(S4(Uuo2Lv4)3Ca4)8' => build_test('Al123(S4(Uuo2Lv4)3Ca4)8', '47867.3854'),
@@ -64,11 +74,12 @@ ddg_goodie_test(
     # Arbitrary Brackets test
     'molar mass of ()()Na(())Cl' => build_test('()()Na(())Cl', '58.4426'),
     
-    # Other Triggers
-    'atomic mass of NaCl' => build_test_alt('NaCl', '58.44277', 'Sodium Chloride'),
     
-    ## Failing tests:
+    
+    # ----- Failing tests: ------
+    # Primary failing example queries:
     'molar mass of asdf' => undef,
+    'molar mass of' => undef,
 
     # Mismatched brackets:
     'molar mass of Al2(SO4))3' => undef,
@@ -83,6 +94,7 @@ ddg_goodie_test(
     
     # Unwanted Characters:
     'molar mass of *(&)H2' => undef,
+    'molar mass of Al2H^2' => undef,
 );
 
 done_testing;

--- a/t/MolarMass.t
+++ b/t/MolarMass.t
@@ -80,6 +80,7 @@ ddg_goodie_test(
     'hydrochloric acid molar mass' => build_test_alt('HCl', '36.46094', 'Hydrochloric Acid'),
     'whats the molar mass of hydrochloric acid?' => build_test_alt('HCl', '36.46094', 'Hydrochloric Acid'),
     'what\'s the molar mass of hydrochloric acid?' => build_test_alt('HCl', '36.46094', 'Hydrochloric Acid'),
+    'molar mass nacl' => build_test_alt('NaCl', '58.44277', 'Sodium Chloride'),
     
     
     
@@ -102,6 +103,12 @@ ddg_goodie_test(
     # Unwanted Characters:
     'molar mass of *(&)H2' => undef,
     'molar mass of Al2H^2' => undef,
+    
+    # Random placement of the words molar mass
+    'something something molar mass haha' => undef,
+    'mmolar masses' => undef,
+    'hmolar mass' => undef,
+    'molar mass' => undef,
 );
 
 done_testing;

--- a/t/MolarMass.t
+++ b/t/MolarMass.t
@@ -79,6 +79,7 @@ ddg_goodie_test(
     'whats the molar mass of NaCl' => build_test_alt('NaCl', '58.44277', 'Sodium Chloride'),
     'hydrochloric acid molar mass' => build_test_alt('HCl', '36.46094', 'Hydrochloric Acid'),
     'whats the molar mass of hydrochloric acid?' => build_test_alt('HCl', '36.46094', 'Hydrochloric Acid'),
+    'what\'s the molar mass of hydrochloric acid?' => build_test_alt('HCl', '36.46094', 'Hydrochloric Acid'),
     
     
     


### PR DESCRIPTION
## Description of changes
Removed "atomic mass of" and "atomic weight of" triggers that were conflicting with Periodic Table IA, and added triggers to handle queries such as "H2SO4 molar mass" and "whats the molar mass of water?".


## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #4240


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@pjhampton @adityatandon007 @moollaza 

## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [ ] Title follows correct format (Specifies Instant Answer + Purpose)
- [ ] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Code**
- [ ] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/molar_mass
<!-- FILL THIS IN:                           ^^^^ -->
