### PR TITLE
TimezoneConverter: fixes #4210 fixed error in timezone display

### DIFF
--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -46,7 +46,12 @@ sub parse_timezone {
     $minutes //= 0;
 
     my $hour = int( $timezones{$name} / 100 );
-    $minutes += $timezones{$name} % 100;
+    # To avoid modulo of negative numbers
+    my $m = abs( $timezones{$name} ) % 100;
+    if ( $timezones{$name} < 0 ){
+        $m *= -1;
+    }
+    $minutes += $m;
 
     return ($timezone, $hour + $modifier + $minutes / 60);
 }
@@ -63,6 +68,7 @@ sub to_time {
     }
     my $minutes
         = ( $hours - int $hours ) * 60 - sprintf( '%.4f', $seconds ) / 60;
+
     my $seconds_format = int $seconds ? ':%02.0f' : "";
     if ($american) {
         # Special case certain hours
@@ -132,6 +138,7 @@ handle query => sub {
     for ( $input->{gmt_timezone}, $output->{gmt_timezone} ) {
         $_ = to_time $_;
         s/\A\b/+/;
+        s/:-\b/:/;
         s/:00\z//;
     }
 

--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -48,9 +48,7 @@ sub parse_timezone {
     my $hour = int( $timezones{$name} / 100 );
     # To avoid modulo of negative numbers
     my $m = abs( $timezones{$name} ) % 100;
-    if ( $timezones{$name} < 0 ){
-        $m *= -1;
-    }
+    $m *= -1 if $timezones{$name} < 0;
     $minutes += $m;
 
     return ($timezone, $hour + $modifier + $minutes / 60);

--- a/t/TimezoneConverter.t
+++ b/t/TimezoneConverter.t
@@ -50,6 +50,9 @@ ddg_goodie_test(
     '11:22am est in utc' => build_test('4:22 PM UTC', '11:22 AM EST (UTC-5) to UTC'),
     '1600 UTC in BST' => build_test('17:00 BST', '16:00 UTC to BST (UTC+1)'),  
     '12:00 GMT in PST' => build_test('4:00 PST', '12:00 GMT to PST (UTC-8)'),
+    '10:00PM EDT to NDT' => build_test('11:30 PM NDT', '10:00 PM EDT (UTC-4) to NDT (UTC-2:30)'),
+    '10:00AM MST to NST' => build_test('1:30 PM NST', '10:00 AM MST (UTC-7) to NST (UTC-3:30)'),
+    '1:40AM PDT to MIT' => build_test('11:10 PM MIT (1 day prior)', '1:40 AM PDT (UTC-7) to MIT (UTC-9:30)'),
     
     # Intentional non-answers
     '12 in binary' => undef,


### PR DESCRIPTION
TimezoneConvertor: Fixed error in displaying timezone.The error was because it was taking modulo of negative number while separating it into minutes and hours in parse_timezone function.

Fixes #4210 

## People to be notified
@glitchmr

## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [x] Title follows correct format (Specifies Instant Answer + Purpose)
- [x] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Code**
- [x] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/timezone_converter
<!-- FILL THIS IN:                           ^^^^ -->
