### PR TITLE
Public DNS: Add Quad9 to the list of Public DNS servers

### DIFF
--- a/share/goodie/public_dns/providers.yml
+++ b/share/goodie/public_dns/providers.yml
@@ -230,3 +230,9 @@ Freenom World:
     - 80.80.80.80
     - 80.80.81.81
   ip6: []
+Quad9:
+  info_url: https://quad9.net/
+  ip4:
+    - 9.9.9.9
+  ip6:
+    - 2620:fe::fe


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
Adds a new Public DNS on that specific IA


## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
n/a

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
n/a

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/public_dns