### PR TITLE
Calculator: Fix on percentages with 4+ decimal places (#4541)

### DIFF
--- a/share/goodie/calculator/calculator.js
+++ b/share/goodie/calculator/calculator.js
@@ -88,9 +88,9 @@ DDH.calculator = DDH.calculator || {};
 
         var expression = expression
             // 1. handles +/- percentages
-            .replace(/(\+) (\d+(\.\d{1,2})?)%/g, PercentageNormalizer.addPercentage)
-            .replace(/(\d+(\.\d{1,2})?) - (\d+(\.\d{1,2})?)%/g, PercentageNormalizer.subtractPercentage)
-            .replace(/(\d+(\.\d{1,2})?)%/g, PercentageNormalizer.soloPercentage)
+            .replace(/(\+) (\d+(\.\d{1,})?)%/g, PercentageNormalizer.addPercentage)
+            .replace(/(\d+(\.\d{1,})?) - (\d+(\.\d{1,})?)%/g, PercentageNormalizer.subtractPercentage)
+            .replace(/(\d+(\.\d{1,})?)%/g, PercentageNormalizer.soloPercentage)
 
             // 2. handles basic arithmetic
             .replace(/×/g, '*')


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
It is the normalizeExpression that has a decimal limit of `\d{1,2}`.
The fix is to replace it with `\d{1,}`

When Testing it works fine!
![screenshot from 2017-12-27 01 55 12](https://user-images.githubusercontent.com/18045566/34364155-046d9ad0-eaa9-11e7-9cd9-3439ea625147.png)


## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
Fixes [#4541](https://github.com/duckduckgo/zeroclickinfo-goodies/issues/4541)


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@pjhampton 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/calculator
<!-- FILL THIS IN:                           ^^^^ -->
