### PR TITLE
Timer: Added some non-english triggers

### DIFF
--- a/lib/DDG/Goodie/Timer.pm
+++ b/lib/DDG/Goodie/Timer.pm
@@ -9,7 +9,7 @@ zci is_cached   => 1;
 
 my @triggers = ('timer', 'countdown', 'count down', 'alarm', 'reminder');
 # Foreign language triggers
-my @foreignTriggers = ('temporizador','chrônometro','таймер');
+my @foreignTriggers = ('temporizador', 'chrônometro', 'таймер');
 push(@triggers, @foreignTriggers);
 # Triggers that are vaild, but not stripped from the resulting query
 my @nonStrippedTriggers = qw(minutes mins seconds secs hours hrs);

--- a/lib/DDG/Goodie/Timer.pm
+++ b/lib/DDG/Goodie/Timer.pm
@@ -1,6 +1,6 @@
 package DDG::Goodie::Timer;
 # ABSTRACT: Shows a countdown timer
-
+use utf8;
 use strict;
 use DDG::Goodie;
 
@@ -8,6 +8,9 @@ zci answer_type => 'timer';
 zci is_cached   => 1;
 
 my @triggers = ('timer', 'countdown', 'count down', 'alarm', 'reminder');
+# Foreign language triggers
+my @foreignTriggers = ('temporizador','chrônometro','таймер');
+push(@triggers, @foreignTriggers);
 # Triggers that are vaild, but not stripped from the resulting query
 my @nonStrippedTriggers = qw(minutes mins seconds secs hours hrs);
 # Triggers that are valid in start only
@@ -16,7 +19,6 @@ my @startTriggers = ();
 # creates 'start a', 'begin a'
 map { push(@startTriggers, "$_ a") } @baseTriggers; 
 push(@startTriggers, @baseTriggers);
-
 # Beautifies the trigger can be appended in front/back of trigger
 my @beautifierTriggers = qw(online);
 #Joins the Timer Value

--- a/share/goodie/timer/timer.js
+++ b/share/goodie/timer/timer.js
@@ -8,15 +8,33 @@ DDH.timer = DDH.timer || {};
 
 DDH.timer.build = function(ops) {
     'use strict';
-
+    
     var SOUND_NAME = "alarm-sound",
         soundUrl = '/share/goodie/timer/' + ops.data.goodie_version + '/alarm.mp3',
         soundIsPlaying = false,
         hasShown = false,
         $lastTimerToFinish,
         Timer,
-        cachedPlayer;
-
+        cachedPlayer,
+        triggerLanguage = ops.data.trigger_language;
+    
+    // translations list
+    var _lang = {
+                   'Timer': {'ru': 'Таймер', 'es': 'Temporizador', 'pt': 'Crônometro'},
+                };
+    
+    // if the phrase or the phrase for trigger language is not specified
+    // returns the phrase itself
+    var i18 = function(phrase) {
+       if(typeof _lang[phrase] === 'undefined')
+           return phrase;
+        
+       if(typeof _lang[phrase][triggerLanguage] === 'undefined')
+           return phrase;
+        
+       return _lang[phrase][triggerLanguage];
+    }
+    
     // helper methods
 
     // add zeros to beginning of string
@@ -176,7 +194,7 @@ DDH.timer.build = function(ops) {
         }
 
         // prefill name with value
-        this.$nameInput.val("Timer " + number);
+        this.$nameInput.val( i18('Timer')+" " + number);
     };
 
     $.extend(Timer.prototype, {

--- a/t/Timer.t
+++ b/t/Timer.t
@@ -16,6 +16,8 @@ my $goodieVersion = $DDG::GoodieBundle::OpenSourceDuckDuckGo::VERSION // 999;
 sub build_structured_answer {
     my $time = shift;
     $time = $time || 0;
+    my $lang = shift;
+    $lang = $lang || 'en';
     return "$time",
         structured_answer => {
             id     =>  'timer',
@@ -27,7 +29,8 @@ sub build_structured_answer {
             },
             data => {
                 time => "$time",
-                goodie_version => $goodieVersion
+                goodie_version => $goodieVersion,
+                trigger_language => $lang,
             },
             templates => {
                 group       => 'base',
@@ -58,9 +61,10 @@ ddg_goodie_test(
     'count down timer'       => build_test(),
     
     # Foreign language triggers
-    'таймер'                 => build_test(),
-    'temporizador'           => build_test(),
-    'chrônometro'            => build_test(),
+    'таймер'                 => build_test('0', 'ru'),
+    'отсчет'                 => build_test('0', 'ru'),
+    'temporizador'           => build_test('0', 'es'),
+    'crônometro'             => build_test('0', 'pt'),
 
     # With initial time
     'timer 15 mins'                                  => build_test('900'),

--- a/t/Timer.t
+++ b/t/Timer.t
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use utf8; # For non ASCII triggers support
 
 use Test::More;
 use DDG::Test::Goodie;
@@ -55,6 +56,11 @@ ddg_goodie_test(
     'Countdown timer'        => build_test(),
     'Online Countdown timer' => build_test(),
     'count down timer'       => build_test(),
+    
+    # Foreign language triggers
+    'таймер'                 => build_test(),
+    'temporizador'           => build_test(),
+    'chrônometro'            => build_test(),
 
     # With initial time
     'timer 15 mins'                                  => build_test('900'),


### PR DESCRIPTION
## Description of changes
PR Adds *temporizador*, *crônometro* & *таймер* triggers to [Timer](https://duck.co/ia/view/timer)

- /?q=temporizador&t=hq
- /?q=crônometro&t=hq
- /?q=таймер&t=hq

## Related Issues and Discussions
- https://github.com/duckduckgo/zeroclickinfo-spice/issues/3119


## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [x] Title follows correct format (Specifies Instant Answer + Purpose)
- [x] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)


**Code**
- [x] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [x] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [x] There is no unnecessary files in place (such as editor config files)
- [x] There is no API keys / secrets present
- [x] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/timer
<!-- FILL THIS IN:                           ^^^^ -->
