### PR TITLE
Text Converter: Fix binary conversion bug.

### DIFF
--- a/share/goodie/text_converter/text_converter.js
+++ b/share/goodie/text_converter/text_converter.js
@@ -10,7 +10,7 @@ DDH.text_converter = DDH.text_converter || {};
         $convert_selects,
         $convert_from_select,
         $convert_to_select,
-        $convert_from_textarea, 
+        $convert_from_textarea,
         $convert_to_textarea;
 
     // TextConverter: A singleton object that performs all the text conversions
@@ -29,7 +29,10 @@ DDH.text_converter = DDH.text_converter || {};
             var to_type = $convert_to_select.val();
             var from = $convert_from_textarea.val();
 
-            if(from_type === "binary" && to_type === "hexadecimal") {
+            if(from_type === "decimal" && to_type === "binary") {
+                return parseInt(from, 10).toString(2);
+
+            } else if(from_type === "binary" && to_type === "hexadecimal") {
                 return TextConverter.binaryToHex(from);
 
             } else if(from_type === "binary" && to_type === "base64") {

--- a/share/goodie/text_converter/text_converter.js
+++ b/share/goodie/text_converter/text_converter.js
@@ -129,14 +129,8 @@ DDH.text_converter = DDH.text_converter || {};
         },
 
         binaryToDecimal: function(binary) {
-            var octet = binary.replace(/\s/g, "").match(/.{1,8}/g);
-            var dec_cache = [];
-
-            for(var i = 0; i < octet.length; i++) {
-                dec_cache.push(parseInt(octet[i], 2));
-            }
-
-            return dec_cache.join(" ");
+            binary = binary.replace(/\s+/g, "");
+            return parseInt(binary, 2);
         },
 
         binaryToText: function(text) {
@@ -146,19 +140,28 @@ DDH.text_converter = DDH.text_converter || {};
         },
 
         binaryToHex: function(binaryString) {
-            var binaryString = binaryString.replace(/\s/g, "");
+            var binaryString = binaryString.replace(/\s+/g, "");
             var output = "";
 
             // For every 4 bits in the binary string
-            for(var i = 0; i < binaryString.length; i += 4) {
+            for(var i = -4; i >= -binaryString.length; i -= 4) {
                 var bytes = binaryString.substr(i, 4);
                 var decimal = parseInt(bytes, 2); // convert to dec then hex
                 var hex = decimal.toString(16);
 
-                output += hex;
+                output = hex + output;
             }
 
-            return output.replace(/[^\dA-Za-z]/g, "").replace(/(.{2})/g, "$1 ").trim();
+            var rest = binaryString.length % 4;
+
+            if(rest != 0) {
+                var bytes = binaryString.substr(0, rest);
+                var decimal = parseInt(bytes, 2);
+
+                output = decimal.toString(16) + output;
+            }
+
+            return output.toUpperCase();
         },
 
         /**


### PR DESCRIPTION
## Description of new Instant Answer, or changes

Fixes #4513, fixes #4567, fixes #4570 and fixes #4566. For binary-to-decimal conversion we don't need to convert each byte separately. For binary-to-hexadecimal we need to go from the last byte to the first one.

## Related Issues and Discussions

## People to notify

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/text_converter
<!-- FILL THIS IN:                           ^^^^ -->
