### PR TITLE
Conversions: Remove duplicate entry for gibibytes.

### DIFF
--- a/share/goodie/conversions/triggers.yml
+++ b/share/goodie/conversions/triggers.yml
@@ -1714,15 +1714,6 @@ unit: gibibyte
 symbols: [GiB]
 ---
 aliases:
-  - gibibyte
-  - gibibytes
-  - gibi byte
-  - gibi bytes
-  - gib
-type: digital
-unit: gibibyte
----
-aliases:
   - tib
   - tibibyte
   - tibibytes


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Aliases for gibibyte seem to have been added twice, once in #4372 and again in #4406. This patch keeps the entry from #4406.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->

I'm often searching for unit conversions, and whenever I submit `gib to mib`, for example, it doesn't ever give the correct secondary unit. However, `mib to gib` works just fine. I suspect this discrepancy is caused by gibibyte's duplicate entry.

![](https://i.imgur.com/uVYLRG3.png)

