### PR TITLE
RestructuredText Cheat Sheet: Fix typo

### DIFF
--- a/share/goodie/cheat_sheets/json/restructuredtext.json
+++ b/share/goodie/cheat_sheets/json/restructuredtext.json
@@ -52,7 +52,7 @@
         ],
         "Text Styles": [
             {
-                "key": "*emphasis",
+                "key": "*emphasis*",
                 "val": "Emphasis"
             },
             {


### PR DESCRIPTION
Fixes small typo: `*emphasis` -> `*emphasis*`

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #4454 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@nickschafran 

**Pull Request**
- [x] Title follows correct format (Specifies Instant Answer + Purpose)
- [x] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

<!-- DO NOT REMOVE -->
---
Instant Answer Page: https://duck.co/ia/view/restructuredtext_cheat_sheet