### PR TITLE
CalcRoots: Fixes triggering on words.

### DIFF
--- a/lib/DDG/Goodie/CalcRoots.pm
+++ b/lib/DDG/Goodie/CalcRoots.pm
@@ -52,6 +52,7 @@ handle query  => sub {
         # Figure out what number the base is
         $base = $';
         $base =  str2nbr($base) if $base =~ /[^0-9]/;
+        return unless $base =~ /[0-9]+/;
 
         # Solve using  the absolute value of the base
         $base = abs($base);

--- a/t/CalcRoots.t
+++ b/t/CalcRoots.t
@@ -36,7 +36,7 @@ ddg_goodie_test(
             qq|<sup>2</sup>&radic;100 = <a href="javascript:;" onclick="document.x.q.value='10';document.x.q.focus();">10</a>|),
     'cube root of 33'                     => build_test('3',  '33',  'The 3-root of 33 is 3.20753432999583.',
             qq|<sup>3</sup>&radic;33 = <a href="javascript:;" onclick="document.x.q.value='3.20753432999583';document.x.q.focus();">3.20753432999583</a>|),
-	'2nd root of 9999999999' => undef,
+    '2nd root of 9999999999' => undef,
     'square root of minus garfield' => undef,
     'cubed root of pete' => undef,
     'negative root of dax the ducky' => undef,

--- a/t/CalcRoots.t
+++ b/t/CalcRoots.t
@@ -36,6 +36,9 @@ ddg_goodie_test(
             qq|<sup>2</sup>&radic;100 = <a href="javascript:;" onclick="document.x.q.value='10';document.x.q.focus();">10</a>|),
     'cube root of 33'                     => build_test('3',  '33',  'The 3-root of 33 is 3.20753432999583.',
             qq|<sup>3</sup>&radic;33 = <a href="javascript:;" onclick="document.x.q.value='3.20753432999583';document.x.q.focus();">3.20753432999583</a>|),
-	'2nd root of 9999999999' => undef
+	'2nd root of 9999999999' => undef,
+  'square root of minus garfield' => undef,
+  'cubed root of pete' => undef,
+  'negative root of dax the ducky' => undef,
 );
 done_testing;

--- a/t/CalcRoots.t
+++ b/t/CalcRoots.t
@@ -37,8 +37,8 @@ ddg_goodie_test(
     'cube root of 33'                     => build_test('3',  '33',  'The 3-root of 33 is 3.20753432999583.',
             qq|<sup>3</sup>&radic;33 = <a href="javascript:;" onclick="document.x.q.value='3.20753432999583';document.x.q.focus();">3.20753432999583</a>|),
 	'2nd root of 9999999999' => undef,
-  'square root of minus garfield' => undef,
-  'cubed root of pete' => undef,
-  'negative root of dax the ducky' => undef,
+    'square root of minus garfield' => undef,
+    'cubed root of pete' => undef,
+    'negative root of dax the ducky' => undef,
 );
 done_testing;


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Prevents triggering on strings such as: 'square root of minus garfield'

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/calc_roots
<!-- FILL THIS IN:                           ^^^^ -->
