### PR TITLE
New Timezonetime IA

### DIFF
--- a/lib/DDG/Goodie/Timezonetime.pm
+++ b/lib/DDG/Goodie/Timezonetime.pm
@@ -45,7 +45,7 @@ handle remainder => sub {
 
     # Check if timezone is in daylight saving or not    
     if ($tz->is_dst_for_datetime( $dt )) {
-	      $daylightStatus = "$timezone is in daylight saving";
+        $daylightStatus = "$timezone is in daylight saving";
     }
     else {
         $daylightStatus = "$timezone is not in daylight saving";

--- a/lib/DDG/Goodie/Timezonetime.pm
+++ b/lib/DDG/Goodie/Timezonetime.pm
@@ -24,22 +24,17 @@ my $timezoneMapping = {
     "PST" => "PST8PDT", 
     "CST" => "CST6CDT"
 };
-
-handle query_lc => sub {
-    my ($query) = $_;
     
-    my $timezones = join('|', keys(%$timezoneMapping));
+my $timezones = join('|', keys(%$timezoneMapping));
+
+handle remainder => sub {
+    my $query = $_;
+    
     my $daylightStatus = "";
     
-    # Parsing timezone out of query string
-    $query =~ s/.*\b($timezones)\b.*/$1/ig;
     my $timezone = uc($query);
-    
-    # If timezone is not in hash then return null
-    return unless (exists($timezoneMapping->{$timezone}));
-
-    # Getting corresponding timezone value from hash
-    my $mappedTimezone = $timezoneMapping->{$timezone};
+    my $mappedTimezone = $timezoneMapping->{$timezone} // 0;
+    return unless $mappedTimezone; 
 
     # Get time for desired timezone
     my $tz = DateTime::TimeZone->new( name => $mappedTimezone );

--- a/lib/DDG/Goodie/Timezonetime.pm
+++ b/lib/DDG/Goodie/Timezonetime.pm
@@ -1,0 +1,85 @@
+package DDG::Goodie::Timezonetime;
+# ABSTRACT: Write an abstract here
+
+# Start at http://docs.duckduckhack.com/walkthroughs/calculation.html if
+# you are new to instant answer development
+
+use DDG::Goodie;
+use strict;
+use warnings;
+
+use DateTime;
+use DateTime::TimeZone;
+
+zci answer_type => 'timezonetime';
+
+# Caching - http://docs.duckduckhack.com/backend-reference/api-reference.html#caching`
+zci is_cached => 1;
+
+# Triggers at the start of the query
+my @triggerStart = ("time in", "time now");
+# Triggers at the end of the query
+my @triggerEnd   = ("now time");
+# Final trigger list
+my @triggersFinal = (@triggerStart, @triggerEnd);
+
+# Triggers - http://docs.duckduckhack.com/walkthroughs/calculation.html#triggers
+triggers any => @triggersFinal;
+
+# Mapping short timezone names to one used by DateTime:Timezone module
+my $timezoneMapping = {"IST" => "Asia/Kolkata", "EST" => "EST", "UTC" => "UTC", "GMT" => "GMT",
+                       "PST" => "PST8PDT", "BST" => "Europe/London", "CST" => "CST6CDT"
+                      };
+
+# Handle statement
+handle query_lc => sub {
+
+    my $query_lc = $_;
+    
+    my $timezones = join('|', keys(%$timezoneMapping));
+    my $daylightStatus = "";
+    
+    # Parsing timezone out of query string
+    $query_lc =~ s/.*\b($timezones)\b.*/$1/ig;
+    my $timezone = uc($query_lc);
+    
+    # If timezone is not in hash then return null
+    unless (exists($timezoneMapping->{$timezone})) {
+	return;
+    }
+
+    # Getting corresponding timezone value from hash
+    my $mappedTimezone = $timezoneMapping->{$timezone};
+
+    # Get time for desired timezone
+    my $tz = DateTime::TimeZone->new( name => $mappedTimezone );
+    my $dt = DateTime->now();
+    my $offset = $tz->offset_for_datetime($dt);
+    $dt->add(seconds => $offset);
+    my $time = $dt->hms(':');
+
+    # Check if timezone is in daylight saving or not    
+    if ($tz->is_dst_for_datetime( $dt )) {
+	$daylightStatus = "$timezone is in daylight saving";
+    }  else {
+        $daylightStatus = "$timezone is not in daylight saving";
+    }
+    
+    return "$time $timezone $daylightStatus",
+        structured_answer => {
+
+            data => {
+                title       => "$time $timezone",
+                subtitle    => "$daylightStatus",
+            },
+
+            templates => {
+                group => 'text',
+                # options => {
+                #
+                # }
+            }
+        };
+};
+
+1;

--- a/lib/DDG/Goodie/Timezonetime.pm
+++ b/lib/DDG/Goodie/Timezonetime.pm
@@ -1,8 +1,5 @@
 package DDG::Goodie::Timezonetime;
-# ABSTRACT: Write an abstract here
-
-# Start at http://docs.duckduckhack.com/walkthroughs/calculation.html if
-# you are new to instant answer development
+# ABSTRACT: Gives the current time in a specified timezone
 
 use DDG::Goodie;
 use strict;
@@ -12,41 +9,34 @@ use DateTime;
 use DateTime::TimeZone;
 
 zci answer_type => 'timezonetime';
-
-# Caching - http://docs.duckduckhack.com/backend-reference/api-reference.html#caching`
 zci is_cached => 1;
 
-# Triggers at the start of the query
-my @triggerStart = ("time in", "time now");
-# Triggers at the end of the query
-my @triggerEnd   = ("now time");
-# Final trigger list
-my @triggersFinal = (@triggerStart, @triggerEnd);
-
-# Triggers - http://docs.duckduckhack.com/walkthroughs/calculation.html#triggers
-triggers any => @triggersFinal;
+triggers start => ("what time in", "what time is it in", "time in");
+triggers startend => ("time", "now time", "time now");
 
 # Mapping short timezone names to one used by DateTime:Timezone module
-my $timezoneMapping = {"IST" => "Asia/Kolkata", "EST" => "EST", "UTC" => "UTC", "GMT" => "GMT",
-                       "PST" => "PST8PDT", "BST" => "Europe/London", "CST" => "CST6CDT"
-                      };
+my $timezoneMapping = {
+    "IST" => "Asia/Kolkata", 
+    "EST" => "EST", 
+    "UTC" => "UTC", 
+    "GMT" => "GMT",
+    "BST" => "Europe/London", 
+    "PST" => "PST8PDT", 
+    "CST" => "CST6CDT"
+};
 
-# Handle statement
 handle query_lc => sub {
-
-    my $query_lc = $_;
+    my ($query) = $_;
     
     my $timezones = join('|', keys(%$timezoneMapping));
     my $daylightStatus = "";
     
     # Parsing timezone out of query string
-    $query_lc =~ s/.*\b($timezones)\b.*/$1/ig;
-    my $timezone = uc($query_lc);
+    $query =~ s/.*\b($timezones)\b.*/$1/ig;
+    my $timezone = uc($query);
     
     # If timezone is not in hash then return null
-    unless (exists($timezoneMapping->{$timezone})) {
-	return;
-    }
+    return unless (exists($timezoneMapping->{$timezone}));
 
     # Getting corresponding timezone value from hash
     my $mappedTimezone = $timezoneMapping->{$timezone};
@@ -60,8 +50,9 @@ handle query_lc => sub {
 
     # Check if timezone is in daylight saving or not    
     if ($tz->is_dst_for_datetime( $dt )) {
-	$daylightStatus = "$timezone is in daylight saving";
-    }  else {
+	      $daylightStatus = "$timezone is in daylight saving";
+    }
+    else {
         $daylightStatus = "$timezone is not in daylight saving";
     }
     
@@ -72,12 +63,8 @@ handle query_lc => sub {
                 title       => "$time $timezone",
                 subtitle    => "$daylightStatus",
             },
-
             templates => {
                 group => 'text',
-                # options => {
-                #
-                # }
             }
         };
 };

--- a/t/Timezonetime.t
+++ b/t/Timezonetime.t
@@ -1,0 +1,55 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::MockTime qw(:all);
+use Test::Deep;
+use DDG::Test::Goodie;
+
+zci answer_type => 'timezonetime';
+zci is_cached   => 1;
+
+my $goodieVersion = $DDG::GoodieBundle::OpenSourceDuckDuckGo::VERSION // 999;
+
+# Build a structured answer that should match the response from the
+# Perl file.
+sub build_structured_answer {
+    my ($time, $timezone, $daylightSaving) = @_;
+    
+    return "$time $timezone $daylightSaving",
+        structured_answer => {
+            data => {
+                title    => "$time $timezone",
+                subtitle => "$daylightSaving",
+                # image => 'http://website.com/image.png',
+            },
+
+            templates => {
+                group => 'text',
+                # options => {
+                #
+                # }
+            }
+        };
+}
+
+# Use this to build expected results for your tests.
+sub build_test { test_zci(build_structured_answer(@_)) }
+
+set_fixed_time('2017-06-03T09:36:53Z');
+
+ddg_goodie_test(
+    ['DDG::Goodie::Timezonetime'],
+    # At a minimum, be sure to include tests for all:
+    # - primary_example_queries
+    # - secondary_example_queries
+    'time in pst'  => build_test("02:36:53", "PST", "PST is in daylight saving"),
+    'ist now time' => build_test("15:06:53", "IST", "IST is not in daylight saving"),
+    'time now cst' => build_test("04:36:53", "CST", "CST is in daylight saving"),
+    # Try to include some examples of queries on which it might
+    # appear that your answer will trigger, but does not.
+    'time in pstt' => undef,
+);
+
+done_testing;

--- a/t/Timezonetime.t
+++ b/t/Timezonetime.t
@@ -1,19 +1,16 @@
 #!/usr/bin/env perl
+# Tests for the Timezonetime goodie
 
 use strict;
 use warnings;
 use Test::More;
-use Test::MockTime qw(:all);
+use Test::MockTime qw/:all/;
 use Test::Deep;
 use DDG::Test::Goodie;
 
 zci answer_type => 'timezonetime';
 zci is_cached   => 1;
 
-my $goodieVersion = $DDG::GoodieBundle::OpenSourceDuckDuckGo::VERSION // 999;
-
-# Build a structured answer that should match the response from the
-# Perl file.
 sub build_structured_answer {
     my ($time, $timezone, $daylightSaving) = @_;
     
@@ -22,34 +19,59 @@ sub build_structured_answer {
             data => {
                 title    => "$time $timezone",
                 subtitle => "$daylightSaving",
-                # image => 'http://website.com/image.png',
             },
-
             templates => {
                 group => 'text',
-                # options => {
-                #
-                # }
             }
         };
 }
 
-# Use this to build expected results for your tests.
 sub build_test { test_zci(build_structured_answer(@_)) }
 
+# INFO: Freezes time for below tests.
 set_fixed_time('2017-06-03T09:36:53Z');
 
 ddg_goodie_test(
     ['DDG::Goodie::Timezonetime'],
-    # At a minimum, be sure to include tests for all:
-    # - primary_example_queries
-    # - secondary_example_queries
+    
+    #
+    # 1. Queries that SHOULD TRIGGER ~~ IN DAYLIGHT SAVINGS
+    #
     'time in pst'  => build_test("02:36:53", "PST", "PST is in daylight saving"),
-    'ist now time' => build_test("15:06:53", "IST", "IST is not in daylight saving"),
     'time now cst' => build_test("04:36:53", "CST", "CST is in daylight saving"),
-    # Try to include some examples of queries on which it might
-    # appear that your answer will trigger, but does not.
-    'time in pstt' => undef,
+    'time in pst'  => build_test("02:36:53", "PST", "PST is in daylight saving"),
+    'time now cst' => build_test("04:36:53", "CST", "CST is in daylight saving"),
+    'time in pst'  => build_test("02:36:53", "PST", "PST is in daylight saving"),
+    'time now cst' => build_test("04:36:53", "CST", "CST is in daylight saving"),
+);
+
+# INFO: Freezes time for below tests.
+set_fixed_time('2016-01-03T09:36:53Z');
+
+ddg_goodie_test(
+    ['DDG::Goodie::Timezonetime'],
+    
+    #
+    # 2. Queries that SHOULD TRIGGER ~~ NOT IN DAYLIGHT SAVINGS
+    #
+    'time in pst'  => build_test("01:36:53", "PST", "PST is not in daylight saving"),
+    'ist now time' => build_test("15:06:53", "IST", "IST is not in daylight saving"),
+    'time now cst' => build_test("03:36:53", "CST", "CST is not in daylight saving"),
+    'time in pst'  => build_test("01:36:53", "PST", "PST is not in daylight saving"),
+    'ist now time' => build_test("15:06:53", "IST", "IST is not in daylight saving"),
+    'time now cst' => build_test("03:36:53", "CST", "CST is not in daylight saving"),
+    'time in pst'  => build_test("01:36:53", "PST", "PST is not in daylight saving"),
+    
+    #
+    # 3. Queries that SHOULD NOT TRIGGER
+    #
+    'what is the time in new york' => undef,
+    'do you know what time it is?' => undef,
+    'how to tell the time' => undef,
+    'time in brooklyn' => undef,
+    'time in belfast' => undef,
+    'whats the time' => undef,
+    'hammer time' => undef,
 );
 
 done_testing;


### PR DESCRIPTION
## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->

Finish's the Timezone/time IA.


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza 

## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [x] Title follows correct format (Specifies Instant Answer + Purpose)
- [x] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Instant Answer Page** (for new Instant Answers)
- [x] Instant Answer page is correctly filled out and contains:
    - The **Title** is appropriately named and formatted
    - The **IA topics** are present and appropriate
    - The **Description** is clear and coherent
    - **Source Name** exists if applicable
    - All **Example Queries** trigger on [Beta](https://beta.duckduckgo.com/)

**Code**
- [ ] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/programming-mission/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/timezonetime
<!-- FILL THIS IN:                           ^^^^ -->
