### PR TITLE
CssAnimations: keys on scalar is forbidden under perl 5.24

### DIFF
--- a/lib/DDG/Goodie/CssAnimations.pm
+++ b/lib/DDG/Goodie/CssAnimations.pm
@@ -18,7 +18,7 @@ my $animations = LoadFile(share('data.yml'));
 
 sub build_response() {
 
-    my $demo_count = keys $animations;
+    my $demo_count = keys %{$animations};
     
     my @result = ();
     


### PR DESCRIPTION
Part-Fixes: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/4414


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/css_animations
<!-- FILL THIS IN:                           ^^^^ -->
