### PR TITLE
Switch Travis to Ubuntu 14 (Trusty)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-dist: precise
 sudo: false
 env:
   - PERL_LWP_SSL_VERIFY_HOSTNAME=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - npm install -g uglify-js handlebars jasmine-node
   - npm install mathjs
   - cpanm --quiet --notest Dist::Zilla
-  - dzil authordeps | grep -ve '^\W' | xargs -n 5 -P 10 cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org --mirror-only
+  - dzil authordeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org/ --mirror http://duckpan.org --mirror-only
   - dzil listdeps | grep -ve '^\W' | cpanm --quiet --notest --mirror http://www.cpan.org --mirror http://duckpan.org --mirror-only
 language: perl
 perl:


### PR DESCRIPTION
## Description of new Instant Answer, or changes
- Switch from Ubuntu Precise to newer Trusty
- Use single process for running CPANM (seems to help prevent builds from failing)


## People to notify
@pjhampton 