### PR TITLE
AltCalendars: Added new "Reiwa" period

### DIFF
--- a/share/goodie/alt_calendars/definitions.json
+++ b/share/goodie/alt_calendars/definitions.json
@@ -17,6 +17,10 @@
         "gregorian_year_started": 1988,
         "wikipedia_page": "Heisei_period"
     },
+    "reiwa": {
+        "gregorian_year_started": 2018,
+        "wikipedia_page": "Reiwa_period"
+    },
     "juche": {
         "gregorian_year_started": 1911,
         "wikipedia_page": "North_Korean_calendar"


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
The current Japanese "Reiwa" period is missing. This PR adds it.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->


## People to notify
<!-- Please @mention any relevant people/organizations here: -->


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/alt_calendars
<!-- FILL THIS IN:                           ^^^^ -->
