### PR TITLE
UnixPermissions: Correct UNIX setuid/setgid permission bits mixup

### DIFF
--- a/lib/DDG/Goodie/UnixPermissions.pm
+++ b/lib/DDG/Goodie/UnixPermissions.pm
@@ -33,10 +33,10 @@ handle query => sub {
     my %attributes = (
         0 => 'no special attributes',
         1 => 'sticky',
-        2 => 'setuid',
-        3 => 'setuid and sticky',
-        4 => 'setgid',
-        5 => 'setgid and sticky',
+        2 => 'setgid',
+        3 => 'setgid and sticky',
+        4 => 'setuid',
+        5 => 'setuid and sticky',
         6 => 'setuid and setgid',
         7 => 'sticky, setuid and setgid',
     );
@@ -54,16 +54,19 @@ handle query => sub {
         my $tmp_attributes = $attributes;
         my @symbolic = split '', $symbolic;
         if ($tmp_attributes >= 4) {
+            # setuid
             $tmp_attributes -= 4;
-            if ($symbolic[5] eq 'x') { $symbolic[5] = 's'; }
-            else { $symbolic[5] = 'S'; }
-        }
-        if ($tmp_attributes >= 2) {
-            $tmp_attributes -= 2;
             if ($symbolic[2] eq 'x') { $symbolic[2] = 's'; }
             else { $symbolic[2] = 'S'; }
         }
+        if ($tmp_attributes >= 2) {
+            # setgid
+            $tmp_attributes -= 2;
+            if ($symbolic[5] eq 'x') { $symbolic[5] = 's'; }
+            else { $symbolic[5] = 'S'; }
+        }
         if ($tmp_attributes >= 1) {
+            # sticky
             $tmp_attributes -= 1;
             if ($symbolic[8] eq 'x') { $symbolic[2] = 't'; }
             else { $symbolic[8] = 'T'; }

--- a/t/UnixPermissions.t
+++ b/t/UnixPermissions.t
@@ -64,6 +64,22 @@ Others: read
         })
     ),
 
+    'chmod 4744' => test_zci(
+'4744 (octal)
+rwsr--r-- (symbolic)
+User: read, write and execute
+Group: read
+Others: read
+Attributes: setuid
+',
+        structured_answer => _expected_result({
+            symbolic => 'rwsr--r--',
+            user => 'read, write and execute',
+            group => 'read',
+            others => 'read',
+            attributes => 'setuid',
+        })
+    ),
     'permission 7644' => test_zci(
 '7644 (octal)
 rwSr-Sr-T (symbolic)


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->

This PR fixes a bug in the Unix Permissions IA that caused setuid and setgid sticky bits to be mixed up. The `2` bit is for setting setgid, `4` for setuid. The IA incorrectly interpreted the opposite.

https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->

Fixes #4714

## People to notify
<!-- Please @mention any relevant people/organizations here: -->


<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: https://duck.co/ia/view/unix_permissions
<!-- FILL THIS IN:                           ^^^^ -->
