### PR TITLE
Markdown Cheat Sheet: Unescape brackets in shortcut description

### DIFF
--- a/share/goodie/cheat_sheets/json/markdown.json
+++ b/share/goodie/cheat_sheets/json/markdown.json
@@ -104,7 +104,7 @@
       },
       {
         "key": "\\[Use numbers for reference-style link definitions\\]\\[1\\]",
-        "val": "Links with a reference number. The number needs to be defined as \\[1\\]: http://slashdot.org"
+        "val": "Links with a reference number. The number needs to be defined as [1]: http://slashdot.org"
       }
     ],
     "Images": [
@@ -114,7 +114,7 @@
       },
       {
         "key": "\\[alt text\\]\\[logo\\]",
-        "val": "The reference style. Reference need to be declared as \\[logo\\]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png \"Logo Title Text 2\""
+        "val": "The reference style. Reference need to be declared as [logo]: https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png \"Logo Title Text 2\""
       }
     ],
     "Code and Syntax Highlighting": [


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
As @smilealdway mentioned:
The suggested markdown text to show reference is incorrect. It has for some reason used escape characters to mention reference links.
duckduckgo suggests using \[1\]: http://slashdot.org while actually, it should be just [1]: http://slashdot.org


## Related Issues and Discussions
Fixes #4697


## People to notify
@smilealdway @moollaza 

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/markdown_cheat_sheet
<!-- FILL THIS IN:                           ^^^^ -->
