### PR TITLE
Fix Travis Builds: use --mirror-only option to prevent installing from backpan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ install:
   - npm install -g uglify-js handlebars jasmine-node
   - npm install mathjs
   - cpanm --quiet --notest Dist::Zilla
-  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --quiet --notest --mirror http://duckpan.org/ --mirror http://www.cpan.org --mirror-only
-  - dzil listdeps | grep -ve '^\W' | cpanm --queit --notest --mirror http://duckpan.org --mirror http://www.cpan.org --mirror-only
+  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org --mirror-only
+  - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org --mirror http://duckpan.org --mirror-only
 language: perl
 perl:
   - 5.16

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ install:
   - npm install -g uglify-js handlebars jasmine-node
   - npm install mathjs
   - cpanm --quiet --notest Dist::Zilla
-  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org
-  - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org
+  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --quiet --notest --mirror http://duckpan.org/ --mirror http://www.cpan.org --mirror-only
+  - dzil listdeps | grep -ve '^\W' | cpanm --queit --notest --mirror http://duckpan.org --mirror http://www.cpan.org --mirror-only
 language: perl
 perl:
   - 5.16


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Adjust .travis.yml to prevent installing modules from BackPAN
