### PR TITLE
ColourCodes: Fixing handling on RGB with values > 0

### DIFF
--- a/lib/DDG/Goodie/ColorCodes.pm
+++ b/lib/DDG/Goodie/ColorCodes.pm
@@ -70,14 +70,12 @@ handle query_lc => sub {
     s/\sto\s(?:$typestr)?//g;
 
     $_ =~ $trigger_and_guard;
-
-    $type = lc $+{'type'} if defined $+{'type'} and exists $types{lc $+{'type'}};
+    $type = $types{lc $+{'type'}} if defined $+{'type'} and exists $types{lc $+{'type'}};
 
     $color = "$+{'r'} $+{'g'} $+{'b'}" if defined $+{'r'} and defined $+{'g'} and defined $+{'b'};
     $color = lc $+{'color'} if defined $+{'color'};
 
     $inverse = 1 if defined $+{'inv'};
-
     $color =~ s/,?\s+/,/g;
     $color =~ s/([0-9]+,[0-9]+,[0-9]+),([0]?\.[0-9]+)/$alpha = $2; $1/e;
 
@@ -92,7 +90,6 @@ handle query_lc => sub {
     }
     
     my $col = try { Convert::Color->new("$type:$color") };
-    
     return unless $col;
 
     if ($inverse) {

--- a/t/ColorCodes.t
+++ b/t/ColorCodes.t
@@ -110,6 +110,10 @@ ddg_goodie_test(
         'Hex: #633CB0 ~ RGBA(99, 60, 176, 1) ~ RGB(39%, 24%, 69%) ~ HSL(260, 49%, 46%) ~ CMYB(44%, 66%, 0%, 31%)'."\n".'Complementary: #89B03C'."\n".'Analogous: #9D3CB0, #3C4FB0',
         %basic_answer 
     ),
+    'rgb(217,37,50)' => test_zci(
+        'Hex: #D92532 ~ RGBA(217, 37, 50, 1) ~ RGB(85%, 15%, 20%) ~ HSL() ~ CMYB()',
+        %basic_answer
+    ),
     # Check the content of the structured answer. Just once.
     'hsl 194 0.53 0.79' => test_zci(
         'Hex: #ADD8E5 ~ RGBA(173, 216, 229, 1) ~ RGB(68%, 85%, 90%) ~ HSL(194, 53%, 79%) ~ CMYB(25%, 6%, 0%, 10%)'."\n".'Complementary: #E6BBAE'."\n".'Analogous: #AEBDE6, #AEE6D7',

--- a/t/ColorCodes.t
+++ b/t/ColorCodes.t
@@ -111,7 +111,7 @@ ddg_goodie_test(
         %basic_answer 
     ),
     'rgb(217,37,50)' => test_zci(
-        'Hex: #D92532 ~ RGBA(217, 37, 50, 1) ~ RGB(85%, 15%, 20%) ~ HSL() ~ CMYB()',
+        'Hex: #D92532 ~ RGBA(217, 37, 50, 1) ~ RGB(85%, 15%, 20%) ~ HSL(356, 71%, 50%) ~ CMYB(0%, 83%, 77%, 15%)'."\n".'Complementary: #25D9CD'."\n".'Analogous: #D97325, #D9258B',
         %basic_answer
     ),
     # Check the content of the structured answer. Just once.


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Total screw-up here, I forgot to map the matched "type" to the type that is supported by `Convert::Color`; I'd written the *guard* in the if correctly, just not the assignment. No idea how I missed that 

Edit: It was working for anything using 3digit numbers (which all the test cases were) but broken if it matched on 2 digits i.e. `rgb(217,37,50)` and also works with 0 so `rgb(0,255,255)` is correct

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->

Fixes: https://github.com/duckduckgo/zeroclickinfo-goodies/issues/4479

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza @mcomella

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/color_codes
<!-- FILL THIS IN:                           ^^^^ -->
