### PR TITLE
Timezone Coverter: Removed friendly "Noon" and "Midnight" times from TimezoneConverter IA

### DIFF
--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -59,6 +59,7 @@ sub to_time {
 
     my $pm = "";
     my $seconds = 3600 * fmod $hours, 1 / 60;
+    my $time_word = "";
 
     # I'm using floating point numbers. They sometimes don't do what I want.
     if ( sprintf( '%.5f', $seconds ) == 60 ) {
@@ -69,13 +70,21 @@ sub to_time {
 
     my $seconds_format = int $seconds ? ':%02.0f' : "";
     if ($american) {
+        if ($hours == 0) {
+            $time_word = 'Midnight - ';
+        } elsif ($hours == 12) {
+            $time_word = 'Noon - ';
+        }
+
         $pm = ' AM';
         if ($hours >= 12) {
             $pm = ' PM';
             $hours -= 12 if (int($hours) > 12);
+        } elsif ($hours == 0) {
+            $hours = 12;
         }
     }
-    sprintf "%i:%02.0f$seconds_format$pm", $hours, $minutes, $seconds;
+    sprintf "$time_word%i:%02.0f$seconds_format$pm", $hours, $minutes, $seconds;
 }
 
 handle query => sub {

--- a/lib/DDG/Goodie/TimezoneConverter.pm
+++ b/lib/DDG/Goodie/TimezoneConverter.pm
@@ -69,11 +69,8 @@ sub to_time {
 
     my $seconds_format = int $seconds ? ':%02.0f' : "";
     if ($american) {
-        # Special case certain hours
-        return 'midnight' if $hours == 0;
-        return 'noon'     if $hours == 12;
         $pm = ' AM';
-        if ($hours > 12) {
+        if ($hours >= 12) {
             $pm = ' PM';
             $hours -= 12 if (int($hours) > 12);
         }

--- a/t/TimezoneConverter.t
+++ b/t/TimezoneConverter.t
@@ -31,8 +31,8 @@ ddg_goodie_test(
     '3:14 UTC in GMT' => build_test('3:14 GMT', '3:14 UTC to GMT'),
     '8:10 AM AZOST into CAT' => build_test('11:10 AM CAT', '8:10 AM AZOST (UTC-1) to CAT (UTC+2)'),
     '1pm EDT into UTC+2' => build_test('7:00 PM UTC+2', '1:00 PM EDT (UTC-4) to UTC+2'),
-    '0pm UTC into GMT' => build_test('Noon GMT', 'Noon UTC to GMT'),
-    '0am UTC into UTC' => build_test('Midnight UTC', 'Midnight UTC to UTC'),
+    '0pm UTC into GMT' => build_test('12:00 PM GMT', '12:00 PM UTC to GMT'),
+    '0am UTC into UTC' => build_test('0:00 AM UTC', '0:00 AM UTC to UTC'),
     '1 UTC into UTC -2 ' => build_test('23:00 UTC-2 (1 day prior)', '1:00 UTC to UTC-2'),
     ' 1 UTC into UTC-1' => build_test('0:00 UTC-1', '1:00 UTC to UTC-1'),
     '21 FNT into EET' => build_test('1:00 EET (1 day after)', '21:00 FNT (UTC-2) to EET (UTC+2)'),
@@ -71,12 +71,12 @@ ddg_goodie_test(
     '11:22am cest in localtime' => build_test(re(qr/5:22 AM EDT/), qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
     '11:22am cest in my local timezone' => build_test(re(qr/5:22 AM EDT/), qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
     '11:22am cest' =>  build_test(re(qr/5:22 AM EDT/), qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
-    '12pm my time in CEST' => build_test(q/6:00 PM CEST/, qq/Noon $test_location_tz to CEST (UTC+2)/),
-    '12pm local timezone in CEST' =>  build_test(q/6:00 PM CEST/, qq/Noon $test_location_tz to CEST (UTC+2)/),
-    '12pm in CEST' => build_test(q/6:00 PM CEST/, qq/Noon $test_location_tz to CEST (UTC+2)/),
-    '12am my timezone in UTC' => build_test(q/4:00 AM UTC/, qq/Midnight $test_location_tz to UTC/),
-    '12am local time in UTC' => build_test(q/4:00 AM UTC/, qq/Midnight $test_location_tz to UTC/),
-    '12am in UTC' => build_test(q/4:00 AM UTC/, qq/Midnight $test_location_tz to UTC/)
+    '12pm my time in CEST' => build_test(q/6:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12pm local timezone in CEST' =>  build_test(q/6:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12pm in CEST' => build_test(q/6:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12am my timezone in UTC' => build_test(q/4:00 AM UTC/, qq/0:00 AM $test_location_tz to UTC/),
+    '12am local time in UTC' => build_test(q/4:00 AM UTC/, qq/0:00 AM $test_location_tz to UTC/),
+    '12am in UTC' => build_test(q/4:00 AM UTC/, qq/0:00 AM $test_location_tz to UTC/)
 );
 restore_time();
 
@@ -91,12 +91,12 @@ ddg_goodie_test(
     '11:22am cest in localtime' => build_test(re(qr/4:22 AM EST/), qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
     '11:22am cest in my local timezone' => build_test(q/4:22 AM EST/, qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
     '11:22am cest' => build_test(q/4:22 AM EST/, qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
-    '12pm my time in CEST' => build_test(q/7:00 PM CEST/, qq/Noon $test_location_tz to CEST (UTC+2)/),
-    '12pm local timezone in CEST' => build_test(q/7:00 PM CEST/, qq/Noon $test_location_tz to CEST (UTC+2)/),
-    '12pm in CEST' => build_test(q/7:00 PM CEST/, qq/Noon $test_location_tz to CEST (UTC+2)/),
-    '12am my timezone in UTC' => build_test(re(qr/5:00 AM UTC/), qq/Midnight $test_location_tz to UTC/),
-    '12am local time in UTC' => build_test(re(qr/5:00 AM UTC/), qq/Midnight $test_location_tz to UTC/),
-    '12am in UTC' => build_test(re(qr/5:00 AM UTC/), qq/Midnight $test_location_tz to UTC/),
+    '12pm my time in CEST' => build_test(q/7:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12pm local timezone in CEST' => build_test(q/7:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12pm in CEST' => build_test(q/7:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12am my timezone in UTC' => build_test(re(qr/5:00 AM UTC/), qq/0:00 AM $test_location_tz to UTC/),
+    '12am local time in UTC' => build_test(re(qr/5:00 AM UTC/), qq/0:00 AM $test_location_tz to UTC/),
+    '12am in UTC' => build_test(re(qr/5:00 AM UTC/), qq/0:00 AM $test_location_tz to UTC/),
 );
 
 restore_time();

--- a/t/TimezoneConverter.t
+++ b/t/TimezoneConverter.t
@@ -31,8 +31,8 @@ ddg_goodie_test(
     '3:14 UTC in GMT' => build_test('3:14 GMT', '3:14 UTC to GMT'),
     '8:10 AM AZOST into CAT' => build_test('11:10 AM CAT', '8:10 AM AZOST (UTC-1) to CAT (UTC+2)'),
     '1pm EDT into UTC+2' => build_test('7:00 PM UTC+2', '1:00 PM EDT (UTC-4) to UTC+2'),
-    '0pm UTC into GMT' => build_test('12:00 PM GMT', '12:00 PM UTC to GMT'),
-    '0am UTC into UTC' => build_test('0:00 AM UTC', '0:00 AM UTC to UTC'),
+    '0pm UTC into GMT' => build_test('Noon - 12:00 PM GMT', 'Noon - 12:00 PM UTC to GMT'),
+    '0am UTC into UTC' => build_test('Midnight - 12:00 AM UTC', 'Midnight - 12:00 AM UTC to UTC'),
     '1 UTC into UTC -2 ' => build_test('23:00 UTC-2 (1 day prior)', '1:00 UTC to UTC-2'),
     ' 1 UTC into UTC-1' => build_test('0:00 UTC-1', '1:00 UTC to UTC-1'),
     '21 FNT into EET' => build_test('1:00 EET (1 day after)', '21:00 FNT (UTC-2) to EET (UTC+2)'),
@@ -71,12 +71,12 @@ ddg_goodie_test(
     '11:22am cest in localtime' => build_test(re(qr/5:22 AM EDT/), qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
     '11:22am cest in my local timezone' => build_test(re(qr/5:22 AM EDT/), qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
     '11:22am cest' =>  build_test(re(qr/5:22 AM EDT/), qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
-    '12pm my time in CEST' => build_test(q/6:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
-    '12pm local timezone in CEST' =>  build_test(q/6:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
-    '12pm in CEST' => build_test(q/6:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
-    '12am my timezone in UTC' => build_test(q/4:00 AM UTC/, qq/0:00 AM $test_location_tz to UTC/),
-    '12am local time in UTC' => build_test(q/4:00 AM UTC/, qq/0:00 AM $test_location_tz to UTC/),
-    '12am in UTC' => build_test(q/4:00 AM UTC/, qq/0:00 AM $test_location_tz to UTC/)
+    '12pm my time in CEST' => build_test(q/6:00 PM CEST/, qq/Noon - 12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12pm local timezone in CEST' =>  build_test(q/6:00 PM CEST/, qq/Noon - 12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12pm in CEST' => build_test(q/6:00 PM CEST/, qq/Noon - 12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12am my timezone in UTC' => build_test(q/4:00 AM UTC/, qq/Midnight - 12:00 AM $test_location_tz to UTC/),
+    '12am local time in UTC' => build_test(q/4:00 AM UTC/, qq/Midnight - 12:00 AM $test_location_tz to UTC/),
+    '12am in UTC' => build_test(q/4:00 AM UTC/, qq/Midnight - 12:00 AM $test_location_tz to UTC/)
 );
 restore_time();
 
@@ -91,12 +91,12 @@ ddg_goodie_test(
     '11:22am cest in localtime' => build_test(re(qr/4:22 AM EST/), qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
     '11:22am cest in my local timezone' => build_test(q/4:22 AM EST/, qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
     '11:22am cest' => build_test(q/4:22 AM EST/, qq/11:22 AM CEST (UTC+2) to $test_location_tz/),
-    '12pm my time in CEST' => build_test(q/7:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
-    '12pm local timezone in CEST' => build_test(q/7:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
-    '12pm in CEST' => build_test(q/7:00 PM CEST/, qq/12:00 PM $test_location_tz to CEST (UTC+2)/),
-    '12am my timezone in UTC' => build_test(re(qr/5:00 AM UTC/), qq/0:00 AM $test_location_tz to UTC/),
-    '12am local time in UTC' => build_test(re(qr/5:00 AM UTC/), qq/0:00 AM $test_location_tz to UTC/),
-    '12am in UTC' => build_test(re(qr/5:00 AM UTC/), qq/0:00 AM $test_location_tz to UTC/),
+    '12pm my time in CEST' => build_test(q/7:00 PM CEST/, qq/Noon - 12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12pm local timezone in CEST' => build_test(q/7:00 PM CEST/, qq/Noon - 12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12pm in CEST' => build_test(q/7:00 PM CEST/, qq/Noon - 12:00 PM $test_location_tz to CEST (UTC+2)/),
+    '12am my timezone in UTC' => build_test(re(qr/5:00 AM UTC/), qq/Midnight - 12:00 AM $test_location_tz to UTC/),
+    '12am local time in UTC' => build_test(re(qr/5:00 AM UTC/), qq/Midnight - 12:00 AM $test_location_tz to UTC/),
+    '12am in UTC' => build_test(re(qr/5:00 AM UTC/), qq/Midnight - 12:00 AM $test_location_tz to UTC/),
 );
 
 restore_time();


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Timezone Converter would previously show the converted times 12 PM and 0 AM as "Noon" and "Midnight", respectively. This PR changes the instant answer so 12 PM and 0 AM are always shown in the same time format as all other times.



## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #1451 


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza @mintsoft 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/timezone_converter
<!-- FILL THIS IN:                           ^^^^ -->
