### PR TITLE
Conversions: Fix metric/imperial ton aliases

### DIFF
--- a/share/goodie/conversions/triggers.yml
+++ b/share/goodie/conversions/triggers.yml
@@ -133,6 +133,8 @@ unit: megagram
 symbols: [megagram]
 ---
 aliases:
+  - tonne
+  - tonnes
   - metric ton
   - metric tons
   - mt
@@ -225,10 +227,15 @@ type: mass
 unit: stick
 ---
 aliases:
-  - ton
   - tons
-  - tonnes
-  - tonne
+  - imperial ton
+  - imperial tons
+  - imperial tonne
+  - imperial tonnes
+  - us ton
+  - us tons
+  - us tonne
+  - us tonnes
 type: mass
 unit: ton
 ---


### PR DESCRIPTION
## Description of new Instant Answer, or changes
These changes move the alias "tonne" to the metricton unit, instead of imperial ton. I've added additional aliases for the imperial/us ton as well.

## People to notify
@pjhampton 

## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [ ] Title follows correct format (Specifies Instant Answer + Purpose)
- [ ] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Code**
- [ ] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/conversions
<!-- FILL THIS IN:                           ^^^^ -->
