### PR TITLE
Conversions: Changed "=" to act like "to" in implicit conversions

### DIFF
--- a/lib/DDG/Goodie/Conversions.pm
+++ b/lib/DDG/Goodie/Conversions.pm
@@ -281,7 +281,7 @@ handle query => sub {
         || (   "" eq $left_num
             && "" eq $right_num
             && $question !~ qr/convert/i
-            && $connecting_word !~ qr/to/i ))
+            && $connecting_word !~ qr/to|=/i ))
     {
         $factor = $right_num;
         @matches = reverse @matches;

--- a/t/Conversions.t
+++ b/t/Conversions.t
@@ -2194,6 +2194,14 @@ ddg_goodie_test(
             physical_quantity => 'volume'
         })
     ),
+    'oz = ml' => test_zci(
+        '', structured_answer => make_answer({
+            raw_input => '1',
+            from_unit => 'impfluidounce',
+            to_unit => 'millilitre',
+            physical_quantity => 'volume'
+        })
+    ),
     'miles to nautical' => test_zci(
         '', structured_answer => make_answer({
             raw_input => '1',


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Fixes an issue where implicit conversions without units of the form `x = y` were returning conversions from `y` to `x`, but the conversion from `x` to `y` is expected, just as it occurs for conversions of the form `x to y`.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #4521 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@moollaza @pjhampton 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/conversions
<!-- FILL THIS IN:                           ^^^^ -->
