### PR TITLE
csharp cheatsheet: Fix mixed `ref` and `sealed`

### DIFF
--- a/share/goodie/cheat_sheets/json/csharp.json
+++ b/share/goodie/cheat_sheets/json/csharp.json
@@ -107,8 +107,12 @@
             "val":"For generic type parameters, the out keyword specifies that the type parameter is covariant."
          },
          {  
-            "key":"sealed",
+            "key":"ref",
             "val":"The ref keyword causes an argument to be passed by reference, not by value."
+         },
+         {  
+            "key":"sealed",
+            "val":"When applied to a class, the sealed modifier prevents other classes from inheriting from it."
          },
          {  
             "key":"this",


### PR DESCRIPTION
csharp cheatsheet: Fix mixed `ref` and `sealed`

## Description of new Instant Answer, or changes
C# cheatsheet had the entry `sealed` with the definition of `ref`. This PR fixed both entries.


## Related Issues and Discussions
I found no issue being reported about it and fixing it directly was simple enough.


## People to notify
?
