### PR TITLE
Area support for Hexagon and Trapezoid

### DIFF
--- a/share/goodie/geometry/geometry.css
+++ b/share/goodie/geometry/geometry.css
@@ -91,3 +91,7 @@
     stroke: #4495D4;
     opacity: 1;
 }
+#geometry--goodie .height.hover {
+    stroke: #4495D4;
+    opacity: 1;
+}

--- a/share/goodie/geometry/objectInfo.yml
+++ b/share/goodie/geometry/objectInfo.yml
@@ -25,9 +25,9 @@ cuboid:
   surface: 2(ab+ac+bc)
   diagonal: √(a<sup>2</sup>+b<sup>2</sup>+c<sup>2</sup>)
 hexagon:
-  area: (3√3/2)a<sup>2</sup>
+  area: (a<sup>2</sup>3√3)/2
 trapezoid:
-  area: (b1+b1)h/2
+  area: h(b1+b2)/2
 ---
 volume:
   symbol: "V"

--- a/share/goodie/geometry/objectInfo.yml
+++ b/share/goodie/geometry/objectInfo.yml
@@ -28,8 +28,8 @@ hexagon:
   area: (a<sup>2</sup>3√3)/2
   perimeter: 6a
 trapezoid:
-  area: h(base<sub>1</sub>+base<sub>2</sub>)/2
-  perimeter: side<sub>1</sub> + base<sub>1</sub> + side<sub>2</sub> + base<sub>2</sub>
+  area: h(base1 + base2)/2
+  perimeter: side1 + base1 + side2 + base2
   height: h
 ---
 volume:

--- a/share/goodie/geometry/objectInfo.yml
+++ b/share/goodie/geometry/objectInfo.yml
@@ -28,9 +28,9 @@ hexagon:
   area: (a<sup>2</sup>3√3)/2
   perimeter: 6a
 trapezoid:
-  area: h(base1 + base2)/2
-  perimeter: side1 + base1 + side2 + base2
-  height: h
+  area: h(b1 + b2)/2
+  perimeter: s1 + b1 + s2 + b2
+  height: 
 ---
 volume:
   symbol: "V"

--- a/share/goodie/geometry/objectInfo.yml
+++ b/share/goodie/geometry/objectInfo.yml
@@ -30,6 +30,7 @@ hexagon:
 trapezoid:
   area: h(base<sub>1</sub>+base<sub>2</sub>)/2
   perimeter: side<sub>1</sub> + base<sub>1</sub> + side<sub>2</sub> + base<sub>2</sub>
+  height: h
 ---
 volume:
   symbol: "V"
@@ -51,4 +52,4 @@ diagonal:
   color: "#4495D4"
 height:
   symbol: "h"
-  color: "#000000"
+  color: "#4495D4"

--- a/share/goodie/geometry/objectInfo.yml
+++ b/share/goodie/geometry/objectInfo.yml
@@ -26,8 +26,10 @@ cuboid:
   diagonal: √(a<sup>2</sup>+b<sup>2</sup>+c<sup>2</sup>)
 hexagon:
   area: (a<sup>2</sup>3√3)/2
+  perimeter: 6a
 trapezoid:
-  area: h(b1+b2)/2
+  area: h(base<sub>1</sub>+base<sub>1</sub>)/2
+  perimeter: sides + b1 + b2
 ---
 volume:
   symbol: "V"

--- a/share/goodie/geometry/objectInfo.yml
+++ b/share/goodie/geometry/objectInfo.yml
@@ -28,8 +28,8 @@ hexagon:
   area: (a<sup>2</sup>3√3)/2
   perimeter: 6a
 trapezoid:
-  area: h(base<sub>1</sub>+base<sub>1</sub>)/2
-  perimeter: sides + b1 + b2
+  area: h(base<sub>1</sub>+base<sub>2</sub>)/2
+  perimeter: side<sub>1</sub> + base<sub>1</sub> + side<sub>2</sub> + base<sub>2</sub>
 ---
 volume:
   symbol: "V"

--- a/share/goodie/geometry/objectInfo.yml
+++ b/share/goodie/geometry/objectInfo.yml
@@ -24,6 +24,10 @@ cuboid:
   volume: abc
   surface: 2(ab+ac+bc)
   diagonal: √(a<sup>2</sup>+b<sup>2</sup>+c<sup>2</sup>)
+hexagon:
+  area: (3√3/2)a<sup>2</sup>
+trapezoid:
+  area: (b1+b1)h/2
 ---
 volume:
   symbol: "V"

--- a/share/goodie/geometry/objectInfo.yml
+++ b/share/goodie/geometry/objectInfo.yml
@@ -49,3 +49,6 @@ circumference:
 diagonal:
   symbol: "e"
   color: "#4495D4"
+height:
+  symbol: "h"
+  color: "#000000"

--- a/share/goodie/geometry/subtitle.handlebars
+++ b/share/goodie/geometry/subtitle.handlebars
@@ -5,7 +5,9 @@
                 <div class="dot {{@key}}" data-type="{{@key}}" style="background-color: {{color}}"></div>
                 <div>
                     <h4>{{nameCaps}}</h4>
+                    {{#if html}}
                     {{symbol}} = {{{html}}}
+                    {{/if}}
                     {{#if result}}
                      = {{result}}
                     {{/if}}

--- a/share/goodie/geometry/svg/hexagon.svg
+++ b/share/goodie/geometry/svg/hexagon.svg
@@ -1,0 +1,1 @@
+<path d="M52,0L103.961524 30 103.961524 90 52 120 0.0384757729 90 0.0384757729 30z" class="area stroke" data-type="area"></path>

--- a/share/goodie/geometry/svg/hexagon.svg
+++ b/share/goodie/geometry/svg/hexagon.svg
@@ -1,1 +1,2 @@
-<path d="M52,0L103.961524 30 103.961524 90 52 120 0.0384757729 90 0.0384757729 30z" class="area stroke" data-type="area"></path>
+<path d="M52,0L103.961524 30 103.961524 90 52 120 0.0384757729 90 0.0384757729 30z" class="stroke area" data-type="area"></path>
+<path d="M52,0L103.961524 30 103.961524 90 52 120 0.0384757729 90 0.0384757729 30z" class="stroke perimeter" data-type="perimeter"></path>

--- a/share/goodie/geometry/svg/trapezoid.svg
+++ b/share/goodie/geometry/svg/trapezoid.svg
@@ -1,0 +1,1 @@
+<path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="area stroke" data-type="area"></path>

--- a/share/goodie/geometry/svg/trapezoid.svg
+++ b/share/goodie/geometry/svg/trapezoid.svg
@@ -1,3 +1,5 @@
 <path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="stroke area" data-type="area"></path>
 <path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="stroke perimeter" data-type="perimeter"></path>
-<path d="M27.9290625,0L92.0709375" class="stroke special diagonal" data-type="diagonal"></path>
+<path d="M 27.9290625,0 L 27.9290625,60" class="stroke special diagonal" data-type="diagonal"></path>
+<path d="M27.9290625,0 L 92.0709375,0" class="stroke special diagonal" data-type="diagonal"></path>
+<path d="M0,60 L 120,60" class="stroke special diagonal" data-type="diagonal"></path>

--- a/share/goodie/geometry/svg/trapezoid.svg
+++ b/share/goodie/geometry/svg/trapezoid.svg
@@ -1,1 +1,2 @@
 <path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="area stroke" data-type="area"></path>
+<path d="M27.9290625,0L92.0709375" class="area stroke" data-type="diagonal"></path>

--- a/share/goodie/geometry/svg/trapezoid.svg
+++ b/share/goodie/geometry/svg/trapezoid.svg
@@ -1,5 +1,3 @@
 <path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="stroke area" data-type="area"></path>
 <path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="stroke perimeter" data-type="perimeter"></path>
-<path d="M 27.9290625,0 L 27.9290625,60" class="stroke special diagonal" data-type="diagonal"></path>
-<path d="M27.9290625,0 L 92.0709375,0" class="stroke special diagonal" data-type="diagonal"></path>
-<path d="M0,60 L 120,60" class="stroke special diagonal" data-type="diagonal"></path>
+<path d="M 27.9290625,0 L 27.9290625,60" class="stroke special height" data-type="height"></path>

--- a/share/goodie/geometry/svg/trapezoid.svg
+++ b/share/goodie/geometry/svg/trapezoid.svg
@@ -1,2 +1,2 @@
-<path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="area stroke" data-type="area"></path>
-<path d="M27.9290625,0L92.0709375" class="stroke special diagonal" data-type="diagonal"></path>
+<path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="stroke area" data-type="area"></path>
+<path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="stroke perimeter" data-type="perimeter"></path>

--- a/share/goodie/geometry/svg/trapezoid.svg
+++ b/share/goodie/geometry/svg/trapezoid.svg
@@ -1,2 +1,3 @@
 <path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="stroke area" data-type="area"></path>
 <path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="stroke perimeter" data-type="perimeter"></path>
+<path d="M27.9290625,0L92.0709375" class="stroke special diagonal" data-type="diagonal"></path>

--- a/share/goodie/geometry/svg/trapezoid.svg
+++ b/share/goodie/geometry/svg/trapezoid.svg
@@ -1,2 +1,2 @@
 <path d="M27.9290625,0L92.0709375 0 120 60 0 60z" class="area stroke" data-type="area"></path>
-<path d="M27.9290625,0L92.0709375" class="area stroke" data-type="diagonal"></path>
+<path d="M27.9290625,0L92.0709375" class="stroke special diagonal" data-type="diagonal"></path>


### PR DESCRIPTION
<!-- Use the appropriate format for your Pull Request title above ^^^^^:

If this is a bug fix:
Geometry: Add support for the area of hexagon and trapezoid

-->


## Description of new Instant Answer, or changes
This PR adds support for the geometry of a regular hexagon and a trapezoid.


## Related Issues and Discussions
Fixes #4216 


## People to notify
@pjhampton 


## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [ ] Title follows correct format (Specifies Instant Answer + Purpose)
- [ ] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Code**
- [ ] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/geometry
<!-- FILL THIS IN:                           ^^^^ -->