### PR TITLE
Replace BYR with BYN

### DIFF
--- a/lib/DDG/Goodie/Loan.pm
+++ b/lib/DDG/Goodie/Loan.pm
@@ -185,7 +185,7 @@ handle remainder => sub {
 	'bt' => 'BTN',
 	'bv' => 'NOK',
 	'bw' => 'BWP',
-	'by' => 'BYR',
+	'by' => 'BYN',
 	'bz' => 'BZD',
 	'ca' => 'CAD',
 	'cc' => 'AUD',
@@ -428,7 +428,7 @@ handle remainder => sub {
 		"MKD",
 	],
 	"p." => [
-		"BYR",
+		"BYN",
 	],
 	"\x{20a9}" => [
 		"KPW",

--- a/share/goodie/currency_in/currencies.json
+++ b/share/goodie/currency_in/currencies.json
@@ -228,9 +228,9 @@
         "ucwords": "Belarus",
         "currencies": [
             {
-                "shortcode": "BYR",
+                "shortcode": "BYN",
                 "currency": "Belarusian Ruble",
-                "string": "Belarusian Ruble (BYR)"
+                "string": "Belarusian Ruble (BYN)"
             }
         ]
     },


### PR DESCRIPTION
BYR shall not be used in 'instant answers'. BYR has been
removed from curcilation in 2016 and replaced by BYN (at
rate of 1 BYN = 10'000 BYR).

---

Example of **incorrect** behaviour:
![1](https://user-images.githubusercontent.com/7157049/27148414-df76b968-5148-11e7-9a7e-c789655652ea.png)
