### PR TITLE
Conversions fix

### DIFF
--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -103,7 +103,7 @@ my $guard = qr/^
                 (?<question>$question_prefix)\s?
                 (?<left_num>$factor_re*|\d+\/\d+)\s?(?<left_unit>$keys)
                 (?:\s
-                    (?<connecting_word>(?:are)?\s?(?:there)?\s?in|(?:convert(?:ed)?)?\s?to|vs|is|convert|per|=(?:[\s\?]+)?|in\sto|(?:equals|is)?\show\smany|(?:equals?(?:\swhat(?:\sin)?)?|make)\sa?|\?\s?=|are\sin\sa|(?:is\swhat\sin)|(?:in to)|from)?\s?
+                    (?<connecting_word>in|(?:convert(?:ed)?)?\s?to|vs|is|convert|per|=(?:[\s\?]+)?|in\sto|(?:equals|is)?\show\smany|(?:equals?(?:\swhat(?:\sin)?)?|make)\sa?|\?\s?=|are\s(?:there)?\s?in\sa?|(?:is\swhat\sin)|(?:in to)|from)?\s?
                     (?<right_num>$factor_re*|\d+\/\d+)\s?(?:of\s)?(?<right_unit>$keys)\s?
                     (?:conver(?:sion|ter)|calculator|equals(?:\swhat)?)?[\?]?
                 )?

--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -103,7 +103,7 @@ my $guard = qr/^
                 (?<question>$question_prefix)\s?
                 (?<left_num>$factor_re*|\d+\/\d+)\s?(?<left_unit>$keys)
                 (?:\s
-                    (?<connecting_word>in|(?:convert(?:ed)?)?\s?to|vs|is|convert|per|=(?:[\s\?]+)?|in\sto|(?:equals|is)?\show\smany|(?:equals?(?:\swhat(?:\sin)?)?|make)\sa?|\?\s?=|are\sin\sa|(?:is\swhat\sin)|(?:in to)|from)?\s?
+                    (?<connecting_word>(?:are)?\s?(?:there)?\s?in|(?:convert(?:ed)?)?\s?to|vs|is|convert|per|=(?:[\s\?]+)?|in\sto|(?:equals|is)?\show\smany|(?:equals?(?:\swhat(?:\sin)?)?|make)\sa?|\?\s?=|are\sin\sa|(?:is\swhat\sin)|(?:in to)|from)?\s?
                     (?<right_num>$factor_re*|\d+\/\d+)\s?(?:of\s)?(?<right_unit>$keys)\s?
                     (?:conver(?:sion|ter)|calculator|equals(?:\swhat)?)?[\?]?
                 )?

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -695,6 +695,22 @@ ddg_goodie_test(
             physical_quantity => 'length'
         })
     ),
+    'how many metres are in 10 yards?' => test_zci(
+        '', structured_answer => make_answer({
+            raw_input => '10',
+            from_unit => 'yard',
+            to_unit => 'meter',
+            physical_quantity => 'length'
+        })
+    ),
+    'how many metres are there in a mile?' => test_zci(
+        '', structured_answer => make_answer({
+            raw_input => '1',
+            from_unit => 'mile',
+            to_unit => 'meter',
+            physical_quantity => 'length'
+        })
+    ),
     'how many cm in a metre?' => test_zci(
         '', structured_answer => make_answer({
             raw_input => '1',


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->
**Conversions**
## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
now conversions IA can answer at questions, composed not only like this "how many metres [are] in a mile?" but also like this "how many metres are there in a mile?" or "how many metres are in 2 miles?".

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #4502 Fixed #4501 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/conversions
<!-- FILL THIS IN:                           ^^^^ -->
