### PR TITLE
AltCalendars: keys on ref is fatal under perl 5.24

### DIFF
--- a/lib/DDG/Goodie/AltCalendars.pm
+++ b/lib/DDG/Goodie/AltCalendars.pm
@@ -15,7 +15,7 @@ my $year_definitions = decode_json($definitions_json);
 my %year_map_with_aliases = map { 
   my $name = $_; 
   map { $_ => $name } ($name, @{$year_definitions->{$name}->{'aliases'} // []}) 
-} (keys $year_definitions);
+} (keys %{$year_definitions});
 
 triggers any => keys %year_map_with_aliases;
 


### PR DESCRIPTION
Part-fixes: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/4414

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/alt_calendars
<!-- FILL THIS IN:                           ^^^^ -->
