### PR TITLE
Conversions: Enable single unit triggers

### DIFF
--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -164,7 +164,8 @@ handle query => sub {
     my @matches = ($left_unit, $right_unit);
 
     # ignore conversion when both units have a number
-    return if ($left_num && $right_num) || $left_unit && !($left_num || $right_unit);
+    return if ($left_num && $right_num);
+    return if length $left_unit <= 3 && !($left_num || $right_unit);
 
     # Compare factors of both units to ensure proper order when ambiguous
     # also, check the <connecting_word> of regex for possible user intentions
@@ -198,7 +199,7 @@ handle query => sub {
 
     # handle case when there is no "to" unit
     # e.g. "36 meters"
-    if ($left_unit && $left_num && !($right_unit || $right_num)) {
+    if ($left_unit && !($right_unit || $right_num)) {
         $factor = $left_num;
     }
     # if the query is in the format <unit> in <num> <unit> we need to flip

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -2138,47 +2138,47 @@ ddg_goodie_test(
      	})
 	),
 
-  # single unit queries with no number 
-  'grams' => test_zci(
-    '', structured_answer => make_answer({
-      raw_input => '1',
-      from_unit => 'gram',
-      to_unit => '',
-      physical_quantity => 'mass'
-    })
-  ),
-  'meters' => test_zci(
-    '', structured_answer => make_answer({
-      raw_input => '1',
-      from_unit => 'meter',
-      to_unit => '',
-      physical_quantity => 'length'
-    })
-  ),
-  'feet' => test_zci(
-    '', structured_answer => make_answer({
-      raw_input => '1',
-      from_unit => 'foot',
-      to_unit => '',
-      physical_quantity => 'length'
-    })
-  ),
-  'miles ph' => test_zci(
-    '', structured_answer => make_answer({
-      raw_input => '1',
-      from_unit => 'mi/h',
-      to_unit => '',
-      physical_quantity => 'speed'
-    })
-  ),
-  'gigabytes' => test_zci(
-    '', structured_answer => make_answer({
-      raw_input => '1',
-      from_unit => 'GB',
-      to_unit => '',
-      physical_quantity => 'digital'
-    })
-  ),
+	# single unit queries with no number 
+	'grams' => test_zci(
+		'', structured_answer => make_answer({
+			raw_input => '1',
+			from_unit => 'gram',
+			to_unit => '',
+			physical_quantity => 'mass'
+		})
+	),
+	'meters' => test_zci(
+		'', structured_answer => make_answer({
+			raw_input => '1',
+			from_unit => 'meter',
+			to_unit => '',
+			physical_quantity => 'length'
+		})
+	),
+	'feet' => test_zci(
+		'', structured_answer => make_answer({
+			raw_input => '1',
+			from_unit => 'foot',
+			to_unit => '',
+			physical_quantity => 'length'
+		})
+	),
+	'miles ph' => test_zci(
+		'', structured_answer => make_answer({
+			raw_input => '1',
+			from_unit => 'mi/h',
+			to_unit => '',
+			physical_quantity => 'speed'
+		})
+	),
+	'gigabytes' => test_zci(
+		'', structured_answer => make_answer({
+			raw_input => '1',
+			from_unit => 'GB',
+			to_unit => '',
+			physical_quantity => 'digital'
+		})
+	),
 
 	 # natural language queries
 	'unit converter' => test_zci(
@@ -2266,16 +2266,16 @@ ddg_goodie_test(
 	'foot in both camps'              => undef,
 	'1E300 miles in metres'           => undef,
 	'5 pas.i to atm'                  => undef,
-  'grams of ham'                    => undef,
-  'car was going 100 mph'           => undef,
-  'length'                          => undef,
-  'speed'                           => undef,
+	'grams of ham'                    => undef,
+	'car was going 100 mph'           => undef,
+	'length'                          => undef,
+	'speed'                           => undef,
 
-  # don't trigger on units where the string is <= 3
-  'cms'                             => undef,
-  'mph'                             => undef,
-  'ft'                              => undef,
-  'gs'                              => undef,
-  'ms'                              => undef,
+	# don't trigger on units where the string is <= 3
+	'cms'                             => undef,
+	'mph'                             => undef,
+	'ft'                              => undef,
+	'gs'                              => undef,
+	'ms'                              => undef,
 );
 done_testing;

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -2138,6 +2138,48 @@ ddg_goodie_test(
      	})
 	),
 
+  # single unit queries with no number 
+  'grams' => test_zci(
+    '', structured_answer => make_answer({
+      raw_input => '1',
+      from_unit => 'gram',
+      to_unit => '',
+      physical_quantity => 'mass'
+    })
+  ),
+  'meters' => test_zci(
+    '', structured_answer => make_answer({
+      raw_input => '1',
+      from_unit => 'meter',
+      to_unit => '',
+      physical_quantity => 'length'
+    })
+  ),
+  'feet' => test_zci(
+    '', structured_answer => make_answer({
+      raw_input => '1',
+      from_unit => 'foot',
+      to_unit => '',
+      physical_quantity => 'length'
+    })
+  ),
+  'miles ph' => test_zci(
+    '', structured_answer => make_answer({
+      raw_input => '1',
+      from_unit => 'mi/h',
+      to_unit => '',
+      physical_quantity => 'speed'
+    })
+  ),
+  'gigabytes' => test_zci(
+    '', structured_answer => make_answer({
+      raw_input => '1',
+      from_unit => 'GB',
+      to_unit => '',
+      physical_quantity => 'digital'
+    })
+  ),
+
 	 # natural language queries
 	'unit converter' => test_zci(
 		'', structured_answer => make_answer_with_base({
@@ -2222,11 +2264,18 @@ ddg_goodie_test(
 	'use a ton of stones'             => undef,
 	'shoot onself in the foot'        => undef,
 	'foot in both camps'              => undef,
-	'Seconds'                         => undef,
-	'feet'                            => undef,
-	'minutes'                         => undef,
-	'99999999999000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 miles in mm' => undef,
 	'1E300 miles in metres'           => undef,
 	'5 pas.i to atm'                  => undef,
+  'grams of ham'                    => undef,
+  'car was going 100 mph'           => undef,
+  'length'                          => undef,
+  'speed'                           => undef,
+
+  # don't trigger on units where the string is <= 3
+  'cms'                             => undef,
+  'mph'                             => undef,
+  'ft'                              => undef,
+  'gs'                              => undef,
+  'ms'                              => undef,
 );
 done_testing;


### PR DESCRIPTION
## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
This PR enables single unit queries such as `grams`, `feet`, `meters`, etc but doesn't let trough ambiguous symbols such as `mph`, `gs`, `ms`, `cm`.

![screen shot 2017-06-21 at 12 55 13 pm](https://user-images.githubusercontent.com/8960296/27383090-52ce2896-5681-11e7-8aa2-da1d40cf6622.png)
![screen shot 2017-06-21 at 12 55 52 pm](https://user-images.githubusercontent.com/8960296/27383091-52da2434-5681-11e7-9341-687c4b0aa4b7.png)
![screen shot 2017-06-21 at 12 54 33 pm](https://user-images.githubusercontent.com/8960296/27383092-52e0f340-5681-11e7-8b02-0c3233fc8cc4.png)


## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->


## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [ ] Title follows correct format (Specifies Instant Answer + Purpose)
- [ ] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Instant Answer Page** (for new Instant Answers)
- [ ] Instant Answer page is correctly filled out and contains:
    - The **Title** is appropriately named and formatted
    - The **IA topics** are present and appropriate
    - The **Description** is clear and coherent
    - **Source Name** exists if applicable
    - All **Example Queries** trigger on [Beta](https://beta.duckduckgo.com/)

**Code**
- [ ] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/conversions
<!-- FILL THIS IN:                           ^^^^ -->
