### PR TITLE
ASCII Table: Remove the trailing backslash before quote

### DIFF
--- a/share/goodie/ascii_table/data.yml
+++ b/share/goodie/ascii_table/data.yml
@@ -185,7 +185,7 @@ body:
     Hex: 22
     Oct: 042
     Html: '&#34;'
-    Char: '\"'
+    Char: '"'
   - Dec: 35
     Hex: 23
     Oct: 043


### PR DESCRIPTION
Currently, the quotation mark in the ASCII table appears as `\"`, this PR fixes it by removing the trailing `\`

<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
Removes trailing backlash for the quotation mark in the ascii table.


## Related Issues and Discussions
/

## People to notify
/

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/ascii_table

