### PR TITLE
FirefoxCheatSheet: Corrected Select Last Tab Shortcut

### DIFF
--- a/share/goodie/cheat_sheets/json/firefox.json
+++ b/share/goodie/cheat_sheets/json/firefox.json
@@ -243,7 +243,7 @@
             },
             {
                 "val":"Select Last Tab",
-                "key":"[Alt] [9]"
+                "key":"[Ctrl] [9]"
             },
             {
                 "val":"Tab Groups View",


### PR DESCRIPTION
Corrected Issue #4742 From alt to Ctrl

<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
http://duck.co/ia/view/firefox_cheat_sheet 

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
<!-- E.g. "Fixes #1234" -->
Fixes #4742 

## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@vishwakulkarni

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
Instant Answer Page: http://duck.co/ia/view/firefox_cheat_sheet
<!-- FILL THIS IN: http://duck.co/ia/view/firefox_cheat_sheet ^^^^ -->
