### PR TITLE
public_dns: Fixes #4664 - Removed CCC Berlin entry

### DIFF
--- a/share/goodie/public_dns/providers.yml
+++ b/share/goodie/public_dns/providers.yml
@@ -189,11 +189,6 @@ German Privacy Foundation e.V.:
     - 85.25.251.254
     - 62.141.58.13
   ip6: []
-Chaos Computer Club Berlin:
-  info_url: https://berlin.ccc.de/
-  ip4:
-    - 213.73.91.35
-  ip6: []
 ClaraNet:
   info_url: http://www.claranet.com/
   ip4:


### PR DESCRIPTION
## Description of new Instant Answer, or changes
Removed CCC Berlin entry. The CCC Berlin DNS server is no longer in use, as per:
https://twitter.com/clubdiscordia/status/983109445784875009?s=11

## Related Issues and Discussions
Fixes #4664

## People to notify
@Mailkov 


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/public_dns
<!-- FILL THIS IN:                           ^^^^ -->
