### PR TITLE
New XAML Goodie

### DIFF
--- a/share/goodie/cheat_sheets/json/xaml.json
+++ b/share/goodie/cheat_sheets/json/xaml.json
@@ -1,0 +1,192 @@
+{
+    "id": "xaml_cheat_sheet",
+    "name": "XAML",
+    "description": "XAML for WPF Cheat Sheet. Includes Data Binding, Styles and Triggers, Resources, Transforms, Brushes, and Layout.",
+
+    "metadata": {
+        "sourceName": "Blueboxes.co.uk",
+        "sourceUrl" : "http://www.cheat-sheets.org/saved-copy/wpfcheatsheet.pdf"
+    },
+
+    "aliases": [
+        "xaml for wpf", "xaml data binding", "xaml styles and triggers", "xaml resources",
+        "xaml transforms", "xaml brushes","xaml layout","xaml snippets"
+    ],
+
+    "template_type": "terminal",
+
+    "section_order": [
+        "Data Binding","Styles and Triggers", "Resources", "Transforms", "Brushes", "Layout"
+    ],
+
+    "sections": {
+        "Data Binding": [
+            {
+                "key": "{Binding}",
+                "val": "Binds the current DataContext"
+            },
+            {
+                "key": "{Binding propertyName}",
+                "val": "Binds the property of the current DataContext"
+            },
+            {
+                "key": "{Binding Source={StaticResourceresName}}",
+                "val": "Binds to a staticresource such as a string"
+            },
+            {
+                "key": "{Binding ElementName= elementName, Path= propertyName}",
+                "val": "Binds to the property of the given element"
+            },
+            {
+                "key": "{TemplateBindingpropertyName}",
+                "val": "Binds to the template parents given property inside a ControlTemplate"
+            },
+            {
+                "key": "<XmlDataProvider x:Key=\"name\" Source=\"filePath\" />",
+                "val": "Added to resources to allow xml data binding"
+            },
+            {
+                "key": "IsSynchronizedWithCurrentItem=\"True\"",
+                "val": "Synchronizes elements bound to same data source"
+            }
+        ],
+        "Styles and Triggers": [
+            {
+                "key": "<Style x:Key=”styleName”>",
+                "val": "Style applied to elements that set this style"
+            },
+            {
+                "key": "<SetterProperty=”propertyName”Value=”value”/>",
+                "val": "Setter sets a property of the current target type"
+            },
+            {
+                "key": "<Style.Triggers>",
+                "val": "Holds Triggers to set a style dependant on event"
+            },
+            {
+                "key": "<Trigger Property=”propertyName” Value=”value”>",
+                "val": "Triggered when dependency property is set"
+            },
+            {
+                "key": "<DataTriggerBinding=\"{BindingPath=propertyName}\"Value=\"theValue\">",
+                "val": "Triggered when bound value is set"
+            },
+            {
+                "key": "<EventTriggerRoutedEvent=”eventName”>",
+                "val": "Triggered when the given routed event is fired"
+            }
+        ],
+        "Resources": [
+            {
+                "key": "<element Name.Resources>",
+                "val": "Holds resources accessible to anything under the element."
+            },
+            {
+                "key": "<system:String x:Key=\"resName\">stringValue </system:String>",
+                "val": "Creates a string resource"
+            },
+            {
+                "key": "<SolidColorBrush x:Key=\"resName\"Color=\"colourValue\" />",
+                "val": "Placed inside Resources tag, creates a resource with the value"
+            },
+            {
+                "key": "StaticResource",
+                "val": "Applied once, when needed"
+            },
+            {
+                "key": "DynamicResource",
+                "val": "Applied as the resources changes"
+            },
+            {
+                "key": "Fill=\"{StaticResourceresName}\"",
+                "val": "Sets fill to the resource"
+            }
+        ],
+        "Transforms": [
+            {
+                "key": "LayoutTransform",
+                "val": "Holds transform or group, executed before layout, moves surrounding elements"
+            },
+            {
+                "key": "RenderTransform",
+                "val": "Holds transform or group executed before layout, create overlapping elements"
+            },
+            {
+                "key": "TransformGroup",
+                "val": "Used to hold multiple transforms "
+            },
+            {
+                "key": "RotateTransform",
+                "val": "Rotates the given element by setting Angle, CenterX and CenterY"
+            },
+            {
+                "key": "TranslateTransform",
+                "val": "Moves elements based on X and Y"
+            },
+            {
+                "key": "SkewTransform",
+                "val": "Skews the given element using AngleX AngleY, CenterX and CenterY"
+            },
+            {
+                "key": "MatrixTransform",
+                "val": "Complex transform based on matrix"
+            }
+        ],
+        "Brushes": [
+            {
+                "key": "SolidColorBrush",
+                "val": "A solid colour brush"
+            },
+            {
+                "key": "LinearGradientBrush",
+                "val": "Gradient brush using GradientStops"
+            },
+            {
+                "key": "RadialGradientBrush",
+                "val": "Gradient radiating out from a point"
+            },
+            {
+                "key": "ImageBrush",
+                "val": "Brush from an ImageSource"
+            },
+            {
+                "key": "DrawingBrush",
+                "val": "Brush based on a given GeometryDrawing"
+            },
+            {
+                "key": "VisualBrush",
+                "val": "Brush using a visual elements image"
+            }
+        ],
+        "Layout": [
+            {
+                "key": "Window",
+                "val": "Primary container for windows applications"
+            },
+            {
+                "key": "Page",
+                "val": "Container with navigation support"
+            },
+            {
+                "key": "StackPanel",
+                "val": "Horizontal or Vertical stacking of elements"
+            },
+            {
+                "key": "Grid",
+                "val": "Grid layout via Grid.Row and Grid.Column"
+            },
+            {
+                "key": "Canvas",
+                "val": "Arrange elements using X and Y co-ordinates"
+            },
+            {
+                "key": "WrapPanel",
+                "val": "Horizontal or Vertical wrapping of visual elements as space is available"
+            },
+            {
+                "key": "DockPanel",
+                "val": "Dock elements via DockPannel.Dock"
+            }
+        ]
+    }
+}

--- a/share/goodie/cheat_sheets/json/xaml.json
+++ b/share/goodie/cheat_sheets/json/xaml.json
@@ -1,10 +1,10 @@
 {
     "id": "xaml_cheat_sheet",
     "name": "XAML",
-    "description": "XAML for WPF Cheat Sheet. Includes Data Binding, Styles and Triggers, Resources, Transforms, Brushes, and Layout.",
+    "description": "XAML for WPF Cheat Sheet. Extensible Application Markup Language is an XML-based markup language developed by Microsoft. Cheat Sheet includes Data Binding, Styles and Triggers, Resources, Transforms, Brushes, and Layout.",
 
     "metadata": {
-        "sourceName": "Blueboxes.co.uk",
+        "sourceName": "Cheat-Sheets.org",
         "sourceUrl" : "http://www.cheat-sheets.org/saved-copy/wpfcheatsheet.pdf"
     },
 
@@ -79,7 +79,7 @@
         "Resources": [
             {
                 "key": "<element Name.Resources>",
-                "val": "Holds resources accessible to anything under the element."
+                "val": "Holds resources accessible to anything under the element"
             },
             {
                 "key": "<system:String x:Key=\"resName\">stringValue </system:String>",
@@ -113,7 +113,7 @@
             },
             {
                 "key": "TransformGroup",
-                "val": "Used to hold multiple transforms "
+                "val": "Used to hold multiple transforms"
             },
             {
                 "key": "RotateTransform",


### PR DESCRIPTION
## Description of new Instant Answer, or changes
XAML for WPF Cheat Sheet. Includes Data Binding, Styles and Triggers, Resources, Transforms, Brushes, and Layout.

##IA URL
https://duck.co/ia/view/xaml

## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [ ] Title follows correct format (Specifies Instant Answer + Purpose)
- [ ] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Instant Answer Page** (for new Instant Answers)
- [ ] Instant Answer page is correctly filled out and contains:
    - The **Title** is appropriately named and formatted
    - The **IA topics** are present and appropriate
    - The **Description** is clear and coherent
    - **Source Name** exists if applicable
    - All **Example Queries** trigger on [Beta](https://beta.duckduckgo.com/)

**Code**
- [ ] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/{ID}
<!-- FILL THIS IN:                           ^^^^ -->
