### PR TITLE
Remove srand(), no longer needed

### DIFF
--- a/lib/DDG/Goodie/ABC.pm
+++ b/lib/DDG/Goodie/ABC.pm
@@ -30,8 +30,6 @@ handle remainder => sub {
         $selection_type = 'Non-random';
         $selection      = $duck[0];
     } else {
-        # Ensure rand is seeded for each process
-        srand();
         # Choose randomly
         $selection = $choices[int rand scalar @choices];
     }

--- a/lib/DDG/Goodie/Chess960.pm
+++ b/lib/DDG/Goodie/Chess960.pm
@@ -108,8 +108,6 @@ RKBRNBNQ RKBRNNQB RBKRBNNQ RKRBBNNQ RKRNBBNQ RKRNBNQB RBKRNNBQ RKRBNNBQ RKRNNBBQ
 );
 
 handle query => sub {
-    # Ensure rand is seeded for each process
-    srand();
 
     my $query = $_;
     my $pos = undef;

--- a/lib/DDG/Goodie/Coin.pm
+++ b/lib/DDG/Goodie/Coin.pm
@@ -18,8 +18,6 @@ handle query_lc => sub {
 
     return unless ($flips);
 
-    # Ensure rand is seeded for each process
-    srand();
     my @output;
 
     my @ht = ("heads", "tails");

--- a/lib/DDG/Goodie/Dessert.pm
+++ b/lib/DDG/Goodie/Dessert.pm
@@ -92,8 +92,6 @@ sub begins_with {
 }
 
 handle remainder => sub {
-    # Ensure rand is seeded for each process
-    srand();
 
     # Check the query. See if it matches this regular expression.
     if(lc $_ =~ m/^(?:that )?(?:start|beginn?)s?(?:ing)? (?:with)? (the letter )?([a-z].*)$/i) {

--- a/lib/DDG/Goodie/Dice.pm
+++ b/lib/DDG/Goodie/Dice.pm
@@ -75,8 +75,6 @@ sub shorthand_roll_output {
 }
 
 handle remainder_lc => sub {
-    # Ensure rand is seeded for each process
-    srand();
 
     my @values = split(' and ', $_);
     my $values = @values; # size of @values;

--- a/lib/DDG/Goodie/GenerateMAC.pm
+++ b/lib/DDG/Goodie/GenerateMAC.pm
@@ -29,8 +29,6 @@ my $infobox = [ { heading => "Related Queries", },
               ];
 
 handle remainder => sub {
-    # Ensure rand is seeded for each process
-    srand();
 
     my $address = join(':', map { sprintf '%0.2X', rand(255) } (1 .. 6));
 

--- a/lib/DDG/Goodie/MagicEightBall.pm
+++ b/lib/DDG/Goodie/MagicEightBall.pm
@@ -37,7 +37,6 @@ handle remainder => sub {
     #only 2 words or more
     return unless /\S \S/;
 
-    srand();
     my $response = $eightBallresponses[int rand scalar @eightBallresponses];
 
     return $response, structured_answer => {

--- a/lib/DDG/Goodie/NLetterWords.pm
+++ b/lib/DDG/Goodie/NLetterWords.pm
@@ -10,8 +10,6 @@ triggers end => "words", "word";
 zci is_cached => 0;
 
 handle query_parts => sub {
-    # Ensure rand is seeded for each process
-    srand();
 
     my $numericalized = str2nbr($_);
     return unless $numericalized =~ /^(\d{1,50}) (letter|char|character) words?$/;

--- a/lib/DDG/Goodie/RandomDate.pm
+++ b/lib/DDG/Goodie/RandomDate.pm
@@ -79,7 +79,6 @@ handle query => sub {
         $format = $+{'format'};
         $force_cldr = defined $+{cldr};
     }
-    srand();
     return if $range_text && $range_type eq 'none';
     my ($min_date, $max_date) = parse_range($range_type, $lang->locale, $range_text);
     return if $range_text && !(defined $min_date && defined $max_date);

--- a/lib/DDG/Goodie/RandomNumber.pm
+++ b/lib/DDG/Goodie/RandomNumber.pm
@@ -10,7 +10,6 @@ zci is_cached   => 0;
 triggers start => 'rand','random','number';
 
 handle query_lc => sub {
-    srand();
     # Random number.
     # q_check (as opposed to q_internal) Allows for decimals.
     return unless ($_ =~ /^\!?(?:rand(?:om|)(?: num(?:ber|)|)(?: between|))( [\d\.]+|)(?: and|)( [\d\.]+|)$/i);

--- a/lib/DDG/Goodie/ZappBrannigan.pm
+++ b/lib/DDG/Goodie/ZappBrannigan.pm
@@ -16,8 +16,6 @@ my $quotes = LoadFile(share('quotes.yml'));
 handle query => sub {
     return unless $_ =~ m/quotes?/;
 
-    # Ensure rand is seeded for each process
-    srand();
     my @quote = @{$quotes->[int(rand(scalar(@$quotes)))]};
 
     return join("\n", @quote),


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Remove random number seeding in Perl modules. This has been fixed internally, upstream.