### PR TITLE
formula_1_cheat_sheet: Added new tyre compounds / removed grand prix info

### DIFF
--- a/share/goodie/cheat_sheets/json/formula-1.json
+++ b/share/goodie/cheat_sheets/json/formula-1.json
@@ -12,75 +12,10 @@
     ],
     "template_type": "reference",
     "section_order": [
-        "Grand Prix",
         "Tyres",
         "Points system"
     ],
     "sections": {
-        "Grand Prix": [{
-            "key": "Australian Grand Prix",
-            "val": "Melbourne Grand Prix Circuit, Melbourne"
-        }, {
-            "key": "Bahrain Grand Prix",
-            "val": "Bahrain International Circuit, Sakhir"
-        }, {
-            "key": "Chinese Grand Prix",
-            "val": "Shanghai International Circuit, Shanghai"
-        }, {
-            "key": "Russian Grand Prix",
-            "val": "Sochi Autodrom, Sochi"
-        }, {
-            "key": "Spanish Grand Prix",
-            "val": "Circuit de Barcelona-Catalunya, Barcelona"
-        }, {
-            "key": "Monaco Grand Prix",
-            "val": "Circuit de Monaco, Monte Carlo"
-        }, {
-            "key": "Canadian Grand Prix",
-            "val": "Circuit Gilles Villeneuve, Montreal"
-        }, {
-            "key": "European Grand Prix",
-            "val": "Baku City Circuit, Baku"
-        }, {
-            "key": "Austrian Grand Prix",
-            "val": "Red Bull Ring, Spielberg"
-        }, {
-            "key": "British Grand Prix",
-            "val": "Silverstone Circuit, Silverstone"
-        }, {
-            "key": "Hungarian Grand Prix",
-            "val": "Hungaroring, Budapest"
-        }, {
-            "key": "German Grand Prix",
-            "val": "Hockenheimring, Hockenheim"
-        }, {
-            "key": "Belgian Grand Prix",
-            "val": "Circuit de Spa-Francorchamps, Stavelot"
-        }, {
-            "key": "Italian Grand Prix",
-            "val": "Autodromo Nazionale Monza, Monza"
-        }, {
-            "key": "Singapore Grand Prix",
-            "val": "Marina Bay Street Circuit, Singapore"
-        }, {
-            "key": "Malaysian Grand Prix",
-            "val": "Sepang International Circuit, Kuala Lumpur"
-        }, {
-            "key": "Japanese Grand Prix",
-            "val": "Suzuka International Racing Course, Suzuka"
-        }, {
-            "key": "United States Grand Prix",
-            "val": "Circuit of the Americas, Austin, Texas"
-        }, {
-            "key": "Mexican Grand Prix",
-            "val": "Autodromo Hermanos Rodriguez, Mexico City"
-        }, {
-            "key": "Brazilian Grand Prix",
-            "val": "Autodromo José Carlos Pace, Sao Paulo"
-        }, {
-            "key": "Abu Dhabi Grand Prix",
-            "val": "Yas Marina Circuit, Abu Dhabi"
-        }],
         "Points system": [{
             "key": "1st place",
             "val": "25 points"
@@ -113,6 +48,9 @@
             "val": "1 point"
         }],
         "Tyres": [{
+            "key": "Hypersoft",
+            "val": "Pink"
+        }, {
             "key": "Ultrasoft",
             "val": "Purple"
         }, {
@@ -126,6 +64,9 @@
             "val": "White"
         }, {
             "key": "Hard",
+            "val": "Ice blue"
+        }, {
+            "key": "Superhard",
             "val": "Orange"
         }, {
             "key": "Intermediate",


### PR DESCRIPTION
I added the two new tyre compounds to be used from 2018 onward.
And I removed the grand prix info, because it is likely to change from year to year.
@moollaza 

<!-- DO NOT REMOVE -->
---

https://duck.co/ia/view/formula_1_cheat_sheet