### PR TITLE
LHC: Limiting overtriggering

### DIFF
--- a/lib/DDG/Goodie/HasLHCDestroyedWorld.pm
+++ b/lib/DDG/Goodie/HasLHCDestroyedWorld.pm
@@ -8,14 +8,14 @@ use strict;
 zci answer_type => 'has_lhcdestroyed_world';
 zci is_cached => 1;
 
-triggers any => 'has the large hadron collider destroyed the world',
+triggers start => 'has the large hadron collider destroyed the world',
                 'has the lhc destroyed the world',
                 'has the large hadron collider destroyed the earth',
                 'has the lhc destroyed the earth';
 
 # Handle statement
 handle remainder => sub {
-
+    return unless /^(yet)?$/;
     return "Nope.",
         structured_answer => {
             id => 'has_lhcdestroyed_world',

--- a/t/HasLHCDestroyedWorld.t
+++ b/t/HasLHCDestroyedWorld.t
@@ -40,7 +40,7 @@ ddg_goodie_test(
     'has the lhc destroyed the earth yet'                   => test_zci(@no),
     'has the lhc destroyed the earth'                       => test_zci(@no),
 
-
+    'in science fiction has the large hadron collider destroyed the world' => undef,
     'large hadron collider'                                 => undef,
     'could the large hadron collider destroyed the world'   => undef,
     'will the large hadron collider destroy the earth'      => undef


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Limits the query patterns more severely to reduce overtriggering (see https://github.com/duckduckgo/zeroclickinfo-goodies/pull/3597#discussion_r135558510)



## People to notify
@AlterationBrick @moollaza 


## Testing & Review
To be completed by Community Leader (or DDG Staff) when reviewing Pull Request

**Pull Request**
- [ ] Title follows correct format (Specifies Instant Answer + Purpose)
- [ ] Description contains a valid Instant Answer Page Link (e.g. https://duck.co/ia/view/my_ia)

**Instant Answer Page** (for new Instant Answers)
- [ ] Instant Answer page is correctly filled out and contains:
    - The **Title** is appropriately named and formatted
    - The **IA topics** are present and appropriate
    - The **Description** is clear and coherent
    - **Source Name** exists if applicable
    - All **Example Queries** trigger on [Beta](https://beta.duckduckgo.com/)

**Code**
- [ ] Adheres to the [DuckDuckGo Style Guide](https://docs.duckduckhack.com/resources/code-style-guide.html)
- [ ] Behaviour is appropriately tested. If improvement, tests are adequately extended.
- [ ] There is no unnecessary files in place (such as editor config files)
- [ ] There is no API keys / secrets present
- [ ] Tests are passing (run `$ duckpan test <goodie_id>`)
    - Tester should report any failures

**Ready to merge?**

- [ ] Has this IA been deployed to and tested on [beta.duckduckgo.com](https://beta.duckduckgo.com/)?
- [ ] For larger commits, has this been approved be more than one community member?
- [ ] The number of reviews is appropriate for this type of PR
- [ ] The commit message is clear, coherent and fitting

**Pull Request Review Guidelines**: https://docs.duckduckhack.com/testing-reference/pr-review.html

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/has_the_large_hadron_collider_destroyed_the_world_yet
<!-- FILL THIS IN:                           ^^^^ -->
