### PR TITLE
Conversions: Allow "celcius" typo, updated tests

### DIFF
--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -96,7 +96,7 @@ handle query => sub {
     }
 
     # hack support for "degrees" prefix on temperatures
-    $_ =~ s/ degree[s]? (centigrade|celsius|fahrenheit|rankine)/ $1/i;
+    $_ =~ s/ degree[s]? (centigrade|cel(?:s|c)ius|fah?renheit|rankine)/ $1/i;
 
     # hack - convert "oz" to "fl oz" if "ml" contained in query
     s/(oz|ounces)/fl oz/i if(/(ml|cup[s]?|litre|liter|gallon|pint)/i && not /fl oz/i);

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -96,7 +96,7 @@ handle query => sub {
     }
 
     # hack support for "degrees" prefix on temperatures
-    $_ =~ s/ degree[s]? (centigrade|cel(?:s|c)ius|fah?renheit|rankine)/ $1/i;
+    $_ =~ s/ degree[s]? (centigrade|cel[sc]ius|fah?renheit|rankine)/ $1/i;
 
     # hack - convert "oz" to "fl oz" if "ml" contained in query
     s/(oz|ounces)/fl oz/i if(/(ml|cup[s]?|litre|liter|gallon|pint)/i && not /fl oz/i);

--- a/share/goodie/conversions/triggers.yml
+++ b/share/goodie/conversions/triggers.yml
@@ -1443,8 +1443,10 @@ aliases:
   - f
   - farenheit
   - deg f
+  - deg fahrenheit
   - deg farenheit
   - degrees f
+  - degrees fahrenheit
   - degrees farenheit
 can_be_negative: 1
 type: temperature
@@ -1454,10 +1456,13 @@ symbols: [°f]
 aliases:
   - c
   - centigrade
+  - celcius
   - deg c
   - deg celsius
+  - deg celcius
   - degrees c
   - degrees celsius
+  - degrees celcius
 can_be_negative: 1
 type: temperature
 unit: celsius

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -202,23 +202,6 @@ ddg_goodie_test(
 			physical_quantity => 'temperature'
 		})
 	),
-	## with typis
-	'convert 5 kelvin to farenheit' => test_zci(
-		'', structured_answer => make_answer({
-			raw_input => '5',
-			from_unit => 'kelvin',
-			to_unit => 'fahrenheit',
-			physical_quantity => 'temperature'
-		})
-	),
-	'convert 5 f to celcius' => test_zci(
-		'', structured_answer => make_answer({
-			raw_input => '5',
-			from_unit => 'fahrenheit',
-			to_unit => 'celsius',
-			physical_quantity => 'temperature'
-		})
-	),
 	'convert 50 centigrade to fahrenheit' => test_zci(
 		'', structured_answer => make_answer({
 			raw_input => '50',
@@ -243,6 +226,24 @@ ddg_goodie_test(
 			physical_quantity => 'temperature'
 		})
 	),
+	## with typos
+	'convert 5 kelvin to farenheit' => test_zci(
+		'', structured_answer => make_answer({
+			raw_input => '5',
+			from_unit => 'kelvin',
+			to_unit => 'fahrenheit',
+			physical_quantity => 'temperature'
+		})
+	),
+	'convert 5 f to celcius' => test_zci(
+		'', structured_answer => make_answer({
+			raw_input => '5',
+			from_unit => 'fahrenheit',
+			to_unit => 'celsius',
+			physical_quantity => 'temperature'
+		})
+	),
+
 	
 	# Implicit conversion requests
 	# MASS

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -202,6 +202,23 @@ ddg_goodie_test(
 			physical_quantity => 'temperature'
 		})
 	),
+	## with typis
+	'convert 5 kelvin to farenheit' => test_zci(
+		'', structured_answer => make_answer({
+			raw_input => '5',
+			from_unit => 'kelvin',
+			to_unit => 'fahrenheit',
+			physical_quantity => 'temperature'
+		})
+	),
+	'convert 5 f to celcius' => test_zci(
+		'', structured_answer => make_answer({
+			raw_input => '5',
+			from_unit => 'fahrenheit',
+			to_unit => 'celsius',
+			physical_quantity => 'temperature'
+		})
+	),
 	'convert 50 centigrade to fahrenheit' => test_zci(
 		'', structured_answer => make_answer({
 			raw_input => '50',


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Many queries are made with the word celsius misspelled as celcius. Seeing as we already account for the "farenheit" misspelling, I've added in "celcius" to account for these missed opportunities.

## People to notify
@pjhampton 

## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [ ] Title follows correct format (Specifies Instant Answer + Purpose)
- [ ] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Code**
- [ ] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/conversions
<!-- FILL THIS IN:                           ^^^^ -->
