### PR TITLE
TextConverter: Sorted static trigger words into to and from categories

### DIFF
--- a/lib/DDG/Goodie/TextConverter.pm
+++ b/lib/DDG/Goodie/TextConverter.pm
@@ -89,7 +89,18 @@ handle query_lc => sub {
     # check to see if query is a static language based trigger
     # eg. binary converter, hex encoder
     if(grep(/^$query$/, @lang_triggers)) {
-        $to_type = get_type_information($query);
+        # these words mean we want to go from the type in the query to text
+        my @from_words = ('decoder', 'decode', 'converter', 'translator');
+        my $from_words_re = join '|', @from_words;
+        # these words mean we want to go from text to the type in the query
+        my @to_words = ('encode', 'encoder', 'translation', 'translate', 'convert', 'conversion');
+        my $to_words_re = join '|', @to_words;
+
+        if ($query =~ /${from_words_re}/gi) {
+            $from_type = get_type_information($query);
+        } elsif ($query =~ /${to_words_re}/gi) {
+            $to_type = get_type_information($query);            
+        }
 
         return '',
             structured_answer => {

--- a/lib/DDG/Goodie/TextConverter.pm
+++ b/lib/DDG/Goodie/TextConverter.pm
@@ -35,6 +35,14 @@ my @merged_triggers = (@single_triggers, @triggers);
 my $triggers_re = join "|", @merged_triggers;
 my $generics_re = join "|", @generics;
 
+# for static language based triggers e.g. 'base64 decode'
+# these words mean we want to go from the type in the query to text
+my @from_words = ('decoder', 'decode', 'converter', 'translator');
+my $from_words_re = join '|', @from_words;
+# these words mean we want to go from text to the type in the query
+my @to_words = ('encode', 'encoder', 'translation', 'translate', 'convert', 'conversion');
+my $to_words_re = join '|', @to_words;
+
 for my $trig (@triggers) {
     push @lang_triggers, map { "$trig $_" } @generics;
 }
@@ -89,13 +97,6 @@ handle query_lc => sub {
     # check to see if query is a static language based trigger
     # eg. binary converter, hex encoder
     if(grep(/^$query$/, @lang_triggers)) {
-        # these words mean we want to go from the type in the query to text
-        my @from_words = ('decoder', 'decode', 'converter', 'translator');
-        my $from_words_re = join '|', @from_words;
-        # these words mean we want to go from text to the type in the query
-        my @to_words = ('encode', 'encoder', 'translation', 'translate', 'convert', 'conversion');
-        my $to_words_re = join '|', @to_words;
-
         if ($query =~ /${from_words_re}/gi) {
             $from_type = get_type_information($query);
         } elsif ($query =~ /${to_words_re}/gi) {

--- a/t/TextConverter.t
+++ b/t/TextConverter.t
@@ -50,22 +50,22 @@ ddg_goodie_test(
 
     'binary converter' => test_zci(
         '', structured_answer => build_structured_answer({
-            from_type => '',
-            to_type => 'binary'
+            from_type => 'binary',
+            to_type => ''
         })
     ),
 
     'hex converter' => test_zci(
         '', structured_answer => build_structured_answer({
-            from_type => '',
-            to_type => 'hexadecimal'
+            from_type => 'hexadecimal',
+            to_type => ''
         })
     ),
 
     'ascii converter' => test_zci(
         '', structured_answer => build_structured_answer({
-            from_type => '',
-            to_type => 'text'
+            from_type => 'text',
+            to_type => ''
         })
     ),
 
@@ -80,6 +80,27 @@ ddg_goodie_test(
         '', structured_answer => build_structured_answer({
             from_type => '',
             to_type => 'base64'
+        })
+    ),
+
+    'base64 decoder' => test_zci(
+        '', structured_answer => build_structured_answer({
+            from_type => 'base64',
+            to_type => ''
+        })
+    ),
+
+    'hex translator' => test_zci(
+        '', structured_answer => build_structured_answer({
+            from_type => 'hexadecimal',
+            to_type => ''
+        })
+    ),
+
+    'binary translation' => test_zci(
+        '', structured_answer => build_structured_answer({
+            from_type => '',
+            to_type => 'binary'
         })
     ),
 


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Queries such as `base64 decode` were showing the instant answer with a conversion from text to base64, but it should be the other way around. The static language words that trigger the instant answer conversion options have been classified into whether the type specified in the query should be the `from_type` or the `to_type`.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #4365 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@pjhampton @mintsoft @moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/text_converter
<!-- FILL THIS IN:                           ^^^^ -->
