### PR TITLE
text "json" added in triggers for json validator

### DIFF
--- a/share/goodie/jsonvalidator/triggers.txt
+++ b/share/goodie/jsonvalidator/triggers.txt
@@ -39,3 +39,4 @@ json indent
 json format check
 lint json
 indent json
+json


### PR DESCRIPTION
jsonvalidator:  text "json" added to trigger

## Description of new Instant Answer, or changes
It adds json to triggers so that users get json validator even when they type json

## People to notify
@sahildua2305 , @tgckpg , @gautamkrishnar
<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/{ID}
<!-- FILL THIS IN:                           ^^^^ -->
