### PR TITLE
Conversions: Fixed typo

### DIFF
--- a/share/goodie/conversions/conversions.js
+++ b/share/goodie/conversions/conversions.js
@@ -378,7 +378,7 @@ DDH.conversions = DDH.conversions || {};
                 { symbol: 'kbit',       name: 'Kilobit' },
                 { symbol: 'mbit',       name: 'Megabit' },
                 { symbol: 'gbit',       name: 'Gigabit' },
-                { symbol: 'tbit',       name: 'Terrabit' },
+                { symbol: 'tbit',       name: 'Terabit' },
                 { symbol: 'KB',         name: 'Kilobyte' },
                 { symbol: 'MB',         name: 'Megabyte' },
                 { symbol: 'GB',         name: 'Gigabyte' },


### PR DESCRIPTION
There should only be 1 "r" in "tera".

This is a 1-character change not in the code that isn't "an essential bug fix", but should be easy to review. The reason I decided to submit this is to avoid teaching people incorrect spellings.

---

Instant Answer Page: https://duck.co/ia/view/conversions
